### PR TITLE
Prepare release v0.1.0 step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ Installation
 ------------
 To install the package, download to source code and run
 ```
-pip install .
+pip install qutip_qip
 ```
-under the directory containing the ``setup.py`` file.
 
-If you want to edit the source code, use instead
+If you want to edit the source code, please download the source code and run the following command under the folder with `setup.cfg`
 ```
 pip install -e .
 ```
@@ -33,7 +32,7 @@ To build and test the documentation, additional packages need to be installed:
 pip install matplotlib sphinx numpydoc sphinx_rtd_theme
 ```
 
-Under the docs directory, use
+Under the `docs` directory, use
 ```
 make html
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,6 +2,14 @@
 Installation
 ************
 
+Quick start
+===========
+To install the package ``qutip-qip`` from PyPI, use
+
+.. code-block:: bash
+
+    pip install qutip_qip
+
 .. _prerequisites:
 
 Prerequisites
@@ -45,7 +53,7 @@ To install the package, download to source code from `GitHub website <https://gi
 
     pip install .
 
-under the directory containing the ``setup.py`` file.
+under the directory containing the ``setup.cfg`` file.
 
 If you want to edit the code, use instead
 

--- a/src/qutip_qip/__init__.py
+++ b/src/qutip_qip/__init__.py
@@ -30,3 +30,4 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+__version__ = "0.1.0"


### PR DESCRIPTION
I realized that since this is the first release, I also need to update the README with the installation guide for `pip` install. This README will be shown on the PyPI website after the release just like this one with TestPyPI https://test.pypi.org/project/qutip-qip/.

The doc is not packed with the package so it doesn't really matter, but sooner or later I will need to do this anyway.

Please confirm if this is correct. @nathanshammah @quantshah @jakelishman @hodgestar 