### PR TITLE
Support different pulse shapes

### DIFF
--- a/doc/source/qip-processor.rst
+++ b/doc/source/qip-processor.rst
@@ -191,6 +191,9 @@ To let it find the optimal pulses, we need to give the parameters for :func:`~qu
 Compiler and scheduler
 ======================
 
+Compiler
+--------
+
 In order to simulate quantum circuits at the level of time evolution.
 We need to first compile the circuit into the Hamiltonian model, i.e.
 the control pulses.
@@ -235,6 +238,9 @@ The first pulse starts from ``t=0`` and ends at ``t=1``, with the strengh :math:
 The second one is turned on from ``t=1`` to ``t=2`` with the same strength.
 The compiled pulse here is different from what is shown in the plot
 in the previous subsection because the scheduler is turned off by default.
+
+Scheduler
+---------
 
 The scheduler is implemented in the class :class:`.compiler.Scheduler`,
 based on the idea of https://doi.org/10.1117/12.666419.
@@ -286,6 +292,26 @@ For pulse schedule, or scheduling gates with different duration,
 one will need to wrap the :class:`.Gate` object with :class:`.compiler.instruction` object,
 with a parameter `duration`.
 The result will then be the start time of each instruction.
+
+Pulse shape
+-----------
+Apart from square pulses, compilers also support different pulse shapes.
+All pulse shapes from `SciPy window functions <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_ that does not require additional parameters are supported.
+The method :obj:`.GateCompiler.generate_pulse_shape` allows one to generate pulse shapes that fulfil the given maximum intensity and the total integral area.
+
+.. plot::
+
+    from qutip_qip.compiler import GateCompiler
+    compiler = GateCompiler()
+    coeff, tlist = compiler.generate_pulse_shape(
+        "hann", 1000, maximum=2., area=1.)
+    fig, ax = plt.subplots(figsize=(4,2))
+    ax.plot(tlist, coeff)
+    ax.set_xlabel("Time")
+    fig.show()
+
+For predefined compilers, the compiled pulse shape can also be configured by the key word ``"shape"`` and ``"num_samples"`` in the dictionary attribute :attr:`.GateCompiler.args`
+or the ``args`` parameter of :obj:`.GateCompiler.compile`.
 
 Noise Simulation
 ================

--- a/doc/source/qip-processor.rst
+++ b/doc/source/qip-processor.rst
@@ -296,7 +296,7 @@ The result will then be the start time of each instruction.
 Pulse shape
 -----------
 Apart from square pulses, compilers also support different pulse shapes.
-All pulse shapes from `SciPy window functions <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_ that does not require additional parameters are supported.
+All pulse shapes from `SciPy window functions <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_ that do not require additional parameters are supported.
 The method :obj:`.GateCompiler.generate_pulse_shape` allows one to generate pulse shapes that fulfil the given maximum intensity and the total integral area.
 
 .. plot::

--- a/doc/source/qip-processor.rst
+++ b/doc/source/qip-processor.rst
@@ -295,6 +295,7 @@ The result will then be the start time of each instruction.
 
 Pulse shape
 -----------
+
 Apart from square pulses, compilers also support different pulse shapes.
 All pulse shapes from `SciPy window functions <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_ that do not require additional parameters are supported.
 The method :obj:`.GateCompiler.generate_pulse_shape` allows one to generate pulse shapes that fulfil the given maximum intensity and the total integral area.

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -83,7 +83,7 @@ class CavityQEDCompiler(GateCompiler):
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"],
             maximum=self.params["sx"][targets[0]],
-            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is= X, not X/2
+            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is X, not X/2
         pulse_info = [("sx" + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -1,4 +1,6 @@
+from functools import partial
 import numpy as np
+import scipy
 
 from ..circuit import QubitCircuit
 from ..operations import Gate
@@ -10,8 +12,22 @@ __all__ = ['CavityQEDCompiler']
 
 class CavityQEDCompiler(GateCompiler):
     """
-    Decompose a :class:`.QubitCircuit` into
-    the pulse sequence for the processor.
+    Compiler for :obj:`.DispersiveCavityQED`.
+    Compiled pulse strength is in the unit of GHz.
+
+    Supported native gates: "RX", "RY", "RZ", "ISWAP", "SQRTISWAP",
+    "GLOBALPHASE".
+
+    Default configuration (see :obj:`.GateCompiler.args` and
+    :obj:`.GateCompiler.compile`):
+
+        +-----------------+--------------------+
+        | key             | value              |
+        +=================+====================+
+        | ``shape``       | ``rectangular``    |
+        +-----------------+--------------------+
+        |``params``       | Hardware Parameters|
+        +-----------------+--------------------+
 
     Parameters
     ----------
@@ -39,81 +55,15 @@ class CavityQEDCompiler(GateCompiler):
         self.gate_compiler.update({
             "ISWAP": self.iswap_compiler,
             "SQRTISWAP": self.sqrtiswap_compiler,
-            "RZ": self.rz_compiler,
-            "RX": self.rx_compiler,
+            "RZ": partial(self.default_single_qubit_compiler, scaling=0.5),
+            "RX": partial(self.default_single_qubit_compiler, scaling=0.5),
             "GLOBALPHASE": self.globalphase_compiler
             })
         self.wq = np.sqrt(self.params["eps"]**2 + self.params["delta"]**2)
         self.Delta = self.wq - self.params["w0"]
         self.global_phase = global_phase
 
-    def rz_compiler(self, gate, args):
-        """
-        Compiler for the RZ gate
-        """
-        targets = gate.targets
-        g = self.params["sz"][targets[0]]
-        coeff = np.sign(gate.arg_value) * g
-        tlist = abs(gate.arg_value) / (2*g) / np.pi / 2
-        pulse_info = [("sz" + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist, pulse_info)]
-
-    def rx_compiler(self, gate, args):
-        """
-        Compiler for the RX gate
-        """
-        targets = gate.targets
-        g = self.params["sx"][targets[0]]
-        coeff = np.sign(gate.arg_value) * g
-        tlist = abs(gate.arg_value) / (2*g) / np.pi / 2
-        pulse_info = [("sx" + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist, pulse_info)]
-
-    def sqrtiswap_compiler(self, gate, args):
-        """
-        Compiler for the SQRTISWAP gate
-
-        Notes
-        -----
-        This version of sqrtiswap_compiler has very low fidelity, please use
-        iswap
-        """
-        # FIXME This decomposition has poor behaviour
-        q1, q2 = gate.targets
-        pulse_info = []
-        pulse_name = "sz" + str(q1)
-        coeff = self.wq[q1] - self.params["w0"]
-        pulse_info += [(pulse_name, coeff)]
-        pulse_name = "sz" + str(q1)
-        coeff = self.wq[q2] - self.params["w0"]
-        pulse_info += [(pulse_name, coeff)]
-        pulse_name = "g" + str(q1)
-        coeff = self.params["g"][q1]
-        pulse_info += [(pulse_name, coeff)]
-        pulse_name = "g" + str(q2)
-        coeff = self.params["g"][q2]
-        pulse_info += [(pulse_name, coeff)]
-
-        J = self.params["g"][q1] * self.params["g"][q2] * (
-            1 / self.Delta[q1] + 1 / self.Delta[q2]) / 2
-        tlist = (4 * np.pi / abs(J)) / 8 / np.pi / 2
-        instruction_list = [Instruction(gate, tlist, pulse_info)]
-
-        # corrections
-        gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/4)
-        compiled_gate1 = self.rz_compiler(gate1, args)
-        instruction_list += compiled_gate1
-        gate2 = Gate("RZ", [q2], None, arg_value=-np.pi/4)
-        compiled_gate2 = self.rz_compiler(gate2, args)
-        instruction_list += compiled_gate2
-        gate3 = Gate("GLOBALPHASE", None, None, arg_value=-np.pi/4)
-        self.globalphase_compiler(gate3, args)
-        return instruction_list
-
-    def iswap_compiler(self, gate, args):
-        """
-        Compiler for the ISWAP gate
-        """
+    def _two_qubit_compiler(self, gate_name, gate, args):
         q1, q2 = gate.targets
         pulse_info = []
         pulse_name = "sz" + str(q1)
@@ -130,20 +80,75 @@ class CavityQEDCompiler(GateCompiler):
         pulse_info += [(pulse_name, coeff)]
 
         J = self.params["g"][q1] * self.params["g"][q2] * (
-            1 / self.Delta[q1] + 1 / self.Delta[q2]) / 2
-        tlist = (4 * np.pi / abs(J)) / 4 / np.pi / 2
+            1. / self.Delta[q1] + 1. / self.Delta[q2]) / 2.
+        if gate_name == "ISWAP":
+            area = 1. / 2.
+            correction_angle = -np.pi / 2.
+        elif gate_name == "SQRTISWAP":
+            area = 1. / 4.
+            correction_angle = -np.pi / 4.
+        else:
+            raise ValueError(f"Gate {gate.name} cannot not be compiled.")
+        coeff, tlist = self.generate_pulse_shape(
+            args["shape"], args["num_samples"], maximum=J, area=area)
         instruction_list = [Instruction(gate, tlist, pulse_info)]
 
         # corrections
-        gate1 = Gate("RZ", [q1], None, arg_value=-np.pi/2.)
-        compiled_gate1 = self.rz_compiler(gate1, args)
+        gate1 = Gate("RZ", [q1], None, arg_value=correction_angle)
+        compiled_gate1 = self.gate_compiler["RZ"](gate1, args)
         instruction_list += compiled_gate1
-        gate2 = Gate("RZ", [q2], None, arg_value=-np.pi/2)
-        compiled_gate2 = self.rz_compiler(gate2, args)
+        gate2 = Gate("RZ", [q2], None, arg_value=correction_angle)
+        compiled_gate2 = self.gate_compiler["RZ"](gate2, args)
         instruction_list += compiled_gate2
-        gate3 = Gate("GLOBALPHASE", None, None, arg_value=-np.pi/2)
+        gate3 = Gate("GLOBALPHASE", None, None, arg_value=correction_angle)
         self.globalphase_compiler(gate3, args)
         return instruction_list
+
+    def sqrtiswap_compiler(self, gate, args):
+        """
+        Compiler for the SQRTISWAP gate.
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
+
+        Notes
+        -----
+        This version of sqrtiswap_compiler has very low fidelity, please use
+        iswap
+        """
+        # FIXME This decomposition has poor behaviour.
+        return self._two_qubit_compiler("SQRTISWAP", gate, args)
+
+    def iswap_compiler(self, gate, args):
+        """
+        Compiler for the ISWAP gate.
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
+        """
+        return self._two_qubit_compiler("ISWAP", gate, args)
 
     def globalphase_compiler(self, gate, args):
         """

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -55,13 +55,37 @@ class CavityQEDCompiler(GateCompiler):
         self.gate_compiler.update({
             "ISWAP": self.iswap_compiler,
             "SQRTISWAP": self.sqrtiswap_compiler,
-            "RZ": partial(self.default_single_qubit_compiler, scaling=0.5),
-            "RX": partial(self.default_single_qubit_compiler, scaling=0.5),
+            "RZ": self.rz_compiler,
+            "RX": self.rx_compiler,
             "GLOBALPHASE": self.globalphase_compiler
             })
         self.wq = np.sqrt(self.params["eps"]**2 + self.params["delta"]**2)
         self.Delta = self.wq - self.params["w0"]
         self.global_phase = global_phase
+
+    def rz_compiler(self, gate, args):
+        """
+        Compiler for the RZ gate
+        """
+        targets = gate.targets
+        coeff, tlist = self.generate_pulse_shape(
+            args["shape"], args["num_samples"],
+            maximum=self.params["sz"][targets[0]],
+            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is Z, not Z/2
+        pulse_info = [("sz" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
+
+    def rx_compiler(self, gate, args):
+        """
+        Compiler for the RX gate
+        """
+        targets = gate.targets
+        coeff, tlist = self.generate_pulse_shape(
+            args["shape"], args["num_samples"],
+            maximum=self.params["sx"][targets[0]],
+            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is= X, not X/2
+        pulse_info = [("sx" + str(targets[0]), coeff)]
+        return [Instruction(gate, tlist, pulse_info)]
 
     def _two_qubit_compiler(self, gate_name, gate, args):
         q1, q2 = gate.targets

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -65,7 +65,7 @@ class CavityQEDCompiler(GateCompiler):
 
     def _rotation_compiler(self, gate, op_label, param_label, args):
         """
-        Single qubit gate compiler.
+        Single qubit rotation compiler.
 
         Parameters
         ----------

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -63,29 +63,77 @@ class CavityQEDCompiler(GateCompiler):
         self.Delta = self.wq - self.params["w0"]
         self.global_phase = global_phase
 
-    def rz_compiler(self, gate, args):
+    def _rotation_compiler(self, gate, op_label, param_label, args):
         """
-        Compiler for the RZ gate
+        Single qubit gate compiler.
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        op_label : str
+            Label of the corresponding control Hamiltonian.
+        param_label : str
+            Label of the hardware parameters saved in
+            :obj:`GateCompiler.params`.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
         """
         targets = gate.targets
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"],
-            maximum=self.params["sz"][targets[0]],
-            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is Z, not Z/2
-        pulse_info = [("sz" + str(targets[0]), coeff)]
+            maximum=self.params[param_label][targets[0]],
+            # The operator is Pauli Z/X/Y, without 1/2.
+            area=gate.arg_value / 2. / np.pi * 0.5)
+        pulse_info = [(op_label + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
+
+    def rz_compiler(self, gate, args):
+        """
+        Compiler for the RZ gate
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
+        """
+        return self._rotation_compiler(gate, "sz", "sz", args)
 
     def rx_compiler(self, gate, args):
         """
         Compiler for the RX gate
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
         """
-        targets = gate.targets
-        coeff, tlist = self.generate_pulse_shape(
-            args["shape"], args["num_samples"],
-            maximum=self.params["sx"][targets[0]],
-            area=gate.arg_value / 2. / np.pi * 0.5)  # operator is X, not X/2
-        pulse_info = [("sx" + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist, pulse_info)]
+        return self._rotation_compiler(gate, "sx", "sx", args)
 
     def _swap_compiler(self, gate, area, correction_angle, args):
         q1, q2 = gate.targets

--- a/src/qutip_qip/compiler/cavityqedcompiler.py
+++ b/src/qutip_qip/compiler/cavityqedcompiler.py
@@ -87,7 +87,7 @@ class CavityQEDCompiler(GateCompiler):
         pulse_info = [("sx" + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def _two_qubit_compiler(self, gate_name, gate, args):
+    def _swap_compiler(self, gate, area, correction_angle, args):
         q1, q2 = gate.targets
         pulse_info = []
         pulse_name = "sz" + str(q1)
@@ -105,14 +105,6 @@ class CavityQEDCompiler(GateCompiler):
 
         J = self.params["g"][q1] * self.params["g"][q2] * (
             1. / self.Delta[q1] + 1. / self.Delta[q2]) / 2.
-        if gate_name == "ISWAP":
-            area = 1. / 2.
-            correction_angle = -np.pi / 2.
-        elif gate_name == "SQRTISWAP":
-            area = 1. / 4.
-            correction_angle = -np.pi / 4.
-        else:
-            raise ValueError(f"Gate {gate.name} cannot not be compiled.")
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"], maximum=J, area=area)
         instruction_list = [Instruction(gate, tlist, pulse_info)]
@@ -152,7 +144,8 @@ class CavityQEDCompiler(GateCompiler):
         iswap
         """
         # FIXME This decomposition has poor behaviour.
-        return self._two_qubit_compiler("SQRTISWAP", gate, args)
+        return self._swap_compiler(
+            gate, area=1/4, correction_angle=-np.pi/4, args=args)
 
     def iswap_compiler(self, gate, args):
         """
@@ -172,7 +165,8 @@ class CavityQEDCompiler(GateCompiler):
         A list of :obj:`.Instruction`, including the compiled pulse
         information for this gate.
         """
-        return self._two_qubit_compiler("ISWAP", gate, args)
+        return self._swap_compiler(
+            gate, area=1/2, correction_angle=-np.pi/2, args=args)
 
     def globalphase_compiler(self, gate, args):
         """

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -60,29 +60,76 @@ class SCQubitsCompiler(GateCompiler):
             ) / max_pulse
         return tlist, coeff
 
-    def ry_compiler(self, gate, args):
+    def _rotation_compiler(self, gate, op_label, param_label, args):
         """
-        Compiler for the RZ gate
+        Single qubit gate compiler.
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        op_label : str
+            Label of the corresponding control Hamiltonian.
+        param_label : str
+            Label of the hardware parameters saved in
+            :obj:`GateCompiler.params`.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
         """
         targets = gate.targets
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"],
-            maximum=self.params["omega_single"][targets[0]],
+            maximum=self.params[param_label][targets[0]],
             area=gate.arg_value / 2. / np.pi)
-        pulse_info = [("sy" + str(targets[0]), coeff)]
+        pulse_info = [(op_label + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
+
+    def ry_compiler(self, gate, args):
+        """
+        Compiler for the RZ gate
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
+        """
+        return self._rotation_compiler(gate, "sy", "omega_single", args)
 
     def rx_compiler(self, gate, args):
         """
         Compiler for the RX gate
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
         """
-        targets = gate.targets
-        coeff, tlist = self.generate_pulse_shape(
-            args["shape"], args["num_samples"],
-            maximum=self.params["omega_single"][targets[0]],
-            area=gate.arg_value / 2. / np.pi)
-        pulse_info = [("sx" + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist, pulse_info)]
+        return self._rotation_compiler(gate, "sx", "omega_single", args)
 
     def cnot_compiler(self, gate, args):
         """

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -62,7 +62,7 @@ class SCQubitsCompiler(GateCompiler):
 
     def _rotation_compiler(self, gate, op_label, param_label, args):
         """
-        Single qubit gate compiler.
+        Single qubit rotation compiler.
 
         Parameters
         ----------

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -106,11 +106,8 @@ class SCQubitsCompiler(GateCompiler):
         tlist = tlist / amplitude * area * sign
         coeff = coeff * amplitude * sign
         from scipy.integrate import simps
-        print(amplitude)
-        print(simps(coeff, tlist))
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"], maximum=zx_coeff, area=area)
-        print(simps(coeff, tlist))
         pulse_info = [("zx" + str(q1) + str(q2), coeff)]
         result += [Instruction(gate, tlist, pulse_info)]
 

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -119,7 +119,6 @@ class SCQubitsCompiler(GateCompiler):
         sign = np.sign(amplitude) * np.sign(area)
         tlist = tlist / amplitude * area * sign
         coeff = coeff * amplitude * sign
-        from scipy.integrate import simps
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"], maximum=zx_coeff, area=area)
         pulse_info = [("zx" + str(q1) + str(q2), coeff)]

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -1,3 +1,4 @@
+from functools import partial
 import numpy as np
 
 from ..circuit import Gate
@@ -11,14 +12,36 @@ class SCQubitsCompiler(GateCompiler):
     """
     Compiler for :class:`.SCQubits`.
     Compiled pulse strength is in the unit of GHz.
+
+    Supported native gates: "RX", "RY", "CNOT".
+
+    Default configuration (see :obj:`.GateCompiler.args` and
+    :obj:`.GateCompiler.compile`):
+
+        +-----------------+-----------------------+
+        | key             | value                 |
+        +=================+=======================+
+        | ``shape``       | ``hann``              |
+        +-----------------+-----------------------+
+        |``num_samples``  | 1000                  |
+        +-----------------+-----------------------+
+        |``params``       | Hardware Parameters   |
+        +-----------------+-----------------------+
     """
     def __init__(self, num_qubits, params):
         super(SCQubitsCompiler, self).__init__(num_qubits, params=params)
         self.gate_compiler.update({
-            "RX": self.single_qubit_compiler,
-            "RY": self.single_qubit_compiler,
+            "RX": partial(
+                self.default_single_qubit_compiler, param_name="omega_single"),
+            "RY": partial(
+                self.default_single_qubit_compiler, param_name="omega_single"),
             "CNOT": self.cnot_compiler,
             })
+        self.args = {  # Default configuration
+            "shape": "hann",
+            "num_samples": 1000,
+            "params": self.params,
+            }
 
     def _normalized_gauss_pulse(self):
         """
@@ -32,37 +55,41 @@ class SCQubitsCompiler(GateCompiler):
         #  td normalization so that the total integral area is 1
         td = 2.4384880692912567
         sigma = 1/6 * td  # 3 sigma
-        tlist = np.linspace(0, td, 100)
+        tlist = np.linspace(0, td, 1000)
         max_pulse = 1 - np.exp(-(0-td/2)**2/2/sigma**2)
-        coeff = (np.exp(-(tlist-td/2)**2/2/sigma**2)
-            - np.exp(-(0-td/2)**2/2/sigma**2)) / max_pulse
+        coeff = (
+            np.exp(-(tlist-td/2)**2/2/sigma**2)
+            - np.exp(-(0-td/2)**2/2/sigma**2)
+            ) / max_pulse
         return tlist, coeff
 
     def single_qubit_compiler(self, gate, args):
         """
         Compiler for the RX and RY gate.
         """
-        targets = gate.targets
-        omega_single = self.params["omega_single"][targets[0]]
-        tlist, coeff = self._normalized_gauss_pulse()
-        sign = np.sign(omega_single) * np.sign(gate.arg_value)
-        tlist = tlist / omega_single * gate.arg_value/np.pi/2 * sign
-        coeff = coeff * omega_single * sign
-        if gate.name == "RY":
-            pulse_prefix = "sy"
-        elif gate.name == "RX":
-            pulse_prefix = "sx"
-        else:
-            raise ValueError(f"Gate {gate.name} cnot not be compiled.")
-        pulse_info = [(pulse_prefix + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist, pulse_info)]
+        return partial(
+            self.default_single_qubit_compiler, param_name="omega_single")
 
     def cnot_compiler(self, gate, args):
         """
         Compiler for CNOT gate using the cross resonance iteraction.
         See
         https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.134507
-        for reference
+        for reference.
+
+        Parameters
+        ----------
+        gate : :obj:`.Gate`:
+            The quantum gate to be compiled.
+        args : dict
+            The compilation configuration defined in the attributes
+            :obj:`.GateCompiler.args` or given as a parameter in
+            :obj:`.GateCompiler.compile`.
+
+        Returns
+        -------
+        A list of :obj:`.Instruction`, including the compiled pulse
+        information for this gate.
         """
         result = []
         q1 = gate.controls[0]
@@ -78,6 +105,12 @@ class SCQubitsCompiler(GateCompiler):
         sign = np.sign(amplitude) * np.sign(area)
         tlist = tlist / amplitude * area * sign
         coeff = coeff * amplitude * sign
+        from scipy.integrate import simps
+        print(amplitude)
+        print(simps(coeff, tlist))
+        coeff, tlist = self.generate_pulse_shape(
+            args["shape"], args["num_samples"], maximum=zx_coeff, area=area)
+        print(simps(coeff, tlist))
         pulse_info = [("zx" + str(q1) + str(q2), coeff)]
         result += [Instruction(gate, tlist, pulse_info)]
 

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -303,70 +303,7 @@ class GateCompiler(object):
             idling_tlist.append([start_time])
         return np.concatenate(idling_tlist)
 
-    def default_single_qubit_compiler(
-            self, gate, args, param_name=None, op_name=None, scaling=1.):
-        """
-        Default compiler for single qubits gates.
-        It compiles ``"RY"`` ``"RX"`` and ``"RZ"`` gate,
-        assuming that the corresponding
-        operator is named ``"sy"``, ``"sx"``, and ``"sz"``.
-
-        Parameters
-        ----------
-        gate : :obj:`.Gate`:
-            The quantum gate to be compiled.
-        args : dict
-            The compilation configuration defined in the attributes
-            :obj:`.GateCompiler.args` or given as a parameter in
-            :obj:`.GateCompiler.compile`.
-        param_name ：str
-            The name of the coefficient saved in the attribute
-            :obj:`GateCompiler.params`.
-            The corresponding value sets the maximum of the pulse.
-            It should be calculated in the corresponding :class:`.Processor`
-            and passed to the compiler.
-        op_name : str
-            The name of the corresponding operator.
-            It will be one of the keys of the returned dictionary of
-            :obj:`.GateCompiler.compile`.
-            The name should match the label prefix of the control Hamiltonians
-            in :obj:`.Processor`.
-            E.g., if the label is "sx0" for the zeroth qubit,
-            set ``op_name="sx"``.
-        scaling : float
-            Scaling for the ``tlist``.
-            By default, the operator is assumed to be
-            ``2*pi*sigmax()/2`` (or y, z).
-            If operators with other factors are used, e.g., ``2*pi*sigmax()``,
-            choose ``scaling=0.5``.
-            It will be multiplied to the ``tlist`` to ensure that
-            the total area is desired.
-
-        Returns
-        -------
-        A list of :obj:`.Instruction`, including the compiled pulse
-        information for this gate.
-        """
-        targets = gate.targets
-        if gate.name == "RY":
-            pulse_prefix = "sy"
-        elif gate.name == "RX":
-            pulse_prefix = "sx"
-        elif gate.name == "RZ":
-            pulse_prefix = "sz"
-        else:
-            raise ValueError(f"Gate {gate.name} cannot not be compiled.")
-        if param_name is None:
-            param_name = pulse_prefix
-        if op_name is None:
-            op_name = pulse_prefix
-        coeff, tlist = self.generate_pulse_shape(
-            args["shape"], args["num_samples"],
-            maximum=self.params[param_name][targets[0]],
-            area=gate.arg_value / 2. / np.pi)
-        pulse_info = [(op_name + str(targets[0]), coeff)]
-        return [Instruction(gate, tlist * scaling, pulse_info)]
-
+    @classmethod
     def generate_pulse_shape(self, window, num_samples, maximum=1., area=1.):
         """
         Return a tuple consisting of a coeff list and a time sequence

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -46,8 +46,8 @@ class GateCompiler(object):
           one of the `SciPy window functions
           <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_.
         * ``num_samples``:
-          Number of samples in continuous pulse.
-          It has not effect in rectangular pulse.
+          Number of samples for continuous pulses.
+          It has no effect for rectangular pulses.
         * ``params``: Hardware parameters computed in the :obj:`Processor`.
 
     """
@@ -304,7 +304,7 @@ class GateCompiler(object):
         return np.concatenate(idling_tlist)
 
     @classmethod
-    def generate_pulse_shape(self, window, num_samples, maximum=1., area=1.):
+    def generate_pulse_shape(cls, window, num_samples, maximum=1., area=1.):
         """
         Return a tuple consisting of a coeff list and a time sequence
         according to a given window function.
@@ -325,6 +325,7 @@ class GateCompiler(object):
             The absolute value will be used if negative.
         area : float
             The total area if one integrates coeff as a function of the time.
+            If the area is negative, the pulse is flipped vertically (i.e. the pulse is multiplied by the sign of the area).
 
         Returns
         -------
@@ -376,10 +377,11 @@ def _normalized_window(window, num_samples):
     """
     if window == "rectangular":
         return 1., 1.
-    if window not in _default_window_t_max.keys():
-        raise RuntimeError(f"Window function {window} is not supported.")
+    t_max = _default_window_t_max.get(window, None)
+    if t_max is None:
+        raise ValueError(f"Window function {window} is not supported.")
     coeff = signal.windows.get_window(
         window, num_samples
     )
-    tlist = np.linspace(0, _default_window_t_max[window], num_samples)
+    tlist = np.linspace(0, t_max, num_samples)
     return coeff, tlist

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -350,11 +350,6 @@ class GateCompiler(object):
         return coeff, tlist
 
 
-"""
-Normalized scipy window functions.
-The scipy implementation only makes sure that it is maximum is 1.
-Here, we save a default t_max so that the integral is always 1.
-"""
 _default_window_t_max = {
     "boxcar": 1.,
     "triang": 2.,
@@ -374,7 +369,9 @@ _default_window_t_max = {
 
 def _normalized_window(shape, num_samples):
     """
-    Return a normalized window functions.
+    Normalized SciPy window functions.
+    The SciPy implementation only makes sure that it is maximum is 1.
+    Here, we save a default t_max so that the integral is always 1.
     """
     if shape == "rectangular":
         return 1., 1.

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -304,14 +304,14 @@ class GateCompiler(object):
         return np.concatenate(idling_tlist)
 
     @classmethod
-    def generate_pulse_shape(cls, window, num_samples, maximum=1., area=1.):
+    def generate_pulse_shape(cls, shape, num_samples, maximum=1., area=1.):
         """
         Return a tuple consisting of a coeff list and a time sequence
-        according to a given window function.
+        according to a given pulse shape.
 
         Parameters
         ----------
-        window : str
+        shape : str
             The name ``"rectangular"`` for constant pulse or
             the name of a Scipy window function.
             See
@@ -320,10 +320,10 @@ class GateCompiler(object):
             for detail.
         num_samples : int
             The number of the samples of the coefficients.
-        maximum : float
+        maximum : float, optional
             The maximum of the coefficients.
             The absolute value will be used if negative.
-        area : float
+        area : float, optional
             The total area if one integrates coeff as a function of the time.
             If the area is negative, the pulse is flipped vertically
             (i.e. the pulse is multiplied by the sign of the area).
@@ -340,10 +340,10 @@ class GateCompiler(object):
         -----
         If Scipy window functions are used, it is suggested to set
         ``Processor.pulse_mode`` to ``"continuous"``.
-        Also, finite number of samples will also make
+        Notice that finite number of sampling points will also make
         the total integral of the coefficients slightly deviate from ``area``.
         """
-        coeff, tlist = _normalized_window(window, num_samples)
+        coeff, tlist = _normalized_window(shape, num_samples)
         sign = np.sign(area)
         coeff *= np.abs(maximum) * sign
         tlist *= abs(area) / np.abs(maximum)
@@ -372,17 +372,17 @@ _default_window_t_max = {
     }
 
 
-def _normalized_window(window, num_samples):
+def _normalized_window(shape, num_samples):
     """
     Return a normalized window functions.
     """
-    if window == "rectangular":
+    if shape == "rectangular":
         return 1., 1.
-    t_max = _default_window_t_max.get(window, None)
+    t_max = _default_window_t_max.get(shape, None)
     if t_max is None:
-        raise ValueError(f"Window function {window} is not supported.")
+        raise ValueError(f"Window function {shape} is not supported.")
     coeff = signal.windows.get_window(
-        window, num_samples
+        shape, num_samples
     )
     tlist = np.linspace(0, t_max, num_samples)
     return coeff, tlist

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -325,7 +325,8 @@ class GateCompiler(object):
             The absolute value will be used if negative.
         area : float
             The total area if one integrates coeff as a function of the time.
-            If the area is negative, the pulse is flipped vertically (i.e. the pulse is multiplied by the sign of the area).
+            If the area is negative, the pulse is flipped vertically
+            (i.e. the pulse is multiplied by the sign of the area).
 
         Returns
         -------

--- a/src/qutip_qip/compiler/spinchaincompiler.py
+++ b/src/qutip_qip/compiler/spinchaincompiler.py
@@ -109,17 +109,11 @@ class SpinChainCompiler(GateCompiler):
         pulse_info = [("sx" + str(targets[0]), coeff)]
         return [Instruction(gate, tlist, pulse_info)]
 
-    def _two_qubit_compiler(self, gate_name, gate, args):
+    def _swap_compiler(self, gate, area, args):
         targets = gate.targets
         q1, q2 = min(targets), max(targets)
         g = self.params["sxsy"][q1]
         maximum = g
-        if gate_name == "ISWAP":
-            area = -1 / 8
-        elif gate_name == "SQRTISWAP":
-            area = -1 / 16
-        else:
-            raise ValueError(f"Gate {gate.name} cannot not be compiled.")
         coeff, tlist = self.generate_pulse_shape(
             args["shape"], args["num_samples"], maximum, area)
         if self.N != 2 and q1 == 0 and q2 == self.N - 1:
@@ -147,7 +141,7 @@ class SpinChainCompiler(GateCompiler):
         A list of :obj:`.Instruction`, including the compiled pulse
         information for this gate.
         """
-        return self._two_qubit_compiler("ISWAP", gate, args)
+        return self._swap_compiler(gate, area=-1/8, args=args)
 
     def sqrtiswap_compiler(self, gate, args):
         """
@@ -167,7 +161,7 @@ class SpinChainCompiler(GateCompiler):
         A list of :obj:`.Instruction`, including the compiled pulse
         information for this gate.
         """
-        return self._two_qubit_compiler("SQRTISWAP", gate, args)
+        return self._swap_compiler(gate, area=-1/16, args=args)
 
     def globalphase_compiler(self, gate, args):
         """

--- a/src/qutip_qip/compiler/spinchaincompiler.py
+++ b/src/qutip_qip/compiler/spinchaincompiler.py
@@ -87,7 +87,7 @@ class SpinChainCompiler(GateCompiler):
 
     def _rotation_compiler(self, gate, op_label, param_label, args):
         """
-        Single qubit gate compiler.
+        Single qubit rotation compiler.
 
         Parameters
         ----------

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -157,7 +157,6 @@ class DispersiveCavityQED(ModelProcessor):
         if any((w0 - self.wq)/(w0 + self.wq) > 0.05):
             warnings.warn(
                 "The rotating-wave approximation might not be valid.")
-        print(self.params)
 
     @property
     def sx_ops(self):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -154,9 +154,10 @@ def test_compiler_result_format():
     assert_array_equal(processor.pulses[0].tlist, tlist[0])
 
 
-@pytest.mark.parametrize("shape", _default_window_t_max.keys())
-def test_pulse_shape(shape):
-    """Test different pulse shape functions"""
+@pytest.mark.parametrize(
+    "shape", list(_default_window_t_max.keys()) + ["rectangular"])
+def test_pulse_shape_scipy(shape):
+    """Test different pulse shape functions imported from scipy"""
     num_qubits = 1
     circuit = QubitCircuit(num_qubits)
     circuit.add_gate("X", 0)
@@ -164,7 +165,10 @@ def test_pulse_shape(shape):
     compiler = SpinChainCompiler(num_qubits, processor.params)
     compiler.args.update({"shape": shape, "num_samples": 100})
     processor.load_circuit(circuit, compiler=compiler)
-    processor.pulse_mode = "continuous"
+    if shape == "rectangular":
+        processor.pulse_mode = "discrete"
+    else:
+        processor.pulse_mode = "continuous"
     init_state = basis(2, 0)
     num_result = processor.run_state(init_state).states[-1]
     ideal_result = circuit.run(init_state)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
+from qutip_qip.compiler.gatecompiler import _default_window_t_max
 
 from qutip_qip.device import (
     DispersiveCavityQED, CircularSpinChain, LinearSpinChain)
@@ -151,3 +152,21 @@ def test_compiler_result_format():
     processor.set_all_tlist(tlist)
     assert_array_equal(processor.pulses[0].coeff, coeffs[0])
     assert_array_equal(processor.pulses[0].tlist, tlist[0])
+
+
+@pytest.mark.parametrize("shape", _default_window_t_max.keys())
+def test_pulse_shape(shape):
+    """Test different pulse shape functions"""
+    num_qubits = 1
+    circuit = QubitCircuit(num_qubits)
+    circuit.add_gate("X", 0)
+    processor = LinearSpinChain(num_qubits)
+    compiler = SpinChainCompiler(num_qubits, processor.params)
+    compiler.args.update({"shape": shape, "num_samples": 100})
+    processor.load_circuit(circuit, compiler=compiler)
+    processor.pulse_mode = "continuous"
+    init_state = basis(2, 0)
+    num_result = processor.run_state(init_state).states[-1]
+    ideal_result = circuit.run(init_state)
+    ifid = 1 - fidelity(num_result, ideal_result)
+    assert(pytest.approx(ifid, abs=0.01) == 0)


### PR DESCRIPTION
- Different pulse shapes are generated using window function from scipy.signal.windows.
- A generate_pulse_shape method is defined and can be used to generate pulse shape with the arbitrary area and required maximum.
- A default single qubit compiler is defined and simplifies the various compiler subclasses.