### PR TITLE
Rename get_noisy_dynamics to get_noisy_pulses

### DIFF
--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -223,7 +223,7 @@ class DecoherenceNoise(Noise):
         ----------
         dims: list, optional
             The dimension of the components system, the default value is
-            [2,2...,2] for qubits system.
+            [2, 2, ..., 2] for a system of qubits.
         pulses : list of :class:`.Pulse`
             The input pulses. The noise will be added to pulses in this list.
         systematic_noise : :class:`.Pulse`

--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -108,7 +108,7 @@ class Noise(object):
         """
         Return the input pulses list with noise added and
         the pulse independent noise in a dummy :class:`.Pulse` object.
-        This is a template method, a method with the same name and signitures
+        This is a template method, a method with the same name and signatures
         needs to be defined in the subclasses.
 
         Parameters

--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -131,19 +131,17 @@ class Noise(object):
         systematic_noise : :class:`.Pulse`
             The dummy pulse representing pulse-independent noise.
         """
-        try:
-            # Try to check if the old API is defined.
-            result = self.get_noisy_dynamics(dims, pulses, systematic_noise)
+        get_noisy_dynamics = getattr(self, "get_noisy_dynamics", None)
+        if get_noisy_dynamics is not None:
             warnings.warn(
                 "Using get_noisy_dynamics as the hook function for custom "
                 "noise will be deprecated, "
                 "please use get_noisy_pulses instead.",
                 PendingDeprecationWarning)
-            return result
-        except AttributeError:
-            raise NotImplementedError(
-                "Subclass error needs a method"
-                "`get_noisy_pulses` to process the noise.") from None
+            return self.get_noisy_dynamics(dims, pulses, systematic_noise)
+        raise NotImplementedError(
+            "Subclass error needs a method"
+            "`get_noisy_pulses` to process the noise.")
 
     def _apply_noise(self, pulses=None, systematic_noise=None, dims=None):
         """

--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -32,6 +32,7 @@
 ###############################################################################
 
 import numbers
+import warnings
 from collections.abc import Iterable
 from copy import deepcopy
 import numpy as np
@@ -103,13 +104,12 @@ class Noise(object):
     The noise object can be added to :class:`.device.Processor` and
     contributes to evolution.
     """
-    def __init__(self):
-        pass
-
-    def get_noisy_dynamics(self, dims, pulses, systematic_noise):
+    def get_noisy_pulses(self, dims=None, pulses=None, systematic_noise=None):
         """
         Return the input pulses list with noise added and
-        the pulse independent noise in a dummy Pulse object.
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+        This is a template method, a method with the same name and signitures
+        needs to be defined in the subclasses.
 
         Parameters
         ----------
@@ -118,7 +118,7 @@ class Noise(object):
             [2,2...,2] for qubits system.
 
         pulses : list of :class:`.Pulse`
-            The input pulses, on which the noise object is to be applied.
+            The input pulses. The noise will be added to pulses in this list.
 
         systematic_noise : :class:`.Pulse`
             The dummy pulse with no ideal control element.
@@ -129,18 +129,28 @@ class Noise(object):
             Noisy pulses.
 
         systematic_noise : :class:`.Pulse`
-            The dummy pulse representing pulse independent noise.
+            The dummy pulse representing pulse-independent noise.
         """
-        raise NotImplementedError(
-            "Subclass error needs a method"
-            "`get_noisy_dynamics` to process the noise.")
+        try:
+            # Try to check if the old API is defined.
+            result = self.get_noisy_dynamics(dims, pulses, systematic_noise)
+            warnings.warn(
+                "Using get_noisy_dynamics as the hook function for custom "
+                "noise will be deprecated, "
+                "please use get_noisy_pulses instead.",
+                PendingDeprecationWarning)
+            return result
+        except AttributeError:
+            raise NotImplementedError(
+                "Subclass error needs a method"
+                "`get_noisy_pulses` to process the noise.") from None
 
     def _apply_noise(self, pulses=None, systematic_noise=None, dims=None):
         """
         For backward compatibility, in case the method has no return value
         or only return the pulse.
         """
-        result = self.get_noisy_dynamics(
+        result = self.get_noisy_pulses(
             pulses=pulses, systematic_noise=systematic_noise, dims=dims)
         if result is None:  # in-place change
             pass
@@ -151,7 +161,7 @@ class Noise(object):
             pulses = result
         else:
             raise TypeError(
-                "Returned value of get_noisy_dynamics not understood.")
+                "Returned value of get_noisy_pulses not understood.")
         return pulses, systematic_noise
 
 
@@ -205,8 +215,29 @@ class DecoherenceNoise(Noise):
                     "thus cannot be applied to all qubits")
         self.all_qubits = all_qubits
 
-    def get_noisy_dynamics(
+    def get_noisy_pulses(
             self, dims=None, pulses=None, systematic_noise=None):
+        """
+        Return the input pulses list with noise added and
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+
+        Parameters
+        ----------
+        dims: list, optional
+            The dimension of the components system, the default value is
+            [2,2...,2] for qubits system.
+        pulses : list of :class:`.Pulse`
+            The input pulses. The noise will be added to pulses in this list.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse with no ideal control element.
+
+        Returns
+        -------
+        noisy_pulses: list of :class:`.Pulse`
+            Noisy pulses.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse representing pulse-independent noise.
+        """
         if systematic_noise is None:
             systematic_noise = Pulse(None, None, label="system")
         N = len(dims)
@@ -283,8 +314,29 @@ class RelaxationNoise(Noise):
                 "either the length is not equal to the number of qubits, "
                 "or T is not a positive number.".format(T))
 
-    def get_noisy_dynamics(
+    def get_noisy_pulses(
             self, dims=None, pulses=None, systematic_noise=None):
+        """
+        Return the input pulses list with noise added and
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+
+        Parameters
+        ----------
+        dims: list, optional
+            The dimension of the components system, the default value is
+            [2,2...,2] for qubits system.
+        pulses : list of :class:`.Pulse`
+            The input pulses. The noise will be added to pulses in this list.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse with no ideal control element.
+
+        Returns
+        -------
+        noisy_pulses: list of :class:`.Pulse`
+            Noisy pulses.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse representing pulse-independent noise.
+        """
         if systematic_noise is None:
             systematic_noise = Pulse(None, None, label="system")
         N = len(dims)
@@ -352,7 +404,7 @@ class ControlAmpNoise(Noise):
         self.tlist = tlist
         self.indices = indices
 
-    def get_noisy_dynamics(
+    def get_noisy_pulses(
             self, dims=None, pulses=None, systematic_noise=None):
         if pulses is None:
             pulses = []
@@ -422,8 +474,29 @@ class RandomNoise(ControlAmpNoise):
         self.dt = dt
         self.indices = indices
 
-    def get_noisy_dynamics(
+    def get_noisy_pulses(
             self, dims=None, pulses=None, systematic_noise=None):
+        """
+        Return the input pulses list with noise added and
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+
+        Parameters
+        ----------
+        dims: list, optional
+            The dimension of the components system, the default value is
+            [2,2...,2] for qubits system.
+        pulses : list of :class:`.Pulse`
+            The input pulses. The noise will be added to pulses in this list.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse with no ideal control element.
+
+        Returns
+        -------
+        noisy_pulses: list of :class:`.Pulse`
+            Noisy pulses.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse representing pulse-independent noise.
+        """
         if pulses is None:
             pulses = []
         if self.indices is None:
@@ -465,8 +538,29 @@ class ZZCrossTalk(Noise):
             self, params):
         self.params = params
 
-    def get_noisy_dynamics(
+    def get_noisy_pulses(
             self, dims=None, pulses=None, systematic_noise=None):
+        """
+        Return the input pulses list with noise added and
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+
+        Parameters
+        ----------
+        dims: list, optional
+            The dimension of the components system, the default value is
+            [2,2...,2] for qubits system.
+        pulses : list of :class:`.Pulse`
+            The input pulses. The noise will be added to pulses in this list.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse with no ideal control element.
+
+        Returns
+        -------
+        noisy_pulses: list of :class:`.Pulse`
+            Noisy pulses.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse representing pulse-independent noise.
+        """
         J = self.params["J"]
         wr_dr = self.params["wr_dressed"]
         wr = self.params["wr"]

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -33,6 +33,7 @@
 
 from numpy.testing import assert_, run_module_suite, assert_allclose
 import numpy as np
+import pytest
 
 from qutip import (
     tensor, qeye, sigmaz, sigmax, sigmay, destroy, identity, QobjEvo,
@@ -44,16 +45,6 @@ from qutip_qip.noise import (
     ZZCrossTalk, Noise)
 from qutip_qip.pulse import Pulse, Drift
 from qutip_qip.circuit import QubitCircuit
-
-
-class DriftNoise(Noise):
-    def __init__(self, op):
-        self.qobj = op
-
-    def get_noisy_dynamics(self, dims, pulses, systematic_noise):
-        systematic_noise.add_coherent_noise(self.qobj, 0, coeff=True)
-        # test the backward compatibility
-        return pulses
 
 
 class TestNoise:
@@ -68,15 +59,15 @@ class TestNoise:
         decnoise = DecoherenceNoise(
             sigmaz(), coeff=coeff, tlist=tlist, targets=[1])
         dims = [2] * 2
-        pulses, systematic_noise = decnoise.get_noisy_dynamics(dims=dims)
+        pulses, systematic_noise = decnoise.get_noisy_pulses(dims=dims)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_allclose(c_ops[0].ops[0].qobj, tensor(qeye(2), sigmaz()))
         assert_allclose(c_ops[0].ops[0].coeff, coeff)
         assert_allclose(c_ops[0].tlist, tlist)
 
-        # Time-indenpendent and all qubits
+        # Time-independent and all qubits
         decnoise = DecoherenceNoise(sigmax(), all_qubits=True)
-        pulses, systematic_noise = decnoise.get_noisy_dynamics(dims=dims)
+        pulses, systematic_noise = decnoise.get_noisy_pulses(dims=dims)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         c_ops = [qu.cte for qu in c_ops]
         assert_(tensor([qeye(2), sigmax()]) in c_ops)
@@ -85,7 +76,7 @@ class TestNoise:
         # Time-denpendent and all qubits
         decnoise = DecoherenceNoise(
             sigmax(), all_qubits=True, coeff=coeff*2, tlist=tlist)
-        pulses, systematic_noise = decnoise.get_noisy_dynamics(dims=dims)
+        pulses, systematic_noise = decnoise.get_noisy_pulses(dims=dims)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_allclose(c_ops[0].ops[0].qobj, tensor(sigmax(), qeye(2)))
         assert_allclose(c_ops[0].ops[0].coeff, coeff*2)
@@ -101,7 +92,7 @@ class TestNoise:
         dims = [2] * 3
         relnoise = RelaxationNoise(t1=[1., 1., 1.], t2=None)
         systematic_noise = Pulse(None, None, label="system")
-        pulses, systematic_noise = relnoise.get_noisy_dynamics(
+        pulses, systematic_noise = relnoise.get_noisy_pulses(
             dims=dims, systematic_noise=systematic_noise)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_(len(c_ops) == 3)
@@ -111,7 +102,7 @@ class TestNoise:
         dims = [2] * 2
         relnoise = RelaxationNoise(t1=None, t2=None)
         systematic_noise = Pulse(None, None, label="system")
-        pulses, systematic_noise = relnoise.get_noisy_dynamics(
+        pulses, systematic_noise = relnoise.get_noisy_pulses(
             dims=dims, systematic_noise=systematic_noise)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_(len(c_ops) == 0)
@@ -119,14 +110,14 @@ class TestNoise:
         # only t2
         relnoise = RelaxationNoise(t1=None, t2=[0.2, 0.7])
         systematic_noise = Pulse(None, None, label="system")
-        pulses, systematic_noise = relnoise.get_noisy_dynamics(
+        pulses, systematic_noise = relnoise.get_noisy_pulses(
             dims=dims, systematic_noise=systematic_noise)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_(len(c_ops) == 2)
 
         # t1+t2 and systematic_noise = None
         relnoise = RelaxationNoise(t1=[1., 1.], t2=[0.5, 0.5])
-        pulses, systematic_noise = relnoise.get_noisy_dynamics(dims=dims)
+        pulses, systematic_noise = relnoise.get_noisy_pulses(dims=dims)
         noisy_qu, c_ops = systematic_noise.get_noisy_qobjevo(dims=dims)
         assert_(len(c_ops) == 4)
 
@@ -141,7 +132,7 @@ class TestNoise:
         pulses = [Pulse(sigmaz(), 0, tlist, coeff)]
         connoise = ControlAmpNoise(coeff=coeff, tlist=tlist)
         noisy_pulses, systematic_noise = \
-            connoise.get_noisy_dynamics(pulses=pulses)
+            connoise.get_noisy_pulses(pulses=pulses)
         assert_allclose(pulses[0].coherent_noise[0].qobj, sigmaz())
         assert_allclose(noisy_pulses[0].coherent_noise[0].coeff, coeff)
 
@@ -162,7 +153,7 @@ class TestNoise:
         gaussnoise = RandomNoise(
             dt=0.1, rand_gen=np.random.normal, loc=mean, scale=std)
         noisy_pulses, systematic_noise = \
-            gaussnoise.get_noisy_dynamics(pulses=pulses)
+            gaussnoise.get_noisy_pulses(pulses=pulses)
         assert_allclose(noisy_pulses[2].qobj, sigmay())
         assert_allclose(noisy_pulses[1].coherent_noise[0].qobj, sigmax())
         assert_allclose(
@@ -176,7 +167,7 @@ class TestNoise:
         gaussnoise = RandomNoise(lam=0.1, dt=0.2, rand_gen=np.random.poisson)
         assert_(gaussnoise.rand_gen is np.random.poisson)
         noisy_pulses, systematic_noise = \
-            gaussnoise.get_noisy_dynamics(pulses=pulses)
+            gaussnoise.get_noisy_pulses(pulses=pulses)
         assert_allclose(
             noisy_pulses[0].coherent_noise[0].tlist,
             np.linspace(1, 6, int(5/0.2) + 1))
@@ -186,19 +177,6 @@ class TestNoise:
         assert_allclose(
             noisy_pulses[2].coherent_noise[0].tlist,
             np.linspace(1, 6, int(5/0.2) + 1))
-
-    def test_user_defined_noise(self):
-        """
-        Test for the user-defined noise object
-        """
-        dr_noise = DriftNoise(sigmax())
-        proc = Processor(1)
-        proc.add_noise(dr_noise)
-        tlist = np.array([0, np.pi/2.])
-        proc.add_pulse(Pulse(identity(2), 0, tlist, False))
-        result = proc.run_state(init_state=basis(2, 0))
-        assert_allclose(
-            fidelity(result.states[-1], basis(2, 1)), 1, rtol=1.0e-6)
 
     def test_zz_cross_talk(self):
         circuit = QubitCircuit(2)
@@ -210,3 +188,71 @@ class TestNoise:
         for pulse in pulses:
             if not isinstance(pulse, Drift) and pulse.label=="systematic_noise":
                 assert(len(pulse.coherent_noise) == 1)
+
+
+class DriftNoise1(Noise):
+    """Standard defintion."""
+    def __init__(self, op):
+        self.qobj = op
+
+    def get_noisy_pulses(self, dims, pulses, systematic_noise):
+        systematic_noise.add_coherent_noise(self.qobj, 0, coeff=True)
+        return pulses, systematic_noise
+
+
+class DriftNoise2(Noise):
+    """Only pulses is returned, no system noise."""
+    def __init__(self, op):
+        self.qobj = op
+
+    def get_noisy_pulses(self, dims, pulses, systematic_noise):
+        systematic_noise.add_coherent_noise(self.qobj, 0, coeff=True)
+        return pulses
+
+
+class DriftNoiseOld1(Noise):
+    """Using get_noisy_dynamics as the hook function."""
+    def __init__(self, op):
+        self.qobj = op
+
+    def get_noisy_dynamics(self, dims, pulses, systematic_noise):
+        systematic_noise.add_coherent_noise(self.qobj, 0, coeff=True)
+        return pulses, systematic_noise
+
+
+class DriftNoiseError1(Noise):
+    """Missing hook function, check the error raised."""
+    def __init__(self, op):
+        self.qobj = op
+
+
+@pytest.mark.parametrize(
+        "noise_class, mode",
+        [(DriftNoise1, "pass"),
+        (DriftNoise2, "pass"),
+        (DriftNoiseOld1, "warning"),
+        (DriftNoiseError1, "error"),
+        ]
+    )
+def test_user_defined_noise(noise_class, mode):
+    """
+    Test for the user-defined noise object
+    """
+    dr_noise = noise_class(sigmax())
+    proc = Processor(1)
+    proc.add_noise(dr_noise)
+    tlist = np.array([0, np.pi/2.])
+    proc.add_pulse(Pulse(identity(2), 0, tlist, False))
+
+    if mode == "warning":
+        with pytest.warns(PendingDeprecationWarning):
+            result = proc.run_state(init_state=basis(2, 0))
+    elif mode == "error":
+        with pytest.raises(NotImplementedError):
+            result = proc.run_state(init_state=basis(2, 0))
+        return
+    else:
+        result = proc.run_state(init_state=basis(2, 0))
+
+    assert_allclose(
+        fidelity(result.states[-1], basis(2, 1)), 1, rtol=1.0e-6)


### PR DESCRIPTION
**Description**
In the noise module, users are allowed to define custom noise for their own physical model. The `Noise` class uses a hook method `get_noisy_dynamics` to realize this. This method will be called when including noise in the physical model.

It was pointed out by @quantshah that the name `get_noisy_dynamics` was wrong because the noise object returns a list of `Pulse`, instead of `QobjEvo`. This PR fixed this issue and use the term `get_noisy_pulses`. The old API is still usable but will issue a `PendingDeprecationWarning`.

I also copied the docstring of `get_noisy_pulses` to those in the subclass for easier reference. I originally thought that if the docstrings are missing, they will be inherited automatically, but this is not the case.

I also pinned @hodgestar because I briefly mentioned this and asked for your advice in one of our discussions.