### PR TITLE
Loose the tests accuracy a bit for numerical circuit tests

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -45,7 +45,7 @@ from qutip_qip.device import (
     DispersiveCavityQED, LinearSpinChain, CircularSpinChain, SCQubits
 )
 
-_tol = 2.e-2
+_tol = 3.e-2
 
 _x = Gate("X", targets=[0])
 _z = Gate("Z", targets=[0])


### PR DESCRIPTION
SCQubits have a lower fidelity because of leakage.
The previous test may fail with about a probability of 10~20%.