### PR TITLE
Fix the wrong gate name in the doc

### DIFF
--- a/docs/source/qip-basics.rst
+++ b/docs/source/qip-basics.rst
@@ -307,7 +307,7 @@ An example code for plotting the example quantum circuit from above is given:
     # create the quantum circuit
     qc = QubitCircuit(2, num_cbits=1)
     qc.add_gate("CNOT", controls=0, targets=1)
-    qc.add_gate("H", targets=1)
+    qc.add_gate("SNOT", targets=1)
     qc.add_gate("ISWAP", targets=[0,1])
     qc.add_measurement("M0", targets=1, classical_store=0)
     # plot the quantum circuit


### PR DESCRIPTION
The H gate is named SNOT in the current version. Correct the docs. #32 
We cannot really test circuit plotting because it requires latex and lots of others software to work.

At some point, we should support both names. This will be much easier after the refactor of the gate representation. @purva-thakre I think it won't be much work once the gate classes are built, right? We can have `H` as a subclass of `SNOT` or vice versa.