### PR TITLE
Links tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Documentation and tutorials
 -------------
 
 The documentation of `qutip-qip` updated to the latest development version is hosted at [qutip-qip.readthedocs.io/](https://qutip-qip.readthedocs.io/en/latest/).
+Tutorials related to using quantum gates and circuits in `qutip-qip` can be found [*here*](https://qutip.org/tutorials#quantum-information-processing) and those related to using noise simulators areavailable at [*this link*](https://qutip.org/tutorials#nisq). 
 
 Code examples used in the preprint [*Pulse-level noisy quantum circuits with QuTiP*](https://arxiv.org/abs/2105.09902), updated for the latest code version, are hosted in [this folder](https://github.com/qutip/qutip-qip/tree/master/doc/pulse-paper).
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,13 @@ qutip-qip: QuTiP quantum information processing
 
 .. toctree::
     :maxdepth: 2
+    :caption: Tutorials
+
+    tutorials.rst
+
+
+.. toctree::
+    :maxdepth: 2
     :caption: User guide
 
     qip-basics.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,6 @@ qutip-qip: QuTiP quantum information processing
     introduction.rst
     installation.rst
 
-
 .. toctree::
     :maxdepth: 2
     :caption: User guide

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -29,7 +29,6 @@ qutip-qip: QuTiP quantum information processing
 
     tutorials.rst
 
-
 .. toctree::
     :maxdepth: 2
     :caption: Contribute to qutip-qip

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,12 +15,6 @@ qutip-qip: QuTiP quantum information processing
     introduction.rst
     installation.rst
 
-.. toctree::
-    :maxdepth: 2
-    :caption: Tutorials
-
-    tutorials.rst
-
 
 .. toctree::
     :maxdepth: 2
@@ -29,6 +23,13 @@ qutip-qip: QuTiP quantum information processing
     qip-basics.rst
     qip-simulator.rst
     qip-processor.rst
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Tutorials
+
+    tutorials.rst
+
 
 .. toctree::
     :maxdepth: 2

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -15,5 +15,3 @@ They are still maintained by the QuTiP team but hosted under different repositor
 The qutip-qip package, QuTiP quantum information processing, aims at providing basic tools for quantum computing simulation both for simple quantum algorithm design and for experimental realization.
 Compared to other libraries for quantum information processing, qutip-qip puts additional emphasis on the physics layer and the interaction with the QuTiP package.
 It offers two different approaches for simulating quantum circuits, one with :class:`.QubitCircuit` calculating unitary evolution under quantum gates by matrix product, another called :class:`.Processor` using open system solvers in QuTiP to simulate noisy quantum device.
-
-Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be found `here <https://qutip.org/tutorials#quantum-information-processing>`_ and those related to using noise simulators are available at this `link <https://qutip.org/tutorials#nisq>`_. 

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -15,3 +15,5 @@ They are still maintained by the QuTiP team but hosted under different repositor
 The qutip-qip package, QuTiP quantum information processing, aims at providing basic tools for quantum computing simulation both for simple quantum algorithm design and for experimental realization.
 Compared to other libraries for quantum information processing, qutip-qip puts additional emphasis on the physics layer and the interaction with the QuTiP package.
 It offers two different approaches for simulating quantum circuits, one with :class:`.QubitCircuit` calculating unitary evolution under quantum gates by matrix product, another called :class:`.Processor` using open system solvers in QuTiP to simulate noisy quantum device.
+
+Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be found `here <https://qutip.org/tutorials#quantum-information-processing>`_ and those related to using noise simulators are available at this `link <https://qutip.org/tutorials#nisq>`_. 

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -1,0 +1,10 @@
+.. _tutorials:
+
+************
+Tutorials
+************
+
+Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
+found `here <https://qutip.org/tutorials#quantum-information-processing>`_ and
+those related to using noise simulators are available at this
+`link <https://qutip.org/tutorials#nisq>`_.


### PR DESCRIPTION
As discussed in #33, links to tutorials are added in documentation and `readme.md`. 

For the moment, haven't changed the anchor as requested in above issue since Boxi had a PR for it. 