### PR TITLE
Fix the leaking noise objects

### DIFF
--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -77,6 +77,7 @@ def process_noise(pulses, noise_list, dims, t1=None, t2=None,
     noisy_pulses: list of :class:`.Pulse`
         The noisy pulses, including the system noise.
     """
+    noise_list = noise_list.copy()
     noisy_pulses = deepcopy(pulses)
     systematic_noise = Pulse(None, None, label="systematic_noise")
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -361,3 +361,11 @@ class TestCircuitProcessor:
         processor = Processor(1)
         processor.add_control(sigmax(), 0, label="test")
         assert("test" in processor.get_pulse_dict())
+
+    def test_repeated_use_of_processor(self):
+        processor = Processor(1, t1=1.)
+        processor.add_pulse(
+            Pulse(sigmax(), targets=0, coeff=True))
+        result1 = processor.run_state(basis(2, 0), tlist=np.linspace(0, 1, 10))
+        result2 = processor.run_state(basis(2, 0), tlist=np.linspace(0, 1, 10))
+        assert_allclose(result1.states[-1].full(), result2.states[-1].full())


### PR DESCRIPTION
A list of noise objects defined by the user is passed to the function. However, when adding T1 and T2 noise, the generated objects were added directly to the list. This changes the `noise_list` defined by the user and is a problem if the same `Processor` instance is used to perform more than one simulation. The T1,T2 noise objects from the previous run will accumulate in the `noise_list`. Therefore, we copy the list before add T1 T2 noise.