### PR TITLE
General decomposition method

### DIFF
--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -1,5 +1,8 @@
 from qutip import Qobj
 import numpy as np
+import copy
+from qutip_qip.circuit import Gate
+
 
 class MethodError(Exception):
     """When invalid method is chosen, this error is raised."""
@@ -96,7 +99,10 @@ def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
     unitary matrix. Here, the inputs are their respective indices in a quantum
     gate's array.
     This function finds the number of steps between both states when only 1 bit
-    can be changed at each step.
+    can be changed at each step. In addition, a partial sequence going from
+    basis state 1 to state 2 and another partial sequence mapping back from
+    state 2 to state 1. The last gray sequence value in forward mapping is used
+    to define the two-level unitary.
     """
     # check array values are not the same
     try:
@@ -143,5 +149,350 @@ def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
         # right to left - with current code, the order is mixed.
         gray_code = _gray_code_sequence(num_qubits)[
             state_2_gray_code_index:state_1_gray_code_index+1]
+    gray_code_forward = gray_code
+    gray_code_backward = gray_code_forward[0:len(gray_code_forward)-1][::-1]
 
-    return(gray_code, num_steps_gray_code)
+    if num_steps_gray_code == 1:
+        return(gray_code_forward, num_steps_gray_code)
+    else:
+        return(gray_code_forward, gray_code_backward, num_steps_gray_code)
+
+
+def _gray_code_gate_info(index_of_state_1, index_of_state_2, num_qubits):
+    """ Finds information about control and targets for CNOT gate in a gray
+    code sequence.
+
+    Returns
+    -------
+        A list of two dictionaries containing information about gate controls
+    and targets.
+
+    `forward_step_iteration_dictionary` contains information
+    iterating over the gray code sequence from state 1 to state 2. Last item
+    will contain information about the two-level unitary gate.
+
+    `backward_step_iteration_dictionary` contains information mapping back to
+    initial state after the two-level unitary circuit has been added to the
+    circuit.
+    """
+    gray_code_info = _gray_code_steps(
+        index_of_state_1, index_of_state_2, num_qubits)
+    num_steps = gray_code_info[-1]
+    if num_steps > 1:
+        gray_code_forward = gray_code_info[0]
+        gray_code_backward = gray_code_info[1]
+    else:
+        gray_code_forward = gray_code_info[0]
+
+    # repeat the mapping from last index to first initial index
+    if num_steps == 1:
+        gray_code = gray_code_forward
+
+        # make a dictionary of an array of binary values
+        # find position of 1's
+        input_binary_values = {}
+
+        for i in range(num_steps+1):
+            bit_array_at_i = []
+            a = gray_code[i]
+            for j in range(num_qubits):
+                bit_array_at_i.append(a[j])
+
+            input_binary_values[i] = bit_array_at_i
+
+        # compare the array values
+        step_iteration_dictionary = {}
+        for i in range(num_steps):
+            a = input_binary_values[i]
+            b = input_binary_values[i+1]
+            controls = []
+            control_value = []
+            target = []
+            all_together = {}
+            for j in range(num_qubits):
+                if a[j] == b[j]:
+                    controls.append(j)
+                    control_value.append(a[j])
+                else:
+                    target.append(j)
+                all_together['controls ='] = controls
+                all_together['control_value ='] = control_value
+                all_together['targets ='] = target
+            step_iteration_dictionary[i] = all_together
+
+        return(step_iteration_dictionary)
+    else:
+        # make a dictionary of an array of binary values
+        # find position of 1's
+        forward_input_binary_values = {}
+        for i in range(len(gray_code_forward)):
+            bit_array_at_i = []
+            a = gray_code_forward[i]
+            for j in range(num_qubits):
+                bit_array_at_i.append(a[j])
+
+            forward_input_binary_values[i] = bit_array_at_i
+
+        backward_input_binary_values = {}
+        for i in range(len(gray_code_backward)):
+            bit_array_at_i = []
+            a = gray_code_backward[i]
+            for j in range(num_qubits):
+                bit_array_at_i.append(a[j])
+
+            backward_input_binary_values[i] = bit_array_at_i
+
+        # compare the array values
+        step_iteration_dictionary = []
+        forward_step_iteration_dictionary = {}
+        backward_step_iteration_dictionary = {}
+
+        # gate information going forward
+        for i in range(len(gray_code_forward)-1):
+            a = forward_input_binary_values[i]
+            b = forward_input_binary_values[i+1]
+            controls = []
+            control_value = []
+            target = []
+            all_together = {}
+            for j in range(num_qubits):
+                if a[j] == b[j]:
+                    controls.append(j)
+                    control_value.append(a[j])
+                else:
+                    target.append(j)
+                all_together['controls ='] = controls
+                all_together['control_value ='] = control_value
+                all_together['targets ='] = target
+            forward_step_iteration_dictionary[i] = all_together
+        step_iteration_dictionary.append(
+            copy.deepcopy(forward_step_iteration_dictionary))
+        # gate information going back to initial basis state
+        for i in range(len(gray_code_backward)-1):
+            a = backward_input_binary_values[i]
+            b = backward_input_binary_values[i+1]
+            controls = []
+            control_value = []
+            target = []
+            all_together = {}
+            for j in range(num_qubits):
+                if a[j] == b[j]:
+                    controls.append(j)
+                    control_value.append(a[j])
+                else:
+                    target.append(j)
+                all_together['controls ='] = controls
+                all_together['control_value ='] = control_value
+                all_together['targets ='] = target
+            backward_step_iteration_dictionary[
+                int((num_steps+1)/2)+i] = all_together
+
+        step_iteration_dictionary.append(
+            copy.deepcopy(backward_step_iteration_dictionary))
+        return(step_iteration_dictionary)
+
+
+def _paulix_for_control_0(step_iteration_dictionary):
+    """ Returns gray code info adjusted for control value = 0. Wherever the
+    control value was changed, Pauli X gate was also added.
+    """
+    n = len(step_iteration_dictionary)
+    # when there's only one step going from state 1 to state 2
+    if n == 1:
+        # find array indices with control value 0
+        gray_code_info = step_iteration_dictionary
+        sub_dict = gray_code_info[0]
+        array_gate_info_with_control_0 = []
+        num_control_qubits = len(sub_dict['control_value ='])
+        new_target_info = []
+        target_info = sub_dict['controls =']
+        ctrl_value = sub_dict['control_value =']
+        for j, k in enumerate(ctrl_value):
+            if k == '0':
+                new_target = target_info[j]
+                new_target_info.append(new_target)
+                # change control value to be 1 if it is 0
+                gray_code_info[0]['control_value ='] = ['1']*num_control_qubits
+            else:
+                return({0: gray_code_info})
+        if len(new_target_info) != 0:
+            # returns info about which two-level array gate decomposition
+            # needs pauli x to correct ctrl_value = 0
+            array_gate_info_with_control_0.append([0, new_target_info])
+
+        # create array of pauli gates to put before and after the decomposition
+        # info from gray code
+        pauli_gate_array_forward = []
+        gate_targets_from_ctrl_0 = array_gate_info_with_control_0[0][1]
+        for i in range(len(gate_targets_from_ctrl_0)):
+            target_qubit = gate_targets_from_ctrl_0[i]
+            paulix = Gate("X", targets=target_qubit)
+            pauli_gate_array_forward.append(paulix)
+
+        pauli_gate_array_backward = pauli_gate_array_forward[::-1]
+        # create the new gate array with pauli gates included
+        full_gate_array = []
+        full_gate_array.extend(pauli_gate_array_forward)
+        full_gate_array.append(gray_code_info[0])
+        # there's only 1 gate i.e. 1 step
+        full_gate_array.extend(pauli_gate_array_backward)
+
+        # what to return
+        if len(full_gate_array) == 0:
+            return(gray_code_info)
+        else:
+            return({0: full_gate_array})
+    else:
+        # gray code info
+        full_gray_code_info = step_iteration_dictionary
+        forward_gray_code = full_gray_code_info[0]
+        backward_gray_code = full_gray_code_info[1]
+
+        # pauli x from forward gray code
+        for_array_gate_info_with_control_0 = []
+        gate_keys = []  # the gates that need pauli x for ctrl value =0
+
+        for i in range(len(forward_gray_code)):
+            for_sub_dict = forward_gray_code[i]
+            for_num_control_qubits = len(for_sub_dict['control_value ='])
+            for_new_target_info = []
+            for_target_info = for_sub_dict['controls =']
+            for_ctrl_value = for_sub_dict['control_value =']
+            for j, k in enumerate(for_ctrl_value):
+                if k == '0':
+                    for_new_target = for_target_info[j]
+                    for_new_target_info.append(for_new_target)
+                    # change control value to be 1 if it is 0
+                    forward_gray_code[i]['control_value ='] = [
+                        '1']*for_num_control_qubits
+
+            if len(for_new_target_info) != 0:
+                # returns info about which two-level array gate decomposition
+                #  needs pauli x to correct ctrl_value = 0
+                for_array_gate_info_with_control_0.append(
+                    [i, for_new_target_info])
+                gate_keys.append(i)
+
+        # create pauli arrays
+        full_left_pauli_gate_dict = {}
+        full_right_pauli_gate_dict = {}
+        for i in range(len(for_array_gate_info_with_control_0)):
+            left_pauli_array = []
+            right_pauli_array = []
+            gate_targets = for_array_gate_info_with_control_0[i][1]
+            for j in range(len(gate_targets)):
+                target_qubit = gate_targets[j]
+                paulix = Gate("X", targets=target_qubit)
+                left_pauli_array.append(paulix)
+            key = gate_keys[i]
+            full_left_pauli_gate_dict[key] = left_pauli_array
+            # the pauli gate order is reversed when applied from the right
+            right_pauli_array = left_pauli_array[::-1]
+            full_right_pauli_gate_dict[key] = right_pauli_array
+
+        # create full forward gate dict with pauli gates
+        full_gate_dict = {}
+        for i in range(len(forward_gray_code)):
+            if len(for_array_gate_info_with_control_0) == len(
+                        forward_gray_code):
+                left_pauli = full_left_pauli_gate_dict[i]
+                right_pauli = full_right_pauli_gate_dict[i]
+                gray_code_with_ctrl_1 = forward_gray_code[i]
+                full_gate_i_info = [
+                    left_pauli, gray_code_with_ctrl_1, right_pauli]
+                full_gate_dict[i] = full_gate_i_info
+            elif len(for_array_gate_info_with_control_0) < len(
+                    forward_gray_code):
+                if i in gate_keys:
+                    left_pauli = full_left_pauli_gate_dict[i]
+                    right_pauli = full_right_pauli_gate_dict[i]
+                    gray_code_with_ctrl_1 = forward_gray_code[i]
+                    full_gate_i_info = [
+                        left_pauli, gray_code_with_ctrl_1, right_pauli]
+                    full_gate_dict[i] = full_gate_i_info
+                else:
+                    full_gate_dict[i] = forward_gray_code[i]
+
+        # backward gray code info
+        back_array_gate_info_with_control_0 = []
+        # create gate keys list for backward gray code
+        back_gate_keys = []
+        for key in backward_gray_code.keys():
+            back_gate_keys.append(key)
+
+        # find qubits with ctrl_value = 0 and change them to 1
+        for i in range(len(backward_gray_code)):
+            key = back_gate_keys[i]
+            back_sub_dict = backward_gray_code[key]
+            back_num_control_qubits = len(back_sub_dict['control_value ='])
+            back_new_target_info = []
+            back_target_info = back_sub_dict['controls =']
+            back_ctrl_value = back_sub_dict['control_value =']
+            for j, k in enumerate(back_ctrl_value):
+                if k == '0':
+                    back_new_target = back_target_info[j]
+                    back_new_target_info.append(back_new_target)
+                    # change control value to be 1 if it is 0
+                    backward_gray_code[key]['control_value ='] = [
+                        '1']*back_num_control_qubits
+
+            if len(back_new_target_info) != 0:
+                # returns info about which two-level array gate decomposition
+                # needs pauli x to correct ctrl_value = 0
+                back_array_gate_info_with_control_0.append(
+                    [key, back_new_target_info])
+
+        # create pauli arrays
+        back_full_left_pauli_gate_dict = {}
+        back_full_right_pauli_gate_dict = {}
+        for i in range(len(back_array_gate_info_with_control_0)):
+            left_pauli_array = []
+            right_pauli_array = []
+            gate_targets = back_array_gate_info_with_control_0[i][1]
+            for j in range(len(gate_targets)):
+                target_qubit = gate_targets[j]
+                paulix = Gate("X", targets=target_qubit)
+                left_pauli_array.append(paulix)
+            key = back_gate_keys[i]
+            back_full_left_pauli_gate_dict[key] = left_pauli_array
+            # the pauli gate order is reversed when applied from the right
+            right_pauli_array = left_pauli_array[::-1]
+            back_full_right_pauli_gate_dict[key] = right_pauli_array
+
+        # create full forward gate dict with pauli gates
+        back_full_gate_dict = {}
+        for i in range(len(backward_gray_code)):
+            if len(back_array_gate_info_with_control_0) == len(
+                    backward_gray_code):
+                key = back_gate_keys[i]
+                left_pauli = back_full_left_pauli_gate_dict[key]
+                right_pauli = back_full_right_pauli_gate_dict[key]
+                gray_code_with_ctrl_1 = backward_gray_code[key]
+                back_full_gate_i_info = [
+                    left_pauli, gray_code_with_ctrl_1, right_pauli]
+                back_full_gate_dict[key] = back_full_gate_i_info
+            elif len(for_array_gate_info_with_control_0) < len(
+                    forward_gray_code):
+                key = back_gate_keys[i]
+                if i in gate_keys:
+                    left_pauli = back_full_left_pauli_gate_dict[key]
+                    right_pauli = back_full_right_pauli_gate_dict[key]
+                    gray_code_with_ctrl_1 = backward_gray_code[key]
+                    back_full_gate_i_info = [
+                        left_pauli, gray_code_with_ctrl_1, right_pauli]
+                    back_full_gate_dict[key] = back_full_gate_i_info
+                else:
+                    back_full_gate_dict[key] = backward_gray_code[key]
+
+        # calculated lengths
+        len_forward_gate_info = len(full_gate_dict)
+        len_backward_gate_info = len(back_full_gate_dict)
+
+        if len_forward_gate_info == 0 and len_backward_gate_info == 0:
+            return(full_gray_code_info)
+        elif len_forward_gate_info == 0 and len_backward_gate_info > 0:
+            return([forward_gray_code, back_full_gate_dict])
+        elif len_forward_gate_info > 0 and len_backward_gate_info == 0:
+            return([full_gate_dict, backward_gray_code])
+        else:
+            return([full_gate_dict, back_full_gate_dict])

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -476,7 +476,7 @@ def _paulix_for_control_0(step_iteration_dictionary):
             elif len(for_array_gate_info_with_control_0) < len(
                     forward_gray_code):
                 key = back_gate_keys[i]
-                if i in gate_keys:
+                if key in gate_keys:
                     left_pauli = back_full_left_pauli_gate_dict[key]
                     right_pauli = back_full_right_pauli_gate_dict[key]
                     gray_code_with_ctrl_1 = backward_gray_code[key]

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -1,5 +1,5 @@
 from qutip import Qobj
-
+import numpy as np
 
 class MethodError(Exception):
     """When invalid method is chosen, this error is raised."""
@@ -29,3 +29,119 @@ def check_gate(gate, num_qubits):
         raise ValueError("Input is not unitary.")
     if gate.dims != [[2] * num_qubits] * 2:
         raise ValueError(f"Input is not a unitary on {num_qubits} qubits.")
+
+
+def _binary_sequence(num_qubits):
+    """ Defines the binary sequence list for basis vectors of a n-qubit gate.
+    The string at index `i` is also the row/column index for a basis vector in
+    a numpy array.
+    """
+    old_sequence = ['0', '1']
+    full_binary_sequence = []
+
+    if num_qubits == 1:
+        full_binary_sequence = old_sequence
+    else:
+        for x in range(num_qubits-1):
+            full_binary_sequence = []
+            zero_append_sequence = ['0' + x for x in old_sequence]
+            full_binary_sequence.extend(zero_append_sequence)
+            one_append_sequence = ['1' + x for x in old_sequence]
+            full_binary_sequence.extend(one_append_sequence)
+            old_sequence = full_binary_sequence
+
+    return(full_binary_sequence)
+
+
+def _gray_code_sequence(num_qubits, output_form=None):
+    """ Finds the sequence of gray codes for basis vectors by using logical
+    XOR operator of Python.
+    For print( _gray_code_sequence(2)), the output is [0, 1, 3, 2] i.e. in
+    terms of the binary sequence, the output is ['00', '01', '11', '10'].
+    https://docs.python.org/3/library/operator.html#operator.xor'
+    Parameters
+    ----------
+    num_qubits
+        Number of qubits in the circuit
+    output_form : :"index_values" or None
+        The format of output list. If a string "index_values" is provided then
+    the function's output is in terms of array indices of the binary sequence.
+    The default is a list of binary strings.
+    Returns
+    --------
+    list
+        List of the gray code sequence in terms of array indices or binary
+        sequence positions.
+    """
+    gray_code_sequence_as_array_indices = []
+
+    for x in range(2**num_qubits):
+        gray_code_at_x = x ^ x // 2  # floor operator to shift bits by 1
+        # when the shift is done, the new spot is filled with a new value.
+        gray_code_sequence_as_array_indices.append(gray_code_at_x)
+        if output_form == "index_values":
+            output = gray_code_sequence_as_array_indices
+        else:
+            gray_code_as_binary = []
+            binary_sequence_list = _binary_sequence(num_qubits)
+            for i in gray_code_sequence_as_array_indices:
+                gray_code_as_binary.append(binary_sequence_list[i])
+            output = gray_code_as_binary
+    return(output)
+
+
+def _gray_code_steps(index_of_state_1, index_of_state_2, num_qubits):
+    """ Finds the sequence mapping from state 1 to state 2.
+    State 1 and 2 define the basis vectors of non-trivial values in a two-level
+    unitary matrix. Here, the inputs are their respective indices in a quantum
+    gate's array.
+    This function finds the number of steps between both states when only 1 bit
+    can be changed at each step.
+    """
+    # check array values are not the same
+    try:
+        assert (index_of_state_1 != index_of_state_2)
+    except AssertionError:
+        raise IndexError("Both indices need to be different.")
+
+    # array index for original binary sequence
+    indices_of_array = []
+    for i in range(2**num_qubits):
+        indices_of_array.append(i)
+
+    # Check both indices could be indices for num_qubits array
+    try:
+        assert all(x in indices_of_array for x in [
+                index_of_state_1, index_of_state_2])
+    except AssertionError:
+        raise IndexError(
+            "At least one of the input indices is invalid.")
+
+    # get the basis vector strings
+    binary_sequence_list = _binary_sequence(num_qubits)
+    state_1_binary = binary_sequence_list[index_of_state_1]
+    state_2_binary = binary_sequence_list[index_of_state_2]
+
+    # compare binary sequence positions to gray code sequence
+    # finds number of steps neeeded to go from one state to another
+    gray_code_sequence = _gray_code_sequence(num_qubits)
+    state_1_gray_code_index = gray_code_sequence.index(state_1_binary)
+    state_2_gray_code_index = gray_code_sequence.index(state_2_binary)
+    num_steps_gray_code = np.abs(
+        state_2_gray_code_index - state_1_gray_code_index)
+
+    if num_steps_gray_code == 1:
+        num_steps_gray_code = num_steps_gray_code
+    else:  # repeat the mapping back to initial index
+        num_steps_gray_code = 2*num_steps_gray_code - 1
+    # create a smaller gray code sequence between the two states of interest
+    if state_1_gray_code_index < state_2_gray_code_index:
+        gray_code = _gray_code_sequence(num_qubits)[
+            state_1_gray_code_index:state_2_gray_code_index+1]
+    else:  # check math for reversed order
+        # what is the difference between using gates from left to right vs
+        # right to left - with current code, the order is mixed.
+        gray_code = _gray_code_sequence(num_qubits)[
+            state_2_gray_code_index:state_1_gray_code_index+1]
+
+    return(gray_code, num_steps_gray_code)

--- a/src/qutip_qip/decompose/_utility.py
+++ b/src/qutip_qip/decompose/_utility.py
@@ -313,12 +313,14 @@ def _paulix_for_control_0(step_iteration_dictionary):
                 new_target_info.append(new_target)
                 # change control value to be 1 if it is 0
                 gray_code_info[0]['control_value ='] = ['1']*num_control_qubits
-            else:
-                return({0: gray_code_info})
+            # else:
+            #    return(gray_code_info)
         if len(new_target_info) != 0:
             # returns info about which two-level array gate decomposition
             # needs pauli x to correct ctrl_value = 0
             array_gate_info_with_control_0.append([0, new_target_info])
+        else:
+            return(gray_code_info)
 
         # create array of pauli gates to put before and after the decomposition
         # info from gray code
@@ -341,7 +343,7 @@ def _paulix_for_control_0(step_iteration_dictionary):
         if len(full_gate_array) == 0:
             return(gray_code_info)
         else:
-            return({0: full_gate_array})
+            return(full_gate_array)
     else:
         # gray code info
         full_gray_code_info = step_iteration_dictionary

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -3,7 +3,10 @@ import cmath
 from qutip import Qobj
 from qutip_qip.decompose._utility import (
     check_gate,
-    MethodError, _gray_code_steps, gray_code_gate_info, _paulix_for_control_0,
+    MethodError,
+    _gray_code_steps,
+    _gray_code_gate_info,
+    _paulix_for_control_0,
 )
 import matplotlib.pyplot as plt
 import warnings
@@ -99,16 +102,204 @@ def _decompose_to_two_level_arrays(input_gate, num_qubits, expand=True):
         return(compact_U_information)
 
 
+def _two_qubit_lastq_target(last_two_level_array_info):
+    """ Finds equivalent circuit of two qubit two-level array when last qubit
+    is the target and first is the control with a control value = 1.
+
+    This object is the first array in output from
+    _decompose_to_two_level_arrays(input_gate, num_qubits, expand = False)
+
+    Only works for ind1 = 2, ind2 = 3
+    """
+    last_two_level_qobj = last_two_level_array_info[-1]
+    last_two_level_array = last_two_level_qobj.full()
+
+    # check two_level_gate
+    check_gate((Qobj(last_two_level_array, dims=[[2] * 2] * 2)), 2)
+
+    # non-trivial indices
+    index_list = last_two_level_array_info[0]
+    index1, index2 = index_list
+    gray_code_dict = _gray_code_gate_info(index1, index2, 2)
+
+    # pauli x gates to make all control 1
+    new_gray_code_dict = _paulix_for_control_0(gray_code_dict)
+    control_qubit = new_gray_code_dict[0]['controls ='][0]
+    target_qubit = new_gray_code_dict[0]['targets ='][0]
+
+    # get ABC decomposition gates
+    single_qubit_decomposition = decompose_one_qubit_gate(
+        last_two_level_qobj, 'ZYZ_PauliX')
+    CNOT_gate = Gate("CNOT", controls=control_qubit, targets=target_qubit)
+
+    # A1, A2 (with default target 0) forming A are at indices 0, 1
+    A1 = single_qubit_decomposition[0]
+    A2 = single_qubit_decomposition[1]
+
+    # At index 2, pauli x gate with default target 0
+    X_gate = single_qubit_decomposition[2]
+
+    # B1, B2 (with default target 0) forming B are at indices 3, 4
+    B1 = single_qubit_decomposition[3]
+    B2 = single_qubit_decomposition[4]
+
+    # C (with default target 0) is at index 6
+    C = single_qubit_decomposition[6]
+
+    # last is the global phase gate which is changed to phasegate
+    phase_angle = single_qubit_decomposition[-1].arg_value
+    phase_gate = Gate(
+        "PHASEGATE",
+        targets=[0],
+        arg_value=phase_angle,
+        arg_label=r"{:0.2f} \times \pi".format(phase_angle / np.pi),
+    )
+
+    # change default targets for gates A, B, C
+    change_targets = [A1, A2, X_gate, B1, B2, C]
+    for i in range(len(change_targets)):
+        change_targets[i].targets = [1]
+
+    # form full gate list
+    final_gate_list = [
+        A1,
+        A2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        B1,
+        B2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        C,
+        phase_gate]
+    return(final_gate_list)
+
+
+def _two_qubit_firstq_target(last_two_level_array_info):
+    """ Finds equivalent circuit of two qubit two-level array when last qubit
+    is the target and first is the control with a control value = 1.
+
+    This object is the first array in output from
+    _decompose_to_two_level_arrays(input_gate, num_qubits, expand = False)
+
+    Only works for ind1 = 1, ind2 = 3
+    """
+    last_two_level_qobj = last_two_level_array_info[-1]
+    last_two_level_array = last_two_level_qobj.full()
+
+    # check two_level_gate
+    check_gate((Qobj(last_two_level_array, dims=[[2] * 2] * 2)), 2)
+
+    # non-trivial indices
+    index_list = last_two_level_array_info[0]
+    index1, index2 = index_list
+    gray_code_dict = _gray_code_gate_info(index1, index2, 2)
+
+    # pauli x gates to make all control 1
+    new_gray_code_dict = _paulix_for_control_0(gray_code_dict)
+    control_qubit = new_gray_code_dict[0]['controls ='][0]
+    target_qubit = new_gray_code_dict[0]['targets ='][0]
+
+    # get ABC decomposition gates
+    single_qubit_decomposition = decompose_one_qubit_gate(
+        last_two_level_qobj, 'ZYZ_PauliX')
+    CNOT_gate = Gate("CNOT", controls=control_qubit, targets=target_qubit)
+
+    # A1, A2 (with default target 0) forming A are at indices 0, 1
+    A1 = single_qubit_decomposition[0]
+    A2 = single_qubit_decomposition[1]
+
+    # At index 2, pauli x gate with default target 0
+    X_gate = single_qubit_decomposition[2]
+
+    # B1, B2 (with default target 0) forming B are at indices 3, 4
+    B1 = single_qubit_decomposition[3]
+    B2 = single_qubit_decomposition[4]
+
+    # C (with default target 0) is at index 6
+    C = single_qubit_decomposition[6]
+
+    # last is the global phase gate which is changed to phasegate
+    phase_angle = single_qubit_decomposition[-1].arg_value
+    phase_gate = Gate(
+        "PHASEGATE",
+        targets=[1],
+        arg_value=phase_angle,
+        arg_label=r"{:0.2f} \times \pi".format(phase_angle / np.pi),
+    )
+
+    # change default targets for gates A, B, C
+    change_targets = [A1, A2, X_gate, B1, B2, C]
+    for i in range(len(change_targets)):
+        change_targets[i].targets = [0]
+
+    # form full gate list
+    final_gate_list = [
+        A1,
+        A2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        B1,
+        B2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        C,
+        phase_gate]
+    return(final_gate_list)
+
+
+def _find_index_for_firstq_target(two_level_array_output, num_qubits):
+    """ Find the two-level array index with first qubit as target and rest
+    as controls.
+    """
+    len_two_level = len(two_level_array_output)
+    single_step = []
+
+    # create an array of single step in gray code sequence
+    for i in range(len_two_level):
+        index1, index2 = two_level_array_output[i][0]
+        gray_code_info = _gray_code_gate_info(index1, index2, num_qubits)
+        if len(gray_code_info) == 1:
+            single_step.append(i)
+
+    # find the index with target_qubit = 0
+    for i in range(len(single_step)):
+        ind = single_step[i]
+        index1, index2 = two_level_array_output[ind][0]
+        gray_code = _gray_code_gate_info(index1, index2, num_qubits)
+        gray_code_target = gray_code[0]['targets =']
+        if gray_code_target[0] == 0:
+            return(ind)
+
+
+
 def decompose_general_qubit_gate(input_gate, num_qubits):
     check_gate(input_gate, num_qubits)
     two_level_array = _decompose_to_two_level_arrays(
-        input_gate, num_qubits, expand=True)
+        input_gate, num_qubits, expand=False)
 
     # first object in two level array is a two-level gate with last qubit as
     # target and others as control
-    last_array = two_level_array[0]
+    last_target_qubit_array = two_level_array[0]
     # because arrays are returned in a reversed order
+    last_target_qubit_array_index = last_target_qubit_array[0]
+    if last_target_qubit_array_index != [2**num_qubits-2, 2**num_qubits-1]:
+        raise MethodError("The chosen method cannot be used.")
 
-    # last object is a two-level gate with first qubit as target and rest as
-    # controls
-    first_array = two_level_array[-1]
+    # look for the two-level matrix with first qubit as target and rest as
+    # controls i.e. want target qubit = 0
+    ind_for_0_target = _find_index_for_firstq_target(
+        two_level_array, num_qubits)
+    first_target_qubit_array = two_level_array[ind_for_0_target]
+    first_target_qubit_array_index = first_target_qubit_array[0]
+
+    # create a list of all two-level arrays without first or last qubit as
+    # targets
+    index_list = list(range(len(two_level_array)))
+    index_list.remove(0)
+    index_list.remove(ind_for_0_target)
+    return(index_list)

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -1,0 +1,114 @@
+import numpy as np
+import cmath
+from qutip import Qobj
+from qutip_qip.decompose._utility import (
+    check_gate,
+    MethodError, _gray_code_steps, gray_code_gate_info, _paulix_for_control_0,
+)
+import matplotlib.pyplot as plt
+import warnings
+from qutip_qip.circuit import Gate
+from qutip_qip.operations import controlled_gate
+from .decompose_single_qubit_gate import decompose_one_qubit_gate
+
+
+def _decompose_to_two_level_arrays(input_gate, num_qubits, expand=True):
+    """Decompose a general qubit gate to two-level arrays.
+    Parameters
+    -----------
+    input_gate : :class:`qutip.Qobj`
+        The gate matrix to be decomposed.
+    num_qubits : int
+        Number of qubits being acted upon by the input_gate
+    expand : True
+        Default parameter to return the output as full two-level Qobj. If
+    `expand = False` then the function returns a tuple of index information
+    and a 2 x 2 Qobj for each gate. The Qobj are returned in reversed order.
+    """
+    check_gate(input_gate, num_qubits)
+    input_array = input_gate.full()
+
+    # Calculate the two level numpy arrays
+    array_list = []
+    index_list = []
+    for i in range(2**num_qubits):
+        for j in range(i+1, 2**num_qubits):
+            new_index = [i, j]
+            index_list.append(new_index)
+
+    for i in range(len(index_list)-1):
+        index_1, index_2 = index_list[i]
+
+        # Values of single qubit U forming the two level unitary
+        a = input_array[index_1][index_1]
+        a_star = np.conj(a)
+        b = input_array[index_2][index_1]
+        b_star = np.conj(b)
+        norm_constant = cmath.sqrt(
+            np.absolute(a*a_star)+np.absolute(b*b_star))
+
+        # Create identity array and then replace with above values for
+        # index_1 and index_2
+        U_two_level = np.identity(2**num_qubits, dtype=complex)
+        U_two_level[index_1][index_1] = a_star/norm_constant
+        U_two_level[index_2][index_1] = b/norm_constant
+        U_two_level[index_1][index_2] = b_star/norm_constant
+        U_two_level[index_2][index_2] = -a/norm_constant
+
+        # Change input by multiplying by above two-level
+        input_array = np.dot(U_two_level, input_array)
+
+        # U dagger to calculate the gates
+        U__two_level_dagger = np.transpose(np.conjugate(U_two_level))
+        array_list.append(U__two_level_dagger)
+
+    # for U6 - multiply input array by U5 and take dagger
+    U_last_dagger = input_array
+    array_list.append(U_last_dagger)
+
+    if expand is True:
+        array_list_with_qobj = []
+        for i in reversed(range(len(index_list))):
+            U_two_level_array = array_list[i]
+            array_list_with_qobj.append(Qobj(
+                U_two_level_array, dims=[[2] * num_qubits] * 2))
+        return(array_list_with_qobj)
+    else:
+        compact_U_information = []
+        for i in reversed(range(len(index_list))):
+            U_non_trivial = np.full([2, 2], None, dtype=complex)
+            index_info = []
+            U_index_together = []
+
+            # create index list
+            index_1, index_2 = index_list[i]
+            index_info = [index_1, index_2]
+            U_index_together.append(index_info)
+
+            # create 2 x 2 arrays
+            U_two_level = array_list[i]
+            U_non_trivial[0][0] = U_two_level[index_1][index_1]
+            U_non_trivial[1][0] = U_two_level[index_2][index_1]
+            U_non_trivial[0][1] = U_two_level[index_1][index_2]
+            U_non_trivial[1][1] = U_two_level[index_2][index_2]
+            U_index_together.append(
+                Qobj(U_non_trivial, dims=[[2] * 1] * 2))
+
+            compact_U_information.append(U_index_together)
+
+        return(compact_U_information)
+
+
+def decompose_general_qubit_gate(input_gate, num_qubits):
+    check_gate(input_gate, num_qubits)
+    two_level_array = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=True)
+
+    # first object in two level array is a two-level gate with last qubit as
+    # target and others as control
+    last_array = two_level_array[0]
+    # because arrays are returned in a reversed order
+
+    # last object is a two-level gate with first qubit as target and rest as
+    # controls
+    first_array = two_level_array[-1]

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -102,6 +102,7 @@ def _decompose_to_two_level_arrays(input_gate, num_qubits, expand=True):
         return(compact_U_information)
 
 
+# To do - delete this function after decisinf if it's needed or not
 def _two_qubit_lastq_target(last_two_level_array_info):
     """ Finds equivalent circuit of two qubit two-level array when last qubit
     is the target and first is the control with a control value = 1.
@@ -177,6 +178,7 @@ def _two_qubit_lastq_target(last_two_level_array_info):
     return(final_gate_list)
 
 
+# To do - delete this function after decisinf if it's needed or not
 def _two_qubit_firstq_target(last_two_level_array_info):
     """ Finds equivalent circuit of two qubit two-level array when last qubit
     is the target and first is the control with a control value = 1.

--- a/src/qutip_qip/decompose/decompose_general_qubit_gate.py
+++ b/src/qutip_qip/decompose/decompose_general_qubit_gate.py
@@ -276,30 +276,479 @@ def _find_index_for_firstq_target(two_level_array_output, num_qubits):
             return(ind)
 
 
+def _full_CNOT_to_Toffoli(num_qubits):
+    """Decomposes a multi-controlled CNOT with last qubit as target into a
+    circuit composed of toffoli and ancilla qubits.
+    """
+    if num_qubits > 3:
+        num_ctrl_qubits = num_qubits - 1
+        num_ancilla_qubits = num_ctrl_qubits - 1
+        # change last qubit due to ancillas
+        last_target_qubit = num_ctrl_qubits + num_ancilla_qubits
+
+        # create ctrl qubit list
+        ctrl_qubit_list = list(range(num_ctrl_qubits))
+        # create ancilla qubit list
+        ancilla_qubit_list = list(range(num_ctrl_qubits, last_target_qubit))
+
+        # first toffoli uses first 2 qubits and first ancilla
+        Toffoli0 = Gate(
+            "TOFFOLI", targets=[ancilla_qubit_list[0]], controls=[0, 1])
+        # remove ancilla qubit and ctrl qubits from their respective lists
+        ctrl_qubit_list.remove(0)
+        ctrl_qubit_list.remove(1)
+
+        # create a list of control and target qubits for toffoli gates
+        ctrls_targ_list = []
+        for i in range(len(ancilla_qubit_list)-1):
+            # index for target qubits
+            j = i + 1
+            ctrls_at_i = [ctrl_qubit_list[i], ancilla_qubit_list[i]]
+            targ_at_i = [ancilla_qubit_list[j]]
+            ctrls_targ_list.append([ctrls_at_i, targ_at_i])
+
+        # create list of toffoli gates
+        full_toffoli_list = [Toffoli0]
+        for i in range(len(ctrls_targ_list)):
+            ctrls_i = ctrls_targ_list[i][0]
+            targ_i = ctrls_targ_list[i][1]
+            toffoli_at_i = Gate("TOFFOLI", targets=targ_i, controls=ctrls_i)
+            full_toffoli_list.append(toffoli_at_i)
+
+        # middle CNOT
+        CNOT_middle = Gate(
+            "CNOT", controls=ancilla_qubit_list[-1], targets=last_target_qubit)
+
+        # full gate list
+        full_gate_list = []
+        for i in range(len(full_toffoli_list)):
+            full_gate_list.append(full_toffoli_list[i])
+
+        full_gate_list.append(CNOT_middle)
+
+        for i in range(len(full_toffoli_list)):
+            reversed_list = full_toffoli_list[::-1]
+            full_gate_list.append(reversed_list[i])
+        return(full_gate_list)
+
+
+def _total_num_qubits_with_ancilla(num_qubits):
+    """Finds total number of qubits when ancilla qubits are added to create a
+    qubit circuit.
+    """
+    if num_qubits > 3:
+        num_ctrl_qubits = num_qubits-1
+        num_ancilla = num_ctrl_qubits - 1
+        total_num_qubits = num_ctrl_qubits + num_ancilla + 1
+        return(total_num_qubits)
+    else:
+        return(num_qubits)
+
+
+def _two_level_CNOT_to_Toffoli(num_qubits):
+    """When a 2-level unitary with last target is supposed to be decomposed,
+    4 multi-controlled CNOT will act on num_qubits-1 qubits.
+    """
+    return(_full_CNOT_to_Toffoli(num_qubits-1))
+
+
+def _sqrt_of_1_qubit_array(input_array):
+    """ Used for decomposition of 3-qubit gate.
+
+    Finds the square root of a 1 qubit gate for decomposing a multi-qubit
+    array into smaller controlled CNOT and 2-qubit two-level unitary.
+    # based on Lemma 7.5 of https://arxiv.org/abs/quant-ph/9503016
+    """
+    # final lemma 7.5 function is not defined - will be dfined if needed
+
+    # This method is for when 1 qubit is not special unitary but the single
+    # qubit decomposition functions defined already make a non-special unitary
+    # output into a su(2) by the determinant.
+    check_gate(Qobj(input_array, dims=[[2] * 1] * 2), 1)
+    # method taken
+    # from https://en.wikipedia.org/wiki/Square_root_of_a_2_by_2_matrix
+
+    U_array = input_array
+    tau = U_array[0][0] + U_array[1][1]
+    delta = np.linalg.det(U_array)
+    s = cmath.sqrt(delta)
+    t = cmath.sqrt(tau + 2*s)
+    sqrt_U = np.multiply(1/t, np.array([[U_array[0][0]+s, U_array[0][1]],
+                                        [U_array[1][0], U_array[1][1]+s]]))
+    return(sqrt_U)
+
+
+def _two_qubit_last_target(last_two_level_array, target_qubit, ctrl_qubit):
+    """ Finds equivalent circuit of two qubit two-level array when last qubit
+    is the target and second-last qubit is the control with a
+    control value = 1.
+
+    This object is the first array in output from
+    _decompose_to_two_level_arrays(input_gate, num_qubits, expand = False)"""
+    last_two_level_qobj = Qobj(last_two_level_array, dims=[[2] * 1] * 2)
+
+    # check two_level_gate
+    check_gate(last_two_level_qobj, 1)
+
+    # decompose the non-trivial single qubit gate matrix
+    single_qubit_decomposition = decompose_one_qubit_gate(
+        last_two_level_qobj, 'ZYZ_PauliX')
+    CNOT_gate = Gate("CNOT", controls=ctrl_qubit, targets=target_qubit)
+
+    # A1, A2 (with default target 0) forming A are at indices 0, 1
+    A1 = single_qubit_decomposition[0]
+    A2 = single_qubit_decomposition[1]
+
+    # At index 2, pauli x gate with default target 0
+    X_gate = single_qubit_decomposition[2]
+
+    # B1, B2 (with default target 0) forming B are at indices 3, 4
+    B1 = single_qubit_decomposition[3]
+    B2 = single_qubit_decomposition[4]
+
+    # C (with default target 0) is at index 6
+    C = single_qubit_decomposition[6]
+
+    # last is the global phase gate which is changed to phasegate
+    phase_angle = single_qubit_decomposition[-1].arg_value
+    phase_gate = Gate(
+        "PHASEGATE",
+        targets=[ctrl_qubit],
+        arg_value=phase_angle,
+        arg_label=r"{:0.2f} \times \pi".format(phase_angle / np.pi),
+    )
+
+    # change default targets for gates A, B, C
+    change_targets = [A1, A2, X_gate, B1, B2, C]
+    for i in range(len(change_targets)):
+        change_targets[i].targets = [target_qubit]
+
+    # form full gate list
+    final_gate_list = [
+        A1,
+        A2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        B1,
+        B2,
+        X_gate,
+        CNOT_gate,
+        X_gate,
+        C,
+        phase_gate]
+    return(final_gate_list)
+
+
+def _threeq_last_target(last_two_level_array):
+    """Defines a method to decompose a 3-qubit two-level array with last
+    qubit as target and first 2 as controls.
+
+    This method was added because the current general method decomposes CNOT's
+    upto Toffoli gates.
+
+    # follows Lemma 6.1 of arXiv:quant-ph/9503016v1
+    """
+    V = _sqrt_of_1_qubit_array(last_two_level_array)
+
+    V_dagger = V.conj().T
+
+    full_gate_list = []
+
+    # first set of gates with 1 as ctrl and 2 as target
+    V12_gate_list = _two_qubit_last_target(V, 2, 1)
+    for i in range(len(V12_gate_list)):
+        full_gate_list.append(V12_gate_list[i])
+
+    # CNOT between V and V_dagger
+    full_gate_list.append(Gate("CNOT", controls=0, targets=1))
+
+    # gate list from V_dagger with 1 as ctrl and 2 as target
+    V_dagger_12_gate_list = _two_qubit_last_target(V_dagger, 2, 1)
+    for i in range(len(V_dagger_12_gate_list)):
+        full_gate_list.append(V_dagger_12_gate_list[i])
+
+    # CNOT between V_dagger and V
+    full_gate_list.append(Gate("CNOT", controls=0, targets=1))
+
+    # last set of gates with 0 as ctrl and 2 as target
+    V02_gate_list = _two_qubit_last_target(V, 2, 0)
+    for i in range(len(V02_gate_list)):
+        full_gate_list.append(V02_gate_list[i])
+
+    return(full_gate_list)
+
+
+def _threeq_first_target(last_two_level_array):
+    """Defines a method to decompose a 3-qubit two-level array with first
+    qubit as target and other 2 as controls.
+
+    This method was added because the current general method decomposes CNOT's
+    upto Toffoli gates.
+
+    # follows Lemma 6.1 of arXiv:quant-ph/9503016v1
+    """
+    V = _sqrt_of_1_qubit_array(last_two_level_array)
+
+    V_dagger = V.conj().T
+
+    full_gate_list = [Gate("X", targets=[2])]
+
+    # first set of gates with 1 as ctrl and 2 as target
+    V12_gate_list = _two_qubit_last_target(V, 0, 1)
+    for i in range(len(V12_gate_list)):
+        full_gate_list.append(V12_gate_list[i])
+
+    # CNOT between V and V_dagger
+    full_gate_list.append(Gate("CNOT", controls=2, targets=1))
+
+    # gate list from V_dagger with 1 as ctrl and 2 as target
+    V_dagger_12_gate_list = _two_qubit_last_target(V_dagger, 0, 1)
+    for i in range(len(V_dagger_12_gate_list)):
+        full_gate_list.append(V_dagger_12_gate_list[i])
+
+    # CNOT between V_dagger and V
+    full_gate_list.append(Gate("CNOT", controls=2, targets=1))
+
+    # last set of gates with 0 as ctrl and 2 as target
+    V02_gate_list = _two_qubit_last_target(V, 0, 2)
+    for i in range(len(V02_gate_list)):
+        full_gate_list.append(V02_gate_list[i])
+    full_gate_list.append(Gate("X", targets=[2]))
+    return(full_gate_list)
+
+
+def _two_q_CNOT_gates(two_qubit_gate):
+    """Create full list of Pauli X and CNOT gates for final decomposition.
+    """
+    two_level_info = _decompose_to_two_level_arrays(
+        two_qubit_gate, 2, expand=False)
+
+    # create a list of non-trivial indices
+    non_trivial_indices = []
+    for i in range(len(two_level_info)):
+        non_trivial_indices.append(two_level_info[i][0])
+
+    # gate dict for two-level gates
+    gate_keys = list(range(len(two_level_info)))
+    full_gate_dict = {}
+
+    # gray code steps
+    full_gray_code_info = []
+    for i in range(len(two_level_info)):
+        ind1, ind2 = non_trivial_indices[i]
+        full_gray_code_info.append(_gray_code_gate_info(ind1, ind2, 2))
+
+    # add pauli gates
+    gray_code_ctrl_val_1 = {}
+    for i in range(len(full_gray_code_info)):
+        gray_pauli_i = _paulix_for_control_0(full_gray_code_info[i])
+        gray_code_ctrl_val_1[i] = gray_pauli_i
+
+    out = gray_code_ctrl_val_1
+
+    # create a dictionary of flattened lists
+    full_dict = {}
+    for i in range(6):
+        for_two_level_i = out[i]
+        if isinstance(for_two_level_i, dict):
+            full_dict[i] = [*out[i].values()]
+        elif isinstance(for_two_level_i, list):
+            if len(for_two_level_i) > 2:
+                full_dict[i] = for_two_level_i
+            elif len((for_two_level_i)) == 2:
+                forwa_seq = for_two_level_i[0]
+                back_seq = for_two_level_i[1]
+                forw_list = []
+                back_list = []
+                for_key_list = [*forwa_seq.keys()]
+                back_key_list = [*back_seq.keys()]
+                for j in for_key_list:
+                    if isinstance(forwa_seq[j], list):
+                        for k in range(len(forwa_seq[j])):
+                            forw_list.append(forwa_seq[j][k])
+                    else:
+                        forw_list.append(forwa_seq[j])
+                for p in back_key_list:
+                    if isinstance(back_seq[p], list):
+                        for q in range(len(back_seq[p])):
+                            back_list.append(back_seq[p][q])
+                    else:
+                        back_list.append(back_seq[p])
+                full_dict[i] = [forw_list, back_list]
+
+    # create a list of keys that will need CNOT gates or decomposition
+    cnot_ind = []
+    for i in range(6):
+        if len(full_dict[i]) == 2:
+            cnot_ind.append(i)
+    forw_ind_list = {}
+    backw_ind_list = {}
+    full_ind_list = []
+    for i in cnot_ind:
+        gray_code_info = full_dict[i]
+        forw = gray_code_info[0]
+        backw = gray_code_info[1]
+        forw_ind_i = []
+        back_ind_i = []
+        for j in forw:
+            if isinstance(j, dict):
+                ind_list = [x for x, q in enumerate(forw) if q == j]
+                forw_ind_i.extend(ind_list)
+
+            full_ind2_list = set()
+
+            for l in range(len(forw_ind_i)):
+                full_ind2_list.add(forw_ind_i[l])
+
+        forw_ind_list[i] = list(full_ind2_list)
+
+        for j in backw:
+            if isinstance(j, dict):
+                ind_list = [x for x, q in enumerate(backw) if q == j]
+                back_ind_i.extend(ind_list)
+            full_ind2_list = set()
+
+            for l in range(len(back_ind_i)):
+                full_ind2_list.add(back_ind_i[l])
+
+        backw_ind_list[i] = list(full_ind2_list)
+
+    # create dictionary for those that need to use the decomposition function
+    # from forward info
+    dec_gate_ind_dict = {}
+    for i in cnot_ind:
+        ind_at_k = forw_ind_list[i][-1]
+        dec_gate_ind_dict[i] = ind_at_k
+        forw_ind_list[i].remove(ind_at_k)
+
+    # add other keys with only 1 step in the gray code
+    for i in range(6):
+        if len(full_dict[i]) == 1:
+            dec_gate_ind_dict[i] = 0
+        elif len(full_dict[i]) > 2:
+            for j in range(len(full_dict[i])):
+                if isinstance(full_dict[i][j], dict):
+                    dec_gate_ind_dict[i] = j
+
+    # sort the entire decomposition dictionary
+    dec_gate_ind_dict_sorted = {}
+    for i in range(6):
+        dec_gate_ind_dict_sorted[i] = dec_gate_ind_dict[i]
+
+    # create full dictionary with CNOT gates and insert in main full dict
+    for i in cnot_ind:
+        full_gray_code_for_two_level_gate_i = full_dict[i]
+        forw_gray_code = full_gray_code_for_two_level_gate_i[0]
+        gate_list = []
+        for j in forw_ind_list[i]:
+            ind_for_insert_cnot = j
+            gate_ctrl_targets = forw_gray_code[j]
+            ctrl_qubit = gate_ctrl_targets['controls ='][0]
+            targ_qubit = gate_ctrl_targets['targets ='][0]
+            full_dict[i][0][j] = Gate(
+                "CNOT", controls=ctrl_qubit, targets=targ_qubit)
+            # can skip extra step for backward gray code because except
+            # for the gates that need decomposition function, going
+            # forward and backward should be same gate info
+            full_dict[i][1] = Gate(
+                "CNOT", controls=ctrl_qubit, targets=targ_qubit)
+
+    # now decompose the 1 qubit non-trivial arrays
+    for i in range(6):
+        input_array = two_level_info[i][1].full()
+        full_gray_code_for_two_level_gate_i = full_dict[i]
+        if len(full_gray_code_for_two_level_gate_i) > 2:
+            full_gray_code = full_gray_code_for_two_level_gate_i
+            ind_to_insert_gates = dec_gate_ind_dict_sorted[i]
+            ctrl_targ_info = full_gray_code[ind_to_insert_gates]
+            ctrl_qubit = ctrl_targ_info['controls ='][0]
+            targ_qubit = ctrl_targ_info['targets ='][0]
+            gate_list = _two_qubit_last_target(
+                input_array, targ_qubit, ctrl_qubit)
+            full_gray_code[ind_to_insert_gates] = gate_list
+            full_dict[i] = full_gray_code
+        elif len(full_gray_code_for_two_level_gate_i) == 1:
+            forw_gray_code = full_gray_code_for_two_level_gate_i[0]
+            ind_to_insert_gates = dec_gate_ind_dict_sorted[i]
+            # in forward gray code
+            if isinstance(forw_gray_code, dict):
+                ctrl_qubit = forw_gray_code['controls ='][0]
+                targ_qubit = forw_gray_code['targets ='][0]
+                gate_list = _two_qubit_last_target(
+                    input_array, targ_qubit, ctrl_qubit)
+                full_dict[i] = gate_list
+        else:
+            forw_gray_code = full_gray_code_for_two_level_gate_i[0]
+            ind_to_insert_gates = dec_gate_ind_dict_sorted[i]
+            # in forward gray code
+            ctrl_targ_info = forw_gray_code[ind_to_insert_gates]
+            ctrl_qubit = ctrl_targ_info['controls ='][0]
+            targ_qubit = ctrl_targ_info['targets ='][0]
+            gate_list = _two_qubit_last_target(
+                input_array, targ_qubit, ctrl_qubit)
+            # forw_gray_code[ind_to_insert_gates] = gate_list
+            full_dict[i][0][ind_to_insert_gates] = gate_list
+    return(full_dict)
+
+
+def _CNOT_gate_to_last_target(step_dict_at_i):
+    """ If the two-level unitary does not describe a unitary with the target as
+    first/last target then CNOT gates are needed to get to extreme target
+    two-level unitary to be able to use known decomposition scheme.
+    """
+    # this could be done via SWAP and resolve_gates as well
+    if len(step_dict_at_i) == 1:
+        gate_info = step_dict_at_i[0]
+
+        num_qubits = len(gate_info['controls ='])+1
+
+        if gate_info['targets ='][0] != num_qubits-1:
+            ctrl_qubit = num_qubits-1
+            target_qubit = gate_info['targets ='][0]
+            CNOT1 = Gate("CNOT", controls=target_qubit, targets=ctrl_qubit)
+            CNOT2 = Gate("CNOT", controls=ctrl_qubit, targets=target_qubit)
+            CNOT3 = Gate("CNOT", controls=target_qubit, targets=ctrl_qubit)
+            gate_list = [CNOT1, CNOT2, CNOT3]
+            return(gate_list)
+        else:
+            return(step_dict_at_i)
+
 
 def decompose_general_qubit_gate(input_gate, num_qubits):
+    """ Returns a dictionary or a list of gates forming input gate and number
+    of qubits in the circuit describing the decomposition.
+    """
+
     check_gate(input_gate, num_qubits)
-    two_level_array = _decompose_to_two_level_arrays(
-        input_gate, num_qubits, expand=False)
 
-    # first object in two level array is a two-level gate with last qubit as
-    # target and others as control
-    last_target_qubit_array = two_level_array[0]
-    # because arrays are returned in a reversed order
-    last_target_qubit_array_index = last_target_qubit_array[0]
-    if last_target_qubit_array_index != [2**num_qubits-2, 2**num_qubits-1]:
-        raise MethodError("The chosen method cannot be used.")
+    if num_qubits == 1:
+        # To do - add choice of single qubit scheme
+        return(decompose_one_qubit_gate(input_gate, "ZYZ"), num_qubits)
+    elif num_qubits == 2:
+        return(_two_q_CNOT_gates(input_gate), num_qubits)
+    else:
+        two_level_array = _decompose_to_two_level_arrays(
+            input_gate, num_qubits, expand=False)
 
-    # look for the two-level matrix with first qubit as target and rest as
-    # controls i.e. want target qubit = 0
-    ind_for_0_target = _find_index_for_firstq_target(
-        two_level_array, num_qubits)
-    first_target_qubit_array = two_level_array[ind_for_0_target]
-    first_target_qubit_array_index = first_target_qubit_array[0]
+        # first object in two level array is a two-level gate with last qubit
+        # as target and others as control
+        last_target_qubit_array = two_level_array[0]
+        # because arrays are returned in a reversed order
+        last_target_qubit_array_index = last_target_qubit_array[0]
+        if last_target_qubit_array_index != [2**num_qubits-2, 2**num_qubits-1]:
+            raise MethodError("The chosen method cannot be used.")
 
-    # create a list of all two-level arrays without first or last qubit as
-    # targets
-    index_list = list(range(len(two_level_array)))
-    index_list.remove(0)
-    index_list.remove(ind_for_0_target)
-    return(index_list)
+        # look for the two-level matrix with first qubit as target and rest as
+        # controls i.e. want target qubit = 0
+        ind_for_0_target = _find_index_for_firstq_target(
+            two_level_array, num_qubits)
+        first_target_qubit_array = two_level_array[ind_for_0_target]
+        first_target_qubit_array_index = first_target_qubit_array[0]
+
+        # create a list of all two-level arrays without first or last qubit as
+        # targets
+        index_list = list(range(len(two_level_array)))
+        index_list.remove(0)
+        index_list.remove(ind_for_0_target)
+        return(index_list)

--- a/tests/decomposition_functions/test_general_qubit_decomposition.py
+++ b/tests/decomposition_functions/test_general_qubit_decomposition.py
@@ -1,0 +1,101 @@
+import numpy as np
+import cmath
+import pytest
+
+from qutip import (
+    Qobj, average_gate_fidelity, rand_unitary
+)
+from qutip_qip.circuit import QubitCircuit
+
+from qutip_qip.decompose._utility import _gray_code_gate_info
+
+from qutip_qip.decompose.decompose_general_qubit_gate import (
+    _decompose_to_two_level_arrays,
+    _two_qubit_lastq_target,
+    _two_qubit_firstq_target,
+    _find_index_for_firstq_target)
+
+
+@pytest.mark.parametrize("num_qubits", [2, 3, 4, 5, 6])
+def test_two_level_full_output(num_qubits):
+    """ Check if product of full two level array output is equal to the input.
+    """
+    input_gate = rand_unitary(2**num_qubits, dims=[[2] * num_qubits] * 2)
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=True)
+
+    product_of_U = array_decompose[-1]
+
+    for i in reversed(range(len(array_decompose)-1)):
+        product_of_U = product_of_U
+        product_of_U_calculated = np.dot(product_of_U, array_decompose[i])
+        product_of_U = product_of_U_calculated
+
+    product_of_U = Qobj(product_of_U, dims=[[2] * num_qubits] * 2)
+    fidelity_of_input_output = average_gate_fidelity(
+        product_of_U, input_gate
+    )
+    assert np.isclose(fidelity_of_input_output, 1.0)
+
+
+def test_two_qubit_lastq_target():
+    """ Checks output of two-level gate decomposition when target = 0 and
+    control qubit = 1. (ind1 = 2, ind2 = 3)
+    """
+    input_gate = rand_unitary(2**2, dims=[[2] * 2] * 2)
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, 2, expand=False)
+    lastq_target_ind = array_decompose[0]
+    gate_list = _two_qubit_lastq_target(lastq_target_ind)
+    qc = QubitCircuit(2, reverse_states=False)
+    qc.add_gates(gate_list)
+    calc_u = qc.compute_unitary()
+
+    # check fidelity
+    array_decompose_full = _decompose_to_two_level_arrays(
+        input_gate, 2, expand=True)
+    lastq_full_qobj = array_decompose_full[0]
+    fidelity_of_input_output = average_gate_fidelity(
+        calc_u, lastq_full_qobj
+    )
+    assert np.isclose(fidelity_of_input_output, 1.0)
+
+
+def test_two_qubit_firstq_target():
+    """ Checks output of two-level gate decomposition when target = 1 and
+    control qubit = 0. (ind1 = 1, ind2 = 3)
+    """
+    input_gate = rand_unitary(2**2, dims=[[2] * 2] * 2)
+    array_decompose = _decompose_to_two_level_arrays(
+        input_gate, 2, expand=False)
+    lastq_target_ind = array_decompose[1]
+    gate_list = _two_qubit_firstq_target(lastq_target_ind)
+    qc = QubitCircuit(2, reverse_states=False)
+    qc.add_gates(gate_list)
+    calc_u = qc.compute_unitary()
+
+    # check fidelity
+    array_decompose_full = _decompose_to_two_level_arrays(
+        input_gate, 2, expand=True)
+    lastq_full_qobj = array_decompose_full[1]
+    fidelity_of_input_output = average_gate_fidelity(
+        calc_u, lastq_full_qobj
+    )
+    assert np.isclose(fidelity_of_input_output, 1.0)
+
+
+@pytest.mark.parametrize("num_qubits", [2, 3, 4, 5, 6])
+def test_find_index_for_firstq_target(num_qubits):
+    """ Tests if the index of two-level where first qubit is target is found.
+    """
+    input_gate = rand_unitary(2**num_qubits, dims=[[2] * num_qubits] * 2)
+    two_level_arrays_expand = _decompose_to_two_level_arrays(
+        input_gate, num_qubits, expand=False)
+    two_level_matrix_position = _find_index_for_firstq_target(
+        two_level_arrays_expand, num_qubits)
+
+    # verify target is 0
+    ind1, ind2 = two_level_arrays_expand[two_level_matrix_position][0]
+    gray_code_sequence_at_pos = _gray_code_gate_info(ind1, ind2, num_qubits)
+    gray_code_gate = gray_code_sequence_at_pos[0]
+    assert gray_code_gate['targets ='][0] == 0


### PR DESCRIPTION
[GSoC Notebook - Deliverable.pdf](https://github.com/qutip/qutip-qip/files/7031142/GSoC.Notebook.-.Deliverable.pdf)

Tutorial of partially working code 
- full final output cannot be checked right now
- Last output in the notebook is not correct due to Toffoli gates being inserted improperly - the circuit should not have introduced ancillas - see figure in [`Decomposition scheme for qubits greater than 2`](https://purva-thakre.github.io/purva-blog/gsoc/qutip/final-gsoc/)

**New To-Do :**

- [ ] Change output of [`_gray_code_gate_info` ](https://github.com/qutip/qutip-qip/pull/90/files#diff-9b635d4decbf8dade1e4507b1a75a5954ab381fa8b3ebc606dc9d2737874e979R161)
        - do not combine into forward gray code and backward gray code
        - return gate info for gates in forward gray code info upto the two-level gate
        - information for two-level gate is returned in another list
- [ ] After above change, [`_paulix_for_control_0`](https://github.com/qutip/qutip-qip/pull/90/files#diff-9b635d4decbf8dade1e4507b1a75a5954ab381fa8b3ebc606dc9d2737874e979R295) will not need 2 separate loops depending on if there's only 1 controlled gate or it's a forward/backward code. 
       - it is important to keep in mind whatever gates are determined for forward gray code list, the backward gray code applies the same gates in a reverse order. (this could be done by checking if the forward_gray_code list is empty or not) 
- [ ] Add a function to iterate over full output of `_paulix_for_control_0` and add CNOT gates for n = 2
- [ ] After the output of all possible gates is a list, introduce a function to iterate over said list of forward gray code and add CNOT gates. 
       - [ ] If the number of qubits is n > 2, choose to stop decomposition at toffoli or go further (provide option)
       - [ ] If the chosen decomposition method is via using ancilla qubits then the gate target can only be last qubit - if we allow the first qubit to be a target, the number of ancillas being introduced doubles.
- [ ] The output of [`_two_q_CNOT_gates`](https://github.com/qutip/qutip-qip/pull/90/files#diff-4add9955651bf88c9e275a01f0238c95ade46f084379817c7d077227f85266f8R524) should be a dictionary of lists only - not nested dictionaries and lists
- [ ] Provide option [of decomposition scheme](https://github.com/qutip/qutip-qip/pull/90/files#diff-4add9955651bf88c9e275a01f0238c95ade46f084379817c7d077227f85266f8R915) for n = 1
- [ ] Provide option [of decomposition scheme](https://github.com/qutip/qutip-qip/pull/90/files#diff-4add9955651bf88c9e275a01f0238c95ade46f084379817c7d077227f85266f8R915) for n = 3 - keep toffoli undecomposed or not
- [ ] Provide option [of decomposition scheme](https://github.com/qutip/qutip-qip/pull/90/files#diff-4add9955651bf88c9e275a01f0238c95ade46f084379817c7d077227f85266f8R915) for n > 3 after the recursion scheme and ancilla outputs are same as input gate - another option to further decompose toffoli
- [ ] Define recursion scheme to decompose without ancillas
- [ ] Use recursion scheme to decompose n-qubit toffoli without ancillas (n>3)

     
