### PR TITLE
Simplify the interface of compiler

### DIFF
--- a/docs/source/qip-processor.rst
+++ b/docs/source/qip-processor.rst
@@ -207,8 +207,8 @@ It is called implicitly when calling the method
 .. testoutput::
     :options: +NORMALIZE_WHITESPACE
 
-    [array([0., 1.]), array([0., 1., 2.]), None, None, None]
-    [array([1.57079633]), array([0.        , 1.57079633]), None, None, None]
+    {'sx0': array([0., 1.]), 'sx1': array([0., 1., 2.])}
+    {'sx0': array([1.57079633]), 'sx1': array([0.        , 1.57079633])}
 
 Here we first use :meth:`.QubitCircuit.resolve_gates`
 to decompose the X gate to its natural gate on Spin Chain model,

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -46,7 +46,7 @@ class CavityQEDCompiler(GateCompiler):
 
     Parameters
     ----------
-    N: int
+    num_qubits: int
         The number of qubits in the system.
 
     params: dict
@@ -56,34 +56,17 @@ class CavityQEDCompiler(GateCompiler):
     global_phase: float, optional
         Record of the global phase change and will be returned.
 
-    pulse_dict: dict, optional
-        A map between the pulse label and its index in the pulse list.
-        If given, the compiled pulse can be identified with
-        ``(pulse_label, coeff)``, instead of ``(pulse_index, coeff)``.
-        The number of key-value pairs should match the number of pulses
-        in the processor.
-        If it is empty, an integer ``pulse_index`` needs to be used
-        in the compiling routine saved under the attributes ``gate_compiler``.
-
     Attributes
     ----------
-    N: int
-        The number of the component systems.
-
-    params: dict
-        A Python dictionary contains the name and the value of the parameters,
-        such as laser frequency, detuning etc.
-
-    pulse_dict: dict
-        A map between the pulse label and its index in the pulse list.
-
     gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.
         It saves the decomposition scheme for each gate.
     """
-    def __init__(self, N, params, pulse_dict, global_phase=0.):
+    def __init__(
+            self, num_qubits, params, global_phase=0.,
+            pulse_dict=None, N=None):
         super(CavityQEDCompiler, self).__init__(
-            N=N, params=params, pulse_dict=pulse_dict)
+            num_qubits, params=params, pulse_dict=pulse_dict, N=N)
         self.gate_compiler.update({
             "ISWAP": self.iswap_compiler,
             "SQRTISWAP": self.sqrtiswap_compiler,

--- a/src/qutip_qip/compiler/spinchaincompiler.py
+++ b/src/qutip_qip/compiler/spinchaincompiler.py
@@ -46,7 +46,7 @@ class SpinChainCompiler(GateCompiler):
 
     Parameters
     ----------
-    N: int
+    num_qubits: int
         The number of qubits in the system.
 
     params: dict
@@ -70,15 +70,12 @@ class SpinChainCompiler(GateCompiler):
 
     Attributes
     ----------
-    N: int
+    num_qubits: int
         The number of the component systems.
 
     params: dict
         A Python dictionary contains the name and the value of the parameters,
         such as laser frequency, detuning etc.
-
-    pulse_dict: dict
-        A map between the pulse label and its index in the pulse list.
 
     gate_compiler: dict
         The Python dictionary in the form of {gate_name: decompose_function}.
@@ -90,9 +87,11 @@ class SpinChainCompiler(GateCompiler):
     global_phase: bool
         Record of the global phase change and will be returned.
     """
-    def __init__(self, N, params, pulse_dict, setup="linear", global_phase=0.):
+    def __init__(
+            self, num_qubits, params, setup="linear",
+            global_phase=0., pulse_dict=None, N=None):
         super(SpinChainCompiler, self).__init__(
-            N=N, params=params, pulse_dict=pulse_dict)
+            num_qubits, params=params, pulse_dict=pulse_dict, N=N)
         self.gate_compiler.update({
             "ISWAP": self.iswap_compiler,
             "SQRTISWAP": self.sqrtiswap_compiler,

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -244,9 +244,10 @@ class Processor(object):
         return label_list
 
     def find_pulse(self, pulse_name):
+        pulse_dict = self.get_pulse_dict()
         if isinstance(pulse_name, str):
             try:
-                return self.pulses[self.pulse_dict[pulse_name]]
+                return self.pulses[pulse_dict[pulse_name]]
             except (KeyError):
                 raise KeyError(
                     "Pulse name {} undefined. "

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -342,7 +342,7 @@ class TestCircuitProcessor:
         result = proc.run_state(init_state=init_state, solver="mcsolve")
         assert_allclose(
             fidelity(result.states[-1], qubit_states(2, [0, 1, 0, 0])),
-            1, rtol=1.e-7) 
+            1, rtol=1.e-7)
 
     def test_no_saving_intermidiate_state(self):
         processor = Processor(1)
@@ -352,3 +352,8 @@ class TestCircuitProcessor:
             )
         result = processor.run_state(basis(2,0), tlist=[0,1])
         assert(len(result.states) == 2)
+
+    def test_pulse_dict(self):
+        processor = Processor(1)
+        processor.add_control(sigmax(), 0, label="test")
+        assert("test" in processor.get_pulse_dict())

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -82,7 +82,7 @@ class TestCircuitProcessor:
         proc2 = Processor(N=2)
         proc2.add_control(sigmaz(), cyclic_permutation=True)
         # TODO generalize to different tlist
-        tlist = [0., 0.1, 0.2, 0.3, 0.4, 0.5]
+        tlist = np.array([0., 0.1, 0.2, 0.3, 0.4, 0.5])
         amp1 = np.arange(0, 5, 1)
         amp2 = np.arange(5, 0, -1)
 


### PR DESCRIPTION
- Use num_qubits instead of N, the latter is still provided as a keyword argument for compatibility.
- The compiler now returns a dictionary between the pulse label and compiled coeffs. The processor is able to handle this directly.
There is no need to pass a pulse_dict variable.
- `load_circuit` is defined in `ModelProcessor`, so that the customized processor no longer needs to provide this.