### PR TITLE
Updates `readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ pip install -e .
 ```
 which makes sure that you are up to date with the latest `pip` version.
 
+In order to check if your code in `some_file.py` follows `PEP8` style guidelines, [*Black*](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) has to be installed.
+```
+pip install black
+python -m black some_file.py --diff --color
+python -m black some_file.py
+```
+Using [*`--diff`*](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#diffs) will show the changes that will be made by `Black`. If you would prefer these changes to be made, use the last line of above code block. 
+
 To build and test the documentation, additional packages need to be installed:
 
 ```


### PR DESCRIPTION
Updates `readme` with information about formatting and style. I couldn't find any information about this in qutip's documentation or was looking at the wrong pages.  

This instructs a user to install [`Black`](https://black.readthedocs.io/en/stable/) and ways to format their code. The defaults set by `Black` have not been changed but could be edited.If another package is preferred, then I can change the lines for preferred package. 

I do think there needs to be additional information regarding the use of `Black` in documentation and/or test files. Will add this after I get a feedback on this initial PR.  