### PR TITLE
Remove the restriction on tlist in processor

### DIFF
--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -710,10 +710,17 @@ class Processor(object):
             Old API, same as init_state.
 
         solver: str
-            "mesolve" or "mcsolve"
+            "mesolve" or "mcsolve",
+            for :func:`~qutip.mesolve` and :func:`~qutip.mcsolve`.
+        
+        noisy: bool
+            Include noise or not.
 
         **kwargs
             Keyword arguments for the qutip solver.
+            E.g `tlist` for time points for recording
+            intermediate states and expectation values;
+            `args` for the solvers and `qutip.QobjEvo`.
 
         Returns
         -------
@@ -742,10 +749,10 @@ class Processor(object):
                     "any keyword arguments.")
             return self.run_analytically(init_state=init_state)
 
-        # kwargs can not contain H or tlist
-        if "H" in kwargs or "tlist" in kwargs:
+        # kwargs can not contain H
+        if "H" in kwargs:
             raise ValueError(
-                "`H` and `tlist` are already specified by the processor "
+                "`H` is already specified by the processor "
                 "and can not be given as a keyword argument")
 
         # construct qobjevo for unitary evolution
@@ -765,14 +772,19 @@ class Processor(object):
             kwargs["c_ops"] = sys_c_ops
 
         # choose solver:
+        if "tlist" in kwargs:
+            tlist = kwargs["tlist"]
+            del kwargs["tlist"]
+        else:
+            tlist=noisy_qobjevo.tlist
         if solver == "mesolve":
             evo_result = mesolve(
                 H=noisy_qobjevo, rho0=init_state,
-                tlist=noisy_qobjevo.tlist, **kwargs)
+                tlist=tlist, **kwargs)
         elif solver == "mcsolve":
             evo_result = mcsolve(
                 H=noisy_qobjevo, psi0=init_state,
-                tlist=noisy_qobjevo.tlist, **kwargs)
+                tlist=tlist, **kwargs)
 
         return evo_result
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -344,5 +344,11 @@ class TestCircuitProcessor:
             fidelity(result.states[-1], qubit_states(2, [0, 1, 0, 0])),
             1, rtol=1.e-7) 
 
-if __name__ == "__main__":
-    run_module_suite()
+    def test_no_saving_intermidiate_state(self):
+        processor = Processor(1)
+        processor.add_pulse(pulse=
+            Pulse(sigmax(), coeff=np.ones(10),
+            tlist=np.linspace(0,1,10), targets=0)
+            )
+        result = processor.run_state(basis(2,0), tlist=[0,1])
+        assert(len(result.states) == 2)


### PR DESCRIPTION
Allow one to modify `tlist` in the `Processor` to prevent saving all intermediate states, see https://github.com/qutip/qutip/issues/1472.