### PR TITLE
Fixes gate label import

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -49,7 +49,7 @@ from .operations import (Gate, rx, ry, rz, sqrtnot, snot, phasegate,
                                         iswap, sqrtswap, sqrtiswap, fredkin,
                                         toffoli, controlled_gate, globalphase,
                                         expand_operator, gate_sequence_product,
-                                        ,'_GATE_NAME_TO_LABEL','_gate_label')
+                                        _GATE_NAME_TO_LABEL,_gate_label)
 from qutip import tensor, basis, identity, ket2dm, qeye
 from qutip.qobj import Qobj
 from qutip.measurement import measurement_statistics

--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -48,7 +48,8 @@ from .operations import (Gate, rx, ry, rz, sqrtnot, snot, phasegate,
                                         csign, berkeley, swapalpha, swap,
                                         iswap, sqrtswap, sqrtiswap, fredkin,
                                         toffoli, controlled_gate, globalphase,
-                                        expand_operator, gate_sequence_product)
+                                        expand_operator, gate_sequence_product,
+                                        ,'_GATE_NAME_TO_LABEL','_gate_label')
 from qutip import tensor, basis, identity, ket2dm, qeye
 from qutip.qobj import Qobj
 from qutip.measurement import measurement_statistics

--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -50,6 +50,7 @@ from .operations import (Gate, rx, ry, rz, sqrtnot, snot, phasegate,
                                         toffoli, controlled_gate, globalphase,
                                         expand_operator, gate_sequence_product,
                                         _GATE_NAME_TO_LABEL,_gate_label)
+                                        
 from qutip import tensor, basis, identity, ket2dm, qeye
 from qutip.qobj import Qobj
 from qutip.measurement import measurement_statistics

--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -57,7 +57,7 @@ __all__ = ['Gate', 'rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'gate_expand_1toN', 'gate_expand_2toN', 'gate_expand_3toN',
            'qubit_clifford_group', 'expand_operator', '_single_qubit_gates',
            '_para_gates', '_ctrl_gates','_swap_like','_toffoli_like',
-           '_fredkin_like']
+           '_fredkin_like','_GATE_NAME_TO_LABEL','_gate_label']
 
 
 _single_qubit_gates = ["RX", "RY", "RZ", "SNOT", "SQRTNOT", "PHASEGATE",


### PR DESCRIPTION
Fixes import of gate labels when gates were moved to operations folder. See related [comment.](https://github.com/qutip/qutip-qip/issues/60#issuecomment-863828529) 

Tested with [examples in this notebook](https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-gates.ipynb#Controlled-PHASE). 

The notebook also needs a separate PR to change how gates are imported + deprecation warning in `In [62]`. This will be added later. 

Following code block is for future reference in relation to `In [62]` : 

``` python

<ipython-input-60-0c4e722f5dae>:3: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  mat = np.zeros((4, 4), dtype=np.complex)
```