### PR TITLE
Adds gray code ordering method

### DIFF
--- a/src/qutip_qip/decompose/__init__.py
+++ b/src/qutip_qip/decompose/__init__.py
@@ -1,1 +1,2 @@
 from .decompose_single_qubit_gate import *
+from .decompose_general_qubit_gate import *

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -136,26 +136,20 @@ def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
     gray_code_sequence = _gray_code_sequence(num_qubits)
     state_1_gray_code_index = gray_code_sequence.index(state_1_binary)
     state_2_gray_code_index = gray_code_sequence.index(state_2_binary)
-    num_steps_gray_code = state_2_gray_code_index - state_1_gray_code_index
+    num_steps_gray_code = np.abs(
+        state_2_gray_code_index - state_1_gray_code_index)
 
     # create a smaller gray code sequence between the two states of interest
-    gray_code = _gray_code_sequence(num_qubits)[
-        state_1_gray_code_index:state_2_gray_code_index+1]
+    if state_1_gray_code_index < state_2_gray_code_index:
+        gray_code = _gray_code_sequence(num_qubits)[
+            state_1_gray_code_index:state_2_gray_code_index+1]
+    else:  # check math for reversed order
+        # what is the difference between using gates from left to right vs
+        # right to left - with current code, the order is mixed.
+        gray_code = _gray_code_sequence(num_qubits)[
+            state_2_gray_code_index:state_1_gray_code_index+1]
+
     return(gray_code, num_steps_gray_code)
-
-
-def gray_code_plot(index_of_state_1, index_of_state_2, num_qubits):
-    """ Plots the difference between each step of a gray code sequence.
-
-    Parameters
-    -----------
-    index_of_state_i: int
-        The non-trivial indices in a two-level unitary matrix gate.
-
-    num_qubits:
-        Number of qubits being acted upon by the quantum gate.
-    """
-    # This function is still incomplete.
 
 
 def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
@@ -181,7 +175,7 @@ def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
     for i in range(num_steps+1):
         bit_array_at_i = []
         a = gray_code[i]
-        for j in range(3):
+        for j in range(num_qubits):
             bit_array_at_i.append(a[j])
 
         input_binary_values[i] = bit_array_at_i
@@ -195,7 +189,7 @@ def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
         control_value = []
         target = []
         all_together = {}
-        for j in range(3):
+        for j in range(num_qubits):
             if a[j] == b[j]:
                 controls.append(j)
                 control_value.append(a[j])

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -139,6 +139,10 @@ def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
     num_steps_gray_code = np.abs(
         state_2_gray_code_index - state_1_gray_code_index)
 
+    if num_steps_gray_code == 1:
+        num_steps_gray_code = num_steps_gray_code
+    else:  # repeat the mapping back to initial index
+        num_steps_gray_code = 2*num_steps_gray_code - 1
     # create a smaller gray code sequence between the two states of interest
     if state_1_gray_code_index < state_2_gray_code_index:
         gray_code = _gray_code_sequence(num_qubits)[
@@ -161,12 +165,13 @@ def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
     gray_code = gray_code_info[0]
     num_steps = gray_code_info[1]
 
-    # find number of ones in each gray code step, this will be used
-    # to keep track of control values.
-    # one_bit_count = []
-    # for i in range(num_steps+1):
-    #    check_bit = gray_code[i].count("1")
-    #    one_bit_count.append(check_bit)
+    # repeat the mapping from last index to first initial index
+    if num_steps == 1:
+        gray_code = gray_code
+    else:  # skip last index
+        for i in reversed(range(len(gray_code)-1)):
+            gray_code_repeat = gray_code[i]
+            gray_code.append(gray_code_repeat)
 
     # make a dictionary of an array of binary values
     # find position of 1's

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -1,5 +1,6 @@
 from qutip import Qobj
-
+import matplotlib.pyplot as plot
+import numpy as np
 
 class MethodError(Exception):
     """When invalid method is chosen, this error is raised."""
@@ -29,3 +30,166 @@ def check_gate(gate, num_qubits):
         raise ValueError("Input is not unitary.")
     if gate.dims != [[2] * num_qubits] * 2:
         raise ValueError(f"Input is not a unitary on {num_qubits} qubits.")
+
+
+def _binary_sequence(num_qubits):
+    """ Defines the binary sequence list for basis vectors of a n-qubit gate.
+
+    The string at index `i` is also the row/column index for a basis vector in
+    a numpy array.
+    """
+    old_sequence = ['0', '1']
+    full_binary_sequence = []
+
+    if num_qubits == 1:
+        full_binary_sequence = old_sequence
+    else:
+        for x in range(num_qubits-1):
+            full_binary_sequence = []
+            zero_append_sequence = ['0' + x for x in old_sequence]
+            full_binary_sequence.extend(zero_append_sequence)
+            one_append_sequence = ['1' + x for x in old_sequence]
+            full_binary_sequence.extend(one_append_sequence)
+            old_sequence = full_binary_sequence
+
+    return(full_binary_sequence)
+
+
+def _gray_code_sequence(num_qubits, output_form=None):
+    """ Finds the sequence of gray codes for basis vectors by using logical
+    XOR operator of Python.
+
+    For print( _gray_code_sequence(2)), the output is [0, 1, 3, 2] i.e. in
+    terms of the binary sequence, the output is ['00', '01', '11', '10'].
+
+    https://docs.python.org/3/library/operator.html#operator.xor'
+
+    Parameters
+    ----------
+    num_qubits
+        Number of qubits in the circuit
+
+    output_form : :"index_values" or None
+        The format of output list. If a string "index_values" is provided then
+    the function's output is in terms of array indices of the binary sequence.
+    The default is a list of binary strings.
+
+    Returns
+    --------
+    list
+        List of the gray code sequence in terms of array indices or binary
+        sequence positions.
+    """
+    gray_code_sequence_as_array_indices = []
+
+    for x in range(2**num_qubits):
+        gray_code_at_x = x ^ x // 2  # floor operator to shift bits by 1
+        # when the shift is done, the new spot is filled with a new value.
+        gray_code_sequence_as_array_indices.append(gray_code_at_x)
+        if output_form == "index_values":
+            output = gray_code_sequence_as_array_indices
+        else:
+            gray_code_as_binary = []
+            binary_sequence_list = _binary_sequence(num_qubits)
+            for i in gray_code_sequence_as_array_indices:
+                gray_code_as_binary.append(binary_sequence_list[i])
+            output = gray_code_as_binary
+    return(output)
+
+
+def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
+    """ Finds the sequence mapping from state 1 to state 2.
+
+    State 1 and 2 define the basis vectors of non-trivial values in a two-level
+    unitary matrix. Here, the inputs are their respective indices in a quantum
+    gate's array.
+
+    This function finds the number of steps between both states when only 1 bit
+    can be changed at each step.
+    """
+    # check array values are not the same
+    try:
+        assert (index_of_state_1 != index_of_state_2)
+    except AssertionError:
+        raise IndexError("Both indices need to be different.")
+
+    # array index for original binary sequence
+    indices_of_array = []
+    for i in range(2**num_qubits):
+        indices_of_array.append(i)
+
+    # Check both indices could be indices for num_qubits array
+    try:
+        assert all(x in indices_of_array for x in [
+                index_of_state_1, index_of_state_2])
+    except AssertionError:
+        raise IndexError(
+            "At least one of the input indices is invalid.")
+
+    # get the basis vector strings
+    binary_sequence_list = _binary_sequence(num_qubits)
+    state_1_binary = binary_sequence_list[index_of_state_1]
+    state_2_binary = binary_sequence_list[index_of_state_2]
+
+    # compare binary sequence positions to gray code sequence
+    # finds number of steps neeeded to go from one state to another
+    gray_code_sequence = _gray_code_sequence(num_qubits)
+    state_1_gray_code_index = gray_code_sequence.index(state_1_binary)
+    state_2_gray_code_index = gray_code_sequence.index(state_2_binary)
+    num_steps_gray_code = state_2_gray_code_index - state_1_gray_code_index
+
+    # create a smaller gray code sequence between the two states of interest
+    gray_code = _gray_code_sequence(num_qubits)[
+        state_1_gray_code_index:state_2_gray_code_index+1]
+    return(gray_code, num_steps_gray_code)
+
+
+def gray_code_plot(index_of_state_1, index_of_state_2, num_qubits):
+    """ Plots the difference between each step of a gray code sequence.
+
+    Parameters
+    -----------
+    index_of_state_i: int
+        The non-trivial indices in a two-level unitary matrix gate.
+
+    num_qubits:
+        Number of qubits being acted upon by the quantum gate.
+    """
+    # This function is still incomplete.
+
+
+def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
+    """ Finds information about control and targets for CNOT gate in a gray
+    code sequence.
+    """
+    gray_code_info = _gray_code_steps(
+        index_of_state_1, index_of_state_2, num_qubits)
+    gray_code = gray_code_info[0]
+    num_steps = gray_code_info[1]
+
+    # find number of ones in each gray code step, this will be used
+    # to keep track of control values.
+    one_bit_count = []
+    for i in range(num_steps+1):
+        check_bit = gray_code[i].count("1")
+        one_bit_count.append(check_bit)
+
+    gate_dictionary = {}
+    for i in range(num_steps):
+        a = gray_code[i]
+        b = gray_code[i+1]
+        for j in range(num_qubits):
+            gate_controls = []
+            gate_target = []
+            gate_control_value = []
+            while a[j] == b[j]:
+                partial_gate_control = j
+                gate_controls.append(partial_gate_control)
+                gate_control_value.append(a[j])
+            else:
+                partial_gate_target = j
+                gate_target.append(partial_gate_target)
+
+        gate_dictionary[i] = [gate_controls, gate_control_value, gate_target]
+
+    return(gate_dictionary)

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -169,27 +169,41 @@ def gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
 
     # find number of ones in each gray code step, this will be used
     # to keep track of control values.
-    one_bit_count = []
+    # one_bit_count = []
+    # for i in range(num_steps+1):
+    #    check_bit = gray_code[i].count("1")
+    #    one_bit_count.append(check_bit)
+
+    # make a dictionary of an array of binary values
+    # find position of 1's
+    input_binary_values = {}
+
     for i in range(num_steps+1):
-        check_bit = gray_code[i].count("1")
-        one_bit_count.append(check_bit)
-
-    gate_dictionary = {}
-    for i in range(num_steps):
+        bit_array_at_i = []
         a = gray_code[i]
-        b = gray_code[i+1]
-        for j in range(num_qubits):
-            gate_controls = []
-            gate_target = []
-            gate_control_value = []
-            while a[j] == b[j]:
-                partial_gate_control = j
-                gate_controls.append(partial_gate_control)
-                gate_control_value.append(a[j])
+        for j in range(3):
+            bit_array_at_i.append(a[j])
+
+        input_binary_values[i] = bit_array_at_i
+
+    # compare the array values
+    step_iteration_dictionary = {}
+    for i in range(num_steps):
+        a = input_binary_values[i]
+        b = input_binary_values[i+1]
+        controls = []
+        control_value = []
+        target = []
+        all_together = {}
+        for j in range(3):
+            if a[j] == b[j]:
+                controls.append(j)
+                control_value.append(a[j])
             else:
-                partial_gate_target = j
-                gate_target.append(partial_gate_target)
+                target.append(j)
+            all_together['controls ='] = controls
+            all_together['control_value ='] = control_value
+            all_together['targets ='] = target
+        step_iteration_dictionary[i] = all_together
 
-        gate_dictionary[i] = [gate_controls, gate_control_value, gate_target]
-
-    return(gate_dictionary)
+    return(step_iteration_dictionary)

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -4,9 +4,9 @@ import cmath
 from qutip import Qobj
 from qutip_qip.decompose._utility import (
     check_gate,
-    MethodError,
+    MethodError, _gray_code_steps, gray_code_gate_info
 )
-
+import matplotlib.pyplot as plt
 import warnings
 from qutip_qip.circuit import Gate
 from qutip_qip.operations import controlled_gate
@@ -17,8 +17,91 @@ from .decompose_single_qubit_gate import decompose_one_qubit_gate
 warnings.filterwarnings("ignore", category=UserWarning)
 
 
-def _decompose_to_two_level_arrays(input_gate, num_qubits):
+def plot_gray_code_grid(index_of_state_1, index_of_state_2, num_qubits):
+    """ Plots the difference between each step of a gray code sequence.
+
+    .. note::
+
+        If you would prefer to plot the full gray code sequence, specify the
+        first and last indices of full sequence. For a n qubit state, the
+        indices of interest will be 0 and :math:`n^2-1` respectively.
+
+    In order to create a plot for a 5 qubit two-level unitary with nontrivial
+    values 00101 and 10001,
+
+    .. code-block:: python
+
+        plot_gray_code_grid(5,17,5)
+        plt.show()
+
+    Parameters
+    -----------
+    index_of_state_i: int
+        The non-trivial indices in a two-level unitary matrix gate.
+
+    num_qubits:
+        Number of qubits being acted upon by the quantum gate.
+
+    Returns
+    -------
+    matplotlib.image.AxesImage
+        The preferred plot for mapping from one binary state to another in a
+    gray code sequence.
+    """
+    # create a gray code sequence
+    gray_code_and_num_steps = _gray_code_steps(
+        index_of_state_1, index_of_state_2, num_qubits)
+    gray_code_sequence = gray_code_and_num_steps[0]
+    num_steps = gray_code_and_num_steps[-1]
+
+    # create a dictionary for creating an array later
+    input_binary_values = {}
+    for i in range(num_steps+1):
+        bit_array_at_i = []
+        a = gray_code_sequence[i]
+        for j in range(num_qubits):
+            bit_array_at_i.append(int(a[j]))
+            input_binary_values[i] = bit_array_at_i
+
+    # array is created for imshow
+    input_binary_array = np.full([num_steps+1, num_qubits], None, dtype=float)
+    for i in range(num_steps+1):
+        input_binary_array[i] = np.array([input_binary_values[i]])
+
+    # size_for_plot = 2*num_qubits  # figsize=(size_for_plot, size_for_plot)
+    # figsize could be used to adjust the length of plot based on the size
+    # of input
+
+    # information for plot
+    fig, ax = plt.subplots(1)
+    y_axis = list(range(len(gray_code_sequence)))
+    x_axis = list(range(num_qubits))
+    ax.set_xticks(x_axis)
+    ax.set_yticks(y_axis)
+    ax.set_yticklabels(list(reversed(gray_code_sequence)))
+    plt.xlabel("Number of Qubits")
+    plt.ylabel("Binary")
+    plt.title('Zero Code Sequence')
+    im = ax.imshow(
+        input_binary_array, cmap='binary', extent=[
+            x_axis[0], x_axis[-1], y_axis[0], y_axis[-1]], aspect='auto')
+
+    return(im)
+
+
+def _decompose_to_two_level_arrays(input_gate, num_qubits, expand=True):
     """Decompose a general qubit gate to two-level arrays.
+
+    Parameters
+    -----------
+    input_gate : :class:`qutip.Qobj`
+        The gate matrix to be decomposed.
+    num_qubits : int
+        Number of qubits being acted upon by the input_gate
+    expand : True
+        Default parameter to return the output as full two-level Qobj. If
+    `expand = False` then the function returns a tuple of index information
+    and a 2 x 2 Qobj for each gate. The Qobj are returned in reversed order.
     """
     check_gate(input_gate, num_qubits)
     input_array = input_gate.full()
@@ -31,7 +114,6 @@ def _decompose_to_two_level_arrays(input_gate, num_qubits):
             new_index = [i, j]
             index_list.append(new_index)
 
-    # index_list = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3]]
     for i in range(len(index_list)-1):
         index_1, index_2 = index_list[i]
 
@@ -40,10 +122,11 @@ def _decompose_to_two_level_arrays(input_gate, num_qubits):
         a_star = np.conj(a)
         b = input_array[index_2][index_1]
         b_star = np.conj(b)
-        norm_constant = cmath.sqrt(np.absolute(a*a_star)+np.absolute(b*b_star))
+        norm_constant = cmath.sqrt(
+            np.absolute(a*a_star)+np.absolute(b*b_star))
 
-        # Create identity array and then replace with above values for index_1
-        # and index_2
+        # Create identity array and then replace with above values for
+        # index_1 and index_2
         U_two_level = np.identity(2**num_qubits, dtype=complex)
         U_two_level[index_1][index_1] = a_star/norm_constant
         U_two_level[index_2][index_1] = b/norm_constant
@@ -55,10 +138,68 @@ def _decompose_to_two_level_arrays(input_gate, num_qubits):
 
         # U dagger to calculate the gates
         U__two_level_dagger = np.transpose(np.conjugate(U_two_level))
-        U__two_level_dagger = Qobj(U__two_level_dagger, dims=[[2] * num_qubits] * 2)
         array_list.append(U__two_level_dagger)
 
     # for U6 - multiply input array by U5 and take dagger
     U_last_dagger = input_array
-    array_list.append(Qobj(U_last_dagger, dims=[[2] * num_qubits] * 2))
-    return(array_list)
+    array_list.append(U_last_dagger)
+
+    if expand is True:
+        array_list_with_qobj = []
+        for i in reversed(range(len(index_list))):
+            U_two_level_array = array_list[i]
+            array_list_with_qobj.append(Qobj(
+                U_two_level_array, dims=[[2] * num_qubits] * 2))
+        return(array_list_with_qobj)
+    else:
+        compact_U_information = []
+        for i in reversed(range(len(index_list))):
+            U_non_trivial = np.full([2, 2], None, dtype=complex)
+            index_info = []
+            U_index_together = []
+
+            # create index list
+            index_1, index_2 = index_list[i]
+            index_info = [index_1, index_2]
+            U_index_together.append(index_info)
+
+            # create 2 x 2 arrays
+            U_two_level = array_list[i]
+            U_non_trivial[0][0] = U_two_level[index_1][index_1]
+            U_non_trivial[1][0] = U_two_level[index_2][index_1]
+            U_non_trivial[0][1] = U_two_level[index_1][index_2]
+            U_non_trivial[1][1] = U_two_level[index_2][index_2]
+            U_index_together.append(
+                Qobj(U_non_trivial, dims=[[2] * 1] * 2))
+
+            compact_U_information.append(U_index_together)
+
+        return(compact_U_information)
+
+
+def _two_level_gate_info(input_gate, num_qubits):
+    """ From the output of two level arrays, create a tuple of controlled gate
+    information.
+    """
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=False)
+
+    full_index_list = []
+    for i in range(len(array_decompose)):
+        index_list = array_decompose[i][0]
+        full_index_list.append(index_list)
+
+    gate_keys = []
+    for i in reversed(range(len(array_decompose))):
+        gate_string = 'gate'
+        gate_string = gate_string + str(i)
+        gate_keys.append(gate_string)
+
+    gate_dictionary = {}
+    for i in range(len(array_decompose)):
+        index_1, index_2 = full_index_list[i]
+        gate_i_info = gray_code_gate_info(index_1, index_2, num_qubits)
+        gate_key = gate_keys[i]
+        gate_dictionary[gate_key] = gate_i_info
+
+    return(gate_dictionary)

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -203,13 +203,24 @@ def _two_level_gate_info(input_gate, num_qubits):
         gate_key = gate_keys[i]
         gate_dictionary[gate_key] = gate_i_info
 
+    # this function output is not what's expected because the output of
+    # gray_code_gate_info is not what's expected.
+    # for this reason, there's no test designed for it, once the error in
+    # gray_code_gate_info is corrected, a test will be added
     return(gate_dictionary)
 
 
 def _sqrt_of_1_qubit_array(input_array):
     """ Finds the square root of a 1 qubit gate for decomposing a multi-qubit
     array into smaller controlled CNOT and 2-qubit two-level unitary.
+
+    # based on Lemma 7.5 of https://arxiv.org/abs/quant-ph/9503016
     """
+    # final lemma 7.5 function is not defined - will be dfined if needed
+
+    # This method is for when 1 qubit is not special unitary but the single
+    # qubit decomposition functions defined already make a non-special unitary
+    # output into a su(2) by the determinant.
     check_gate(Qobj(input_array, dims=[[2] * 1] * 2), 1)
     # method taken
     # from https://en.wikipedia.org/wiki/Square_root_of_a_2_by_2_matrix
@@ -222,3 +233,234 @@ def _sqrt_of_1_qubit_array(input_array):
     sqrt_U = np.multiply(1/t, np.array([[U_array[0][0]+s, U_array[0][1]],
                                         [U_array[1][0], U_array[1][1]+s]]))
     return(sqrt_U)
+
+
+def _lemma_6_1(input_array):
+    """ Decompose a 3 qubit multi-controlled array.
+    https://arxiv.org/abs/quant-ph/9503016
+    """
+    # add condition to check if input is target for last qubit and rest are
+    # controls - easier with a subclass instance
+    U = input_array
+    check_gate(Qobj(U), num_qubits=1)
+    V = _sqrt_of_1_qubit_array(U)
+    V_dagger = np.transpose(np.conjugate(V))
+    V1_gate = controlled_gate(
+        V, controls=[1], target=2, control_value=[1])
+    V_dagger_gate = controlled_gate(
+        V_dagger, controls=[1], target=2, control_value=[1])
+    V2_gate = controlled_gate(
+            V, controls=[0], target=2, control_value=[1])
+    CNOT_ctrl_0 = Gate("CNOT", controls=0, targets=1)
+    return(
+        V1_gate,
+        CNOT_ctrl_0,
+        V_dagger_gate,
+        CNOT_ctrl_0,
+        V2_gate
+        )
+
+
+def _lemma_6_1_for_4_qubit(input_array):
+    """ Method shown on page 17 of https://arxiv.org/abs/quant-ph/9503016
+    """
+    # generalize both 6.1 functions to when num_qubits < 5
+
+    # add condition to check if input is target for last qubit and rest are
+    # controls  - easier with a subclass instance
+    U = input_array
+    check_gate(Qobj(U), num_qubits=1)
+    V = _sqrt_of_1_qubit_array(U)
+    # reuse V to get square root of V because V**4 = U
+    V = _sqrt_of_1_qubit_array(V)
+    V_dagger = np.transpose(np.conjugate(V))
+    V1Gate = controlled_gate(
+        V, controls=[0], target=[3], control_value=[1])
+    V2Gate = controlled_gate(
+        V_dagger, controls=[1], target=[3], control_value=[1])
+    V3Gate = controlled_gate(
+        V, controls=[1], target=[3], control_value=[1])
+    V4Gate = controlled_gate(
+        V_dagger, controls=[2], target=[3], control_value=[1])
+    V5Gate = controlled_gate(
+        V, controls=[2], target=[3], control_value=[1])
+    CNOT1 = Gate("CNOT", controls=0, targets=1)
+    CNOT2 = Gate("CNOT", controls=1, targets=2)
+    CNOT3 = Gate("CNOT", controls=0, targets=2)
+    return(
+        V1Gate,
+        CNOT1,
+        V2Gate,
+        CNOT1,
+        V3Gate,
+        CNOT2,
+        V4Gate,
+        CNOT3,
+        V5Gate,
+        CNOT2,
+        V4Gate,
+        CNOT3,
+        V5Gate
+        )
+
+
+def _lemma_5_1(input_array):
+    """ Decompose 2-qubit controlled unitary.
+    https://arxiv.org/abs/quant-ph/9503016
+    """
+    # add condition to check if input is target for last qubit and rest are
+    # controls  - easier with a subclass instance
+    U = input_array
+    check_gate(Qobj(U), num_qubits=1)
+    gate_list = decompose_one_qubit_gate(Qobj(U), "ZYZ_PauliX")
+
+    # Change the gate targets for ABC and X gates from default = 0
+    # First 2 indices are for A, next 2 are for B and last is for C
+    # Note that we have avoided changing the Pauli X indices because it is
+    # easier to define a gate with the target qubit.
+    target_indices_to_change = [0, 1, 3, 4, 6]
+    for i in target_indices_to_change:
+        gate_list[i].targets = [1]
+
+    # last is phase whose target is not changed based on Lemma 5.2 of
+    # arXiv:quant-ph/9503016v1 but the gate type is changed
+    phase_angle = gate_list[-1].arg_value
+    phase_gate = Gate(
+        "PHASEGATE",
+        targets=[0],
+        arg_value=phase_angle,
+        arg_label=r"{:0.2f} \times \pi".format(phase_angle / np.pi),
+    )
+    Pauli_X = Gate("X", targets=[1], classical_controls=[0])
+
+    CNOT_ctrl_0 = Gate("CNOT", controls=0, targets=1)
+    return (
+        gate_list[0],
+        gate_list[1],
+        Pauli_X,
+        CNOT_ctrl_0,
+        Pauli_X,
+        gate_list[3],
+        gate_list[4],
+        Pauli_X,
+        CNOT_ctrl_0,
+        Pauli_X,  # to do : add a condition to check for control value before
+        # adding Pauli_X
+        gate_list[6],
+        phase_gate,
+    )
+
+
+def _control_0_to_pauli_x(input_gate, num_qubits):
+    """ If the control value is 0 for qubit_i, this function returns info about
+    the indices where pauli X gate should be added.
+    """
+    two_level_gate_info = _two_level_gate_info(input_gate, num_qubits)
+    pauli_x_info = {}
+    for i in range(len(two_level_gate_info)):
+        control_value_list = two_level_gate_info[i]["control_value ="]
+        for j in range(len(control_value_list)):
+            if control_value_list[j] == 0:
+                pauli_x_partial_info = {}
+                gate_indices = [j-1, j]
+                pauli_x_partial_info[j] = gate_indices
+
+            pauli_x_info[i] = pauli_x_partial_info
+
+    return(pauli_x_info)
+
+
+def _multi_cnot_to_two_diff_cnot(input_array, num_qubits):
+    """ Decomposes a multicontrolled cnot into a circuit described by multiple
+    cnots of smaller controls.
+
+    # based on lemma 7.3 of https://arxiv.org/abs/quant-ph/9503016
+    """
+    # add condition to check if input is target for last qubit and rest are
+    # controls - easier with a subclass instance
+
+    # the gate is not a control on num_qubits-1 qubit
+    assert num_qubits >= 5
+    cnot_gate_info = {}
+    num_qubits_list = list(range(num_qubits))
+
+    m = list(range(2, num_qubits-3))
+
+    # m target gates
+
+    # num_qubits-m-1 target gates
+
+
+
+
+
+
+def _decompose_multi_cnot_further():
+    """ Decomposes output of lemma 7.3 even further by using only 1 particular
+    cnot with different controls.
+
+    # based on lemma 7.2 of https://arxiv.org/abs/quant-ph/9503016
+    """
+
+
+# Added both 7.9 and 7.11 because not sure which one leads to the least number
+# of gates.
+def _decompose_lemma7_9():
+    """ Decomposes a multi-qubit controlled 2x 2 special unitary into a
+    decomposition described by CNOT and ABC decomposition gates.
+
+
+    # based on Lemma 7.9 of https://arxiv.org/abs/quant-ph/9503016
+    """
+
+
+
+
+def decompose_general_qubit_gate(input_gate, num_qubits, method):
+    """ Decomposes a general qubit gate into description of CNOT and single
+    qubit gates.
+    """
+    check_gate(input_gate, num_qubits)
+    if method is None:
+        if num_qubits == 1:
+            decompose_one_qubit_gate(input_gate, "ZYZ_PauliX")
+    else:
+        raise MethodError("Choose the decomposition method for num_qubits > 1")
+    if method == "two_level":
+        two_level_gate_info = _two_level_gate_info(input_gate, num_qubits)
+        # make function return two level gates when a gate object has been
+        # created - cannot return two-level gate objects at the moment
+
+    else:
+        # the code below for num_qubits = 2,3,4 is repitive for now until it's
+        # checked that the only difference between the threee methods is just
+        # the lemma fn for decomposition
+
+        # once that's verified, a dictionary can be defined with keys for their
+        # respective mthods.
+        if num_qubits == 2:
+            final_gate_dictionary = {}
+            two_level_compact_info = _decompose_to_two_level_arrays(
+                input_gate, 2, expand=False)
+            for i in range(len(two_level_compact_info)):
+                input_array = two_level_compact_info[i][1]
+                two_level_gate_info = _two_level_gate_info(
+                    input_gate, num_qubits)
+                total_num_gates = len(two_level_gate_info)
+                for j in range(total_num_gates):
+                    if len(total_num_gates) == 1:
+                        gate_i_info = _lemma_5_1(input_array)
+                        final_gate_dictionary[j] = gate_i_info
+            # to do : change targets and controls based on two_level_gate_info
+                    else:
+                        # find position of known decomposition
+                        # rest are cnot
+                        n = int((len(total_num_gates)+1)/2)
+                        # output of _two_level_gate_info is incorrect
+                    # this portion is skipped until that output is corrected
+
+        # num_qubits =3, 4 are also expected to have a similar structure as
+        # num_qubits =2
+
+        else:
+        # for the method when number of qubits is gretaer than or equal to 5

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -17,6 +17,7 @@ from .decompose_single_qubit_gate import decompose_one_qubit_gate
 warnings.filterwarnings("ignore", category=UserWarning)
 
 
+# Functions for gray code decomposition
 def plot_gray_code_grid(index_of_state_1, index_of_state_2, num_qubits):
     """ Plots the difference between each step of a gray code sequence.
 
@@ -203,3 +204,21 @@ def _two_level_gate_info(input_gate, num_qubits):
         gate_dictionary[gate_key] = gate_i_info
 
     return(gate_dictionary)
+
+
+def _sqrt_of_1_qubit_array(input_array):
+    """ Finds the square root of a 1 qubit gate for decomposing a multi-qubit
+    array into smaller controlled CNOT and 2-qubit two-level unitary.
+    """
+    check_gate(Qobj(input_array, dims=[[2] * 1] * 2), 1)
+    # method taken
+    # from https://en.wikipedia.org/wiki/Square_root_of_a_2_by_2_matrix
+
+    U_array = input_array
+    tau = U_array[0][0] + U_array[1][1]
+    delta = np.linalg.det(U_array)
+    s = cmath.sqrt(delta)
+    t = cmath.sqrt(tau + 2*s)
+    sqrt_U = np.multiply(1/t, np.array([[U_array[0][0]+s, U_array[0][1]],
+                                        [U_array[1][0], U_array[1][1]+s]]))
+    return(sqrt_U)

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -1,0 +1,64 @@
+import numpy as np
+import cmath
+
+from qutip import Qobj
+from qutip_qip.decompose._utility import (
+    check_gate,
+    MethodError,
+)
+
+import warnings
+from qutip_qip.circuit import Gate
+from qutip_qip.operations import controlled_gate
+
+from .decompose_single_qubit_gate import decompose_one_qubit_gate
+
+# for unknown labels in two level gates
+warnings.filterwarnings("ignore", category=UserWarning)
+
+
+def _decompose_to_two_level_arrays(input_gate, num_qubits):
+    """Decompose a general qubit gate to two-level arrays.
+    """
+    check_gate(input_gate, num_qubits)
+    input_array = input_gate.full()
+
+    # Calculate the two level numpy arrays
+    array_list = []
+    index_list = []
+    for i in range(2**num_qubits):
+        for j in range(i+1, 2**num_qubits):
+            new_index = [i, j]
+            index_list.append(new_index)
+
+    # index_list = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3]]
+    for i in range(len(index_list)-1):
+        index_1, index_2 = index_list[i]
+
+        # Values of single qubit U forming the two level unitary
+        a = input_array[index_1][index_1]
+        a_star = np.conj(a)
+        b = input_array[index_2][index_1]
+        b_star = np.conj(b)
+        norm_constant = cmath.sqrt(np.absolute(a*a_star)+np.absolute(b*b_star))
+
+        # Create identity array and then replace with above values for index_1
+        # and index_2
+        U_two_level = np.identity(2**num_qubits, dtype=complex)
+        U_two_level[index_1][index_1] = a_star/norm_constant
+        U_two_level[index_2][index_1] = b/norm_constant
+        U_two_level[index_1][index_2] = b_star/norm_constant
+        U_two_level[index_2][index_2] = -a/norm_constant
+
+        # Change input by multiplying by above two-level
+        input_array = np.dot(U_two_level, input_array)
+
+        # U dagger to calculate the gates
+        U__two_level_dagger = np.transpose(np.conjugate(U_two_level))
+        U__two_level_dagger = Qobj(U__two_level_dagger, dims=[[2] * num_qubits] * 2)
+        array_list.append(U__two_level_dagger)
+
+    # for U6 - multiply input array by U5 and take dagger
+    U_last_dagger = input_array
+    array_list.append(Qobj(U_last_dagger, dims=[[2] * num_qubits] * 2))
+    return(array_list)

--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -227,6 +227,12 @@ class TwoLevelGate(Gate):
     """ Defines a class for two-level unitary. This gate has 4 non-trivial
     indices and the rest are identical to an identity matrix.
     """
+    def __init__(self, name, num_qubits, targets, controls, control_value):
+        self.name = name
+        self.num_qubits = num_qubits
+        self.targets = targets
+        self.controls = controls
+        self.control_value = control_value
 
 
 

--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -223,6 +223,14 @@ class Gate:
                                                self.arg_value))
 
 
+class TwoLevelGate(Gate):
+    """ Defines a class for two-level unitary. This gate has 4 non-trivial
+    indices and the rest are identical to an identity matrix.
+    """
+
+
+
+
 _GATE_NAME_TO_LABEL = {
     'X': r'X',
     'Y': r'Y',

--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -56,7 +56,7 @@ __all__ = ['Gate', 'rx', 'ry', 'rz', 'sqrtnot', 'snot', 'phasegate', 'qrot',
            'globalphase', 'hadamard_transform', 'gate_sequence_product',
            'gate_expand_1toN', 'gate_expand_2toN', 'gate_expand_3toN',
            'qubit_clifford_group', 'expand_operator', '_single_qubit_gates',
-           '_para_gates', '_ctrl_gates','_swap_like','_toffoli_like',
+           '_para_gates', '_ctrl_gates', '_swap_like', '_toffoli_like',
            '_fredkin_like']
 
 

--- a/tests/decomposition_functions/test_decompose_general_qubit_gate.py
+++ b/tests/decomposition_functions/test_decompose_general_qubit_gate.py
@@ -1,0 +1,75 @@
+import numpy as np
+import cmath
+import pytest
+
+from qutip import (
+    Qobj, average_gate_fidelity, rand_unitary
+)
+
+from qutip_qip.decompose.decompose_general_qubit_gate import (
+                    _decompose_to_two_level_arrays,
+                    plot_gray_code_grid
+    )
+
+
+# def test_plot_gray_code_grid():
+#    """ Test output type of gray code plotting function.
+#    """
+# To Do : Use an image comparison decorator
+
+
+@pytest.mark.parametrize("num_qubits", [2, 3, 4, 5, 6, 7])
+def test_two_level_full_output(num_qubits):
+    """ Check if product of full two level array output is equal to the input.
+    """
+    input_gate = rand_unitary(2**num_qubits, dims=[[2] * num_qubits] * 2)
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=True)
+
+    product_of_U = array_decompose[-1]
+
+    for i in reversed(range(len(array_decompose)-1)):
+        product_of_U = product_of_U
+        product_of_U_calculated = np.dot(product_of_U, array_decompose[i])
+        product_of_U = product_of_U_calculated
+
+    product_of_U = Qobj(product_of_U, dims=[[2] * num_qubits] * 2)
+    fidelity_of_input_output = average_gate_fidelity(
+        product_of_U, input_gate
+    )
+    assert np.isclose(fidelity_of_input_output, 1.0)
+
+
+@pytest.mark.parametrize("num_qubits", [2, 3, 4, 5, 6, 7])
+def test_two_level_compact_output(num_qubits):
+    """ Check if product of compact two level array output is equal to the
+    input after creating a two-level array.
+    """
+    input_gate = rand_unitary(2**num_qubits, dims=[[2] * num_qubits] * 2)
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=False)
+
+    compact_to_full = []
+    for i in range(len(array_decompose)):
+        U_two_level = np.identity(2**num_qubits, dtype=complex)
+        index_1, index_2 = array_decompose[i][0]
+        U_2_qobj = array_decompose[i][1]
+        U_2_array = U_2_qobj.full()
+        U_two_level[index_1][index_1] = U_2_array[0][0]
+        U_two_level[index_2][index_1] = U_2_array[1][0]
+        U_two_level[index_1][index_2] = U_2_array[0][1]
+        U_two_level[index_2][index_2] = U_2_array[1][1]
+        compact_to_full.append(U_two_level)
+
+    product_of_U = compact_to_full[-1]
+
+    for i in reversed(range(len(compact_to_full)-1)):
+        product_of_U = product_of_U
+        product_of_U_calculated = np.dot(product_of_U, compact_to_full[i])
+        product_of_U = product_of_U_calculated
+
+    product_of_U = Qobj(product_of_U, dims=[[2] * num_qubits] * 2)
+    fidelity_of_input_output = average_gate_fidelity(
+        product_of_U, input_gate
+    )
+    assert np.isclose(fidelity_of_input_output, 1.0)

--- a/tests/decomposition_functions/test_decompose_general_qubit_gate.py
+++ b/tests/decomposition_functions/test_decompose_general_qubit_gate.py
@@ -12,7 +12,6 @@ from qutip_qip.decompose.decompose_general_qubit_gate import (
                     _sqrt_of_1_qubit_array,
     )
 
-from qutip_qip.decompose._utility import gray_code_gate_info
 
 # def test_plot_gray_code_grid():
 #    """ Test output type of gray code plotting function.
@@ -89,42 +88,3 @@ def test_sqrt_of_1_qubit_array():
         Qobj(sqrtU_squared, dims=[[2] * 1] * 2), U
     )
     assert np.isclose(fidelity_of_input_output, 1.0)
-
-
-@pytest.mark.xfail
-def test_gray_code_info():
-    """ Tests if the controls, targets are correctly idenitfied.
-    """
-    # Note the current function is not outputting expected gate control/target
-    # info. The shortened gray code sequence should be ['000', '001', '011',
-    # '010', '110', '111', '110', '010', '011', '001', '000'] but the gate
-    # control and target info should not be returned for '111' to '110'.
-    calculated_output3 = gray_code_gate_info(0, 7, 3)
-    ex_out = {
-     0: {
-        'controls =': [0, 1], 'control_value =': ['0', '0'], 'targets =': [2]},
-     1: {
-        'controls =': [0, 2], 'control_value =': ['0', '1'], 'targets =': [1]},
-     2: {
-        'controls =': [0, 1], 'control_value =': ['0', '1'], 'targets =': [2]},
-     3: {
-        'controls =': [1, 2], 'control_value =': ['1', '0'], 'targets =': [0]},
-     4: {'controls =': [0, 1], 'control_value =': ['1', '1'], 'targets =': [2]},
-     5: {'controls =': [1, 2], 'control_value =': ['1', '0'], 'targets =': [0]},
-     6: {
-        'controls =': [0, 1], 'control_value =': ['0', '1'], 'targets =': [2]},
-     7: {'controls =': [0, 2], 'control_value =': ['0', '1'], 'targets =': [1]},
-     8: {'controls =': [0, 1], 'control_value =': ['0', '0'], 'targets =': [2]}
-     }
-    # currently last gate of the sequence is not output correctly
-    assert calculated_output3 == ex_out
-
-    calc_output2 = gray_code_gate_info(0, 2, 2)
-    ex_out2 = {
-     0: {'controls =': [0], 'control_value =': ['0'], 'targets =': [1]},
-     1: {'controls =': [1], 'control_value =': ['1'], 'targets =': [0]},
-     2: {'controls =': [0], 'control_value =': ['1'], 'targets =': [1]},
-     3: {'controls =': [1], 'control_value =': ['1'], 'targets =': [0]},
-     4: {'controls =': [0], 'control_value =': ['0'], 'targets =': [1]},
-     }
-    assert calc_output2 == ex_out2

--- a/tests/decomposition_functions/test_utility.py
+++ b/tests/decomposition_functions/test_utility.py
@@ -4,6 +4,9 @@ import pytest
 from qutip import Qobj, qeye
 from qutip_qip.decompose._utility import (
     check_gate,
+    _binary_sequence,
+    _gray_code_sequence,
+    _gray_code_steps
 )
 
 
@@ -39,7 +42,8 @@ def test_check_gate_non_unitary(non_unitary):
 def test_check_gate_non_1qubit(non_1qubit_unitary):
     """Checks if non-unitary input is correctly identified."""
     num_qubits = 1
-    with pytest.raises(ValueError, match=f"Input is not a unitary on {num_qubits} qubits."):
+    with pytest.raises(
+         ValueError, match=f"Input is not a unitary on {num_qubits} qubits."):
         check_gate(non_1qubit_unitary, num_qubits)
 
 
@@ -48,3 +52,72 @@ def test_check_gate_unitary_input(unitary):
     """Checks if shape of input is correctly identified."""
     # No error raised if it passes.
     check_gate(unitary, num_qubits=1)
+
+
+@pytest.mark.parametrize("num_qubits", [2, 3, 4, 5, 6, 7])
+@pytest.mark.parametrize("method", [_gray_code_sequence, _binary_sequence])
+def test_full_sequence_length(num_qubits, method):
+    """ Tests length of binary and gray code sequence compared to the number of
+    qubits.
+    """
+    expected_len_sequence = 2**num_qubits
+    len_from_function = len(method(num_qubits))
+    assert np.equal(expected_len_sequence, len_from_function)
+
+
+def test_binary_sequence():
+    """ Checks if the output of binary code function is as expected.
+    """
+    expected_seq2 = ['00', '01', '10', '11']
+    calc_sequence2 = _binary_sequence(2)
+    assert expected_seq2 == calc_sequence2
+
+    expected_seq3 = ['000', '001', '010', '011', '100', '101', '110', '111']
+    calc_sequence3 = _binary_sequence(3)
+    assert expected_seq3 == calc_sequence3
+
+
+def test_gray_code_sequence():
+    """ Checks if output of gray code function is as expected.
+    """
+    expected_seq2 = ['00', '01', '11', '10']
+    calc_sequence2 = _gray_code_sequence(2)
+    assert expected_seq2 == calc_sequence2
+
+    expected_seq3 = ['000', '001', '011', '010', '110', '111', '101', '100']
+    calc_sequence3 = _gray_code_sequence(3)
+    assert expected_seq3 == calc_sequence3
+
+
+def test_gray_code_steps():
+    """ Checks the number of steps and smaller gray code sequence is returned.
+    """
+    # the expected number of steps is mapping from index1 to index2 and then
+    # mapping back to index1 if the first iteration is done in more than 1 steps.
+
+    # for num_qubits = 2, if the mapping is done from '00' to '10'
+    expected_num_steps = 5
+    expected_gray_code = ['00', '01', '11', '10']
+    calc_num_steps_sequence = _gray_code_steps(0, 2, 2)
+    calc_num_steps = calc_num_steps_sequence[1]
+    calc_gray_code = calc_num_steps_sequence[0]
+    assert np.equal(calc_num_steps, expected_num_steps)
+    assert expected_gray_code == calc_gray_code
+
+    # for num_qubits = 2, '00' to '01' is only 1 step
+    expected_num_steps = 1
+    expected_gray_code = ['00', '01']
+    calc_num_steps_sequence = _gray_code_steps(0, 1, 2)
+    calc_num_steps = calc_num_steps_sequence[1]
+    calc_gray_code = calc_num_steps_sequence[0]
+    assert np.equal(calc_num_steps, expected_num_steps)
+    assert expected_gray_code == calc_gray_code
+
+    # for num_qubits = 3, mapping from '000' to '111'
+    expected_num_steps = 9
+    expected_gray_code = ['000', '001', '011', '010', '110', '111']
+    calc_num_steps_sequence = _gray_code_steps(0, 7, 3)
+    calc_num_steps = calc_num_steps_sequence[1]
+    calc_gray_code = calc_num_steps_sequence[0]
+    assert np.equal(calc_num_steps, expected_num_steps)
+    assert expected_gray_code == calc_gray_code

--- a/tests/decomposition_functions/test_utility.py
+++ b/tests/decomposition_functions/test_utility.py
@@ -6,7 +6,8 @@ from qutip_qip.decompose._utility import (
     check_gate,
     _binary_sequence,
     _gray_code_sequence,
-    _gray_code_steps
+    _gray_code_steps,
+    gray_code_gate_info
 )
 
 
@@ -121,3 +122,45 @@ def test_gray_code_steps():
     calc_gray_code = calc_num_steps_sequence[0]
     assert np.equal(calc_num_steps, expected_num_steps)
     assert expected_gray_code == calc_gray_code
+
+
+@pytest.mark.xfail
+def test_gray_code_info():
+    """ Tests if the controls, targets are correctly idenitfied.
+    """
+    # Note the current function is not outputting expected gate control/target
+    # info. The shortened gray code sequence should be ['000', '001', '011',
+    # '010', '110', '111', '110', '010', '011', '001', '000'] but the gate
+    # control and target info should not be returned for '111' to '110'.
+    calculated_output3 = gray_code_gate_info(0, 7, 3)
+    ex_out = {
+     0: {
+        'controls =': [0, 1], 'control_value =': ['0', '0'], 'targets =': [2]},
+     1: {
+        'controls =': [0, 2], 'control_value =': ['0', '1'], 'targets =': [1]},
+     2: {
+        'controls =': [0, 1], 'control_value =': ['0', '1'], 'targets =': [2]},
+     3: {
+        'controls =': [1, 2], 'control_value =': ['1', '0'], 'targets =': [0]},
+     4: {
+        'controls =': [0, 1], 'control_value =': ['1', '1'], 'targets =': [2]},
+     5: {
+        'controls =': [1, 2], 'control_value =': ['1', '0'], 'targets =': [0]},
+     6: {
+        'controls =': [0, 1], 'control_value =': ['0', '1'], 'targets =': [2]},
+     7: {
+        'controls =': [0, 2], 'control_value =': ['0', '1'], 'targets =': [1]},
+     8: {'controls =': [0, 1], 'control_value =': ['0', '0'], 'targets =': [2]}
+     }
+    # currently last gate of the sequence is not output correctly
+    assert calculated_output3 == ex_out
+
+    calc_output2 = gray_code_gate_info(0, 2, 2)
+    ex_out2 = {
+     0: {'controls =': [0], 'control_value =': ['0'], 'targets =': [1]},
+     1: {'controls =': [1], 'control_value =': ['1'], 'targets =': [0]},
+     2: {'controls =': [0], 'control_value =': ['1'], 'targets =': [1]},
+     3: {'controls =': [1], 'control_value =': ['1'], 'targets =': [0]},
+     4: {'controls =': [0], 'control_value =': ['0'], 'targets =': [1]},
+     }
+    assert calc_output2 == ex_out2


### PR DESCRIPTION
**Examples**

1. **Plotting the gray code grid**
Suppose the non-trivial state indices of a two-level unitary are 10 and 31. The gray code sequence of this mapping can be obtained via

```python
plot_gray_code_grid(10,31,5)
plt.show()
``` 
![image](https://user-images.githubusercontent.com/66048318/127573452-ca346c8b-c92f-4b4d-9d99-aa24ed631b18.png)

2. 