### PR TITLE
Correct some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,30 @@ Installation
 ------------
 To install the package, download to source code and run
 ```
-    pip install .
+pip install .
 ```
 under the directory containing the ``setup.py`` file.
 
 If you want to edit the source code, use instead
 ```
-    pip install -e .
+pip install -e .
 ```
 
-To build and test the documentation, the following packages are required:
+To build and test the documentation, additional packages need to be installed:
 
 ```
-    sphinx numpydoc sphinx_rtd_theme doctest
+pip install matplotlib sphinx numpydoc sphinx_rtd_theme
 ```
 
 Under the docs directory, use
 ```
-    make html
+make html
 ```
-to build the documentation.
+to build the documentation, or
+```
+make doctest
+```
+to test the code in the documentation.
 
 Documentation
 -------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,9 +28,9 @@ In addition
 
 .. code-block:: bash
 
-    sphinx sphinx_rtd_theme doctest
+    sphinx numpydoc sphinx_rtd_theme
 
-are used to build the documentation.
+are used to build and test the documentation.
 
 A few other packages such as LaTeX is used for circuit plotting, please refer to the main documentation section for detailed instruction.
 

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -91,7 +91,7 @@ class DispersiveCavityQED(ModelProcessor):
         - ``deltamax``: the pulse strength of sigma-x control, default ``1.0``
         - ``epsmax``: the pulse strength of sigma-z control, default ``9.5``
         - ``eps``: the bare transition frequency for each of the qubits,
-          default ``10``
+          default ``9.5``
         - ``delta``: the coupling between qubit states, default ``0.0``
         - ``g``: the coupling strength between the resonator and the qubit,
           default ``1.0``

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -40,12 +40,14 @@ class SCQubits(ModelProcessor):
           for each pair of superconducting qubits,
           e.g. ``[5.15, 5.09, 5.15, ...]``
         - ``wr``: resonator bare frequency, default ``[5.96]*num_qubits``
+        - ``g``: The coupling strength between the resonator and the qubits,
+          default ``[0.1]*(num_qubits - 1)``
         - ``alpha``: anharmonicity for each superconducting qubit,
           default ``[-0.3]*num_qubits``
         - ``omega_single``: control strength for single-qubit gate,
-          default ``[-0.01]*num_qubits``
+          default ``[0.01]*num_qubits``
         - ``omega_cr``: control strength for cross resonance gate,
-          default ``[-0.01]*num_qubits``
+          default ``[0.01]*num_qubits``
 
     Attributes
     ----------


### PR DESCRIPTION
Fix inconsistency in the docstrings of some processors. The default value is defined in the `__init__` method of the class.
Correct the guide for using `doctest`, fix #38 