### PR TITLE
Separate the physical model into a Model class

### DIFF
--- a/doc/pulse-paper/pulse_simulation.py
+++ b/doc/pulse-paper/pulse_simulation.py
@@ -27,7 +27,7 @@ solver_result = processor.run_state(
     tlist=plot_time)
 
 mpl.rcParams['axes.prop_cycle'] = mpl.cycler(color=["#1f77b4"]) 
-fig1, ax1 = processor.plot_pulses(figsize=(LINEWIDTH/2, LINEWIDTH/4))
+fig1, ax1 = processor.plot_pulses(figsize=(LINEWIDTH/2, LINEWIDTH/4), use_control_latex=False)
 ax1[0].set_xlim(-0.5, np.pi/2 + 0.5)
 ax1[0].set_ylim(-0.1, 1.1)
 ax1[0].axhline(0)
@@ -39,11 +39,11 @@ fig1.show()
 # continuous pulse
 processor = Processor(1)
 processor.pulse_mode = "continuous"
-processor.add_control(sigmax())
+processor.add_control(sigmax(), label="sigmax")
 tlist = np.linspace(0., np.pi/2, 21)
 coeff = np.array(np.sin(2*tlist) * np.pi/2)
-processor.pulses[0].tlist = tlist
-processor.pulses[0].coeff = coeff
+processor.set_coeffs({"sigmax": coeff})
+processor.set_tlist({"sigmax": tlist})
 solver_result2 = processor.run_state(
     init_state=basis(2, 0),
     tlist=plot_time)

--- a/doc/source/apidoc/qutip_qip.device.rst
+++ b/doc/source/apidoc/qutip_qip.device.rst
@@ -13,9 +13,13 @@ qutip\_qip.device
    .. autosummary::
 
       Processor
+      Model
       ModelProcessor
       LinearSpinChain
       CircularSpinChain
+      SpinChainModel
       DispersiveCavityQED
+      CavityQEDModel
       SCQubits
+      SCQubitsModel
       OptPulseProcessor

--- a/src/qutip_qip/device/__init__.py
+++ b/src/qutip_qip/device/__init__.py
@@ -1,9 +1,13 @@
 """
 Simulation of quantum hardware.
 """
-from .processor import Processor
+from .processor import Processor, Model
 from .modelprocessor import ModelProcessor
-from .spinchain import SpinChain, LinearSpinChain, CircularSpinChain
-from .cavityqed import DispersiveCavityQED
+from .spinchain import (
+    LinearSpinChain,
+    CircularSpinChain,
+    SpinChainModel,
+)
+from .cavityqed import DispersiveCavityQED, CavityQEDModel
 from .optpulseprocessor import OptPulseProcessor
-from .circuitqed import *
+from .circuitqed import SCQubits, SCQubitsModel

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -139,7 +139,7 @@ class CavityQEDModel(Model):
     num_qubits : int
         The number of qubits.
     num_levels : int, optional
-        The truncation level of the resonator.
+        The truncation level of the Hilbert space for the resonator.
     **params :
         Keyword arguments for hardware parameters, in the unit of GHz.
         Qubit parameters can either be a float or a list of the length

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -132,7 +132,8 @@ class DispersiveCavityQED(ModelProcessor):
 
 class CavityQEDModel(Model):
     """
-    The physical model for :obj:`.DispersiveCavityQED`.
+    The physical model for a dispersive cavity-QED processor
+    (:obj:`.DispersiveCavityQED`).
 
     Parameters
     ----------

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -132,12 +132,12 @@ class DispersiveCavityQED(ModelProcessor):
 
 class CavityQEDModel(Model):
     """
-    The physical model for a dispersive cavity-QED system.
+    The physical model for :obj:`.DispersiveCavityQED`.
 
     Parameters
     ----------
     num_qubits : int
-        The number of component systems.
+        The number of qubits.
     num_levels : int, optional
         The truncation level of the resonator.
     **params :
@@ -201,7 +201,7 @@ class CavityQEDModel(Model):
 
     def _set_up_controls(self):
         """
-        Generate the Hamiltonians for the spinchain model and save them in the
+        Generate the Hamiltonians for the cavity-qed model and save them in the
         attribute `ctrls`.
 
         Parameters

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -264,7 +264,7 @@ class CavityQEDModel(Model):
                 "The rotating-wave approximation might not be valid."
             )
 
-    def get_latex_str(self):
+    def get_control_latex(self):
         """
         Get the labels for each Hamiltonian.
         It is used in the method method :meth:`.Processor.plot_pulses`.

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -169,7 +169,7 @@ class SCQubitsModel(Model):
             # projector to the 0 and 1 subspace
             projector1 = (
                 basis(d1, 0) * basis(d1, 0).dag()
-                + basis(d1, 1) * basis(d2, 1).dag()
+                + basis(d1, 1) * basis(d1, 1).dag()
             )
             projector2 = (
                 basis(d2, 0) * basis(d2, 0).dag()

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -61,7 +61,8 @@ class SCQubits(ModelProcessor):
 
 class SCQubitsModel(Model):
     """
-    The physical model for :obj:`.SCQubits`.
+    The physical model for superconducting-qubit model processor
+    (:obj:`.SCQubits`) with fixed frequency.
 
     Parameters
     ----------

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -61,12 +61,12 @@ class SCQubits(ModelProcessor):
 
 class SCQubitsModel(Model):
     """
-    The physical model for superconducting qubits with fixed frequency.
+    The physical model for :obj:`.SCQubits`.
 
     Parameters
     ----------
     num_qubits: int
-        The number of component systems.
+        The number of qubits.
     dims: list, optional
         The dimension of each component system.
         Default value is a qubit system of ``dim=[2,2,2,...,2]``.

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -265,7 +265,7 @@ class SCQubitsModel(Model):
         # Times 2 because we use -2πZX/4 as operators
         self.params["zx_coeff"] = np.asarray(zx_coeff) * 2
 
-    def get_latex_str(self):
+    def get_control_latex(self):
         """
         Get the labels for each Hamiltonian.
         It is used in the method method :meth:`.Processor.plot_pulses`.

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -31,65 +31,82 @@ class SCQubits(ModelProcessor):
     Parameters
     ----------
     num_qubits: int
-        Number of qubits
-    t1, t2: float or list, optional
-        Coherence time for all qubit or each qubit
+        The number of qubits in the system.
+    dims: list, optional
+        The dimension of each component system.
+        Default value is a qubit system of ``dim=[2,2,2,...,2]``.
     zz_crosstalk: bool, optional
-        if zz cross talk is included.
+        If ZZ cross-talk is included.
     **params:
-        Keyword argument for hardware parameters, in the unit of GHz.
-        Each can should be given as list:
-
-        - ``wq``: qubit bare frequency, default 5.15 and 5.09
-          for each pair of superconducting qubits,
-          e.g. ``[5.15, 5.09, 5.15, ...]``
-        - ``wr``: resonator bare frequency, default ``[5.96]*num_qubits``
-        - ``g``: The coupling strength between the resonator and the qubits,
-          default ``[0.1]*(num_qubits - 1)``
-        - ``alpha``: anharmonicity for each superconducting qubit,
-          default ``[-0.3]*num_qubits``
-        - ``omega_single``: control strength for single-qubit gate,
-          default ``[0.01]*num_qubits``
-        - ``omega_cr``: control strength for cross resonance gate,
-          default ``[0.01]*num_qubits``
-
-    Attributes
-    ----------
-    dims: list
-        Dimension of the subsystem, e.g. ``[3,3,3]``.
-    pulse_mode: "discrete" or "continuous"
-        Given pulse is treated as continuous pulses or discrete step functions.
-    native_gates: list of str
-        The native gate sets
+        Hardware parameters. See :obj:`SCQubitsModel`.
     """
 
-    def __init__(
-        self, num_qubits, t1=None, t2=None, zz_crosstalk=False, **params
-    ):
-        super(SCQubits, self).__init__(num_qubits, t1=t1, t2=t2)
-        self.num_qubits = num_qubits
-        self.dims = [3] * num_qubits
-        self.pulse_mode = "continuous"
-        params = {}
-        params["num_qubits"] = num_qubits
-        params["dims"] = self.dims
-        self.model = SCQubitsModel(**params)
-        self.params = self.model.params
+    def __init__(self, num_qubits, dims=None, zz_crosstalk=False, **params):
+        if dims is None:
+            dims = [3] * num_qubits
+        model = SCQubitsModel(
+            num_qubits=num_qubits,
+            dims=dims,
+            zz_crosstalk=zz_crosstalk,
+            **params,
+        )
+        super(SCQubits, self).__init__(model=model)
         self.native_gates = ["RX", "RY", "CNOT"]
         self._default_compiler = SCQubitsCompiler
-        if zz_crosstalk:
-            self.add_noise(ZZCrossTalk(self.params))
+        self.pulse_mode = "continuous"
 
     def topology_map(self, qc):
         return to_chain_structure(qc)
 
 
 class SCQubitsModel(Model):
-    def __init__(self, **params):
+    """
+    The physical model for superconducting qubits with fixed frequency.
+
+    Parameters
+    ----------
+    num_qubits: int
+        The number of component systems.
+    dims: list, optional
+        The dimension of each component system.
+        Default value is a qubit system of ``dim=[2,2,2,...,2]``.
+    zz_crosstalk: bool, optional
+        If ZZ cross-talk is included.
+    **params:
+        Keyword arguments for hardware parameters, in the unit of GHz.
+        Each should be given as list:
+
+        - wq : list, optional
+            Qubits bare frequency, default 5.15 and 5.09
+            for each pair of superconducting qubits,
+            default ``[5.15, 5.09, 5.15, ...]``.
+        - wr : list, optional
+            Resonator bare frequency, default ``[5.96]*num_qubits``.
+        - g : list, optional
+            The coupling strength between the resonator and the qubits,
+            default ``[0.1]*(num_qubits - 1)``.
+        - alpha : list, optional
+            Anharmonicity for each superconducting qubit,
+            default ``[-0.3]*num_qubits``.
+        - omega_single : list, optional
+            Control strength for single-qubit gate,
+            default ``[0.01]*num_qubits``.
+        - omega_cr : list, optional
+            Control strength for cross resonance gate,
+            default ``[0.01]*num_qubits``.
+        - t1 : float or list, optional
+            Characterize the amplitude damping for each qubit.
+        - t2 : list of list, optional
+            Characterize the total dephasing for each qubit.
+    """
+
+    def __init__(self, num_qubits, dims=None, zz_crosstalk=False, **params):
+        self.num_qubits = num_qubits
+        self.dims = dims
         self.params = {
             "wq": np.array(
-                ((5.15, 5.09) * int(np.ceil(params["num_qubits"] / 2)))[
-                    : params["num_qubits"]
+                ((5.15, 5.09) * int(np.ceil(self.num_qubits / 2)))[
+                    : self.num_qubits
                 ]
             ),
             "wr": 5.96,
@@ -103,21 +120,21 @@ class SCQubitsModel(Model):
         self._drift = []
         self._set_up_drift()
         self._controls = self._set_up_controls()
+        self._noise = []
+        if zz_crosstalk:
+            self._noise.append(ZZCrossTalk(self.params))
 
     def _set_up_drift(self):
-        for m in range(self.params["num_qubits"]):
-            destroy_op = destroy(self.params["dims"][m])
+        for m in range(self.num_qubits):
+            destroy_op = destroy(self.dims[m])
             coeff = 2 * np.pi * self.params["alpha"][m] / 2.0
             self._drift.append(
                 (coeff * destroy_op.dag() ** 2 * destroy_op ** 2, [m])
             )
 
-    def get_all_drift(self):
-        return self._drift
-
     @property
     def _old_index_label_map(self):
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         return (
             ["sx" + str(i) for i in range(num_qubits)]
             + ["sz" + str(i) for i in range(num_qubits)]
@@ -125,24 +142,14 @@ class SCQubitsModel(Model):
             + ["zx" + str(i + 1) + str(i) for i in range(num_qubits)]
         )
 
-    def get_control(self, label):
-        """label should be hashable"""
-        _old_index_label_map = self._old_index_label_map
-        if isinstance(label, int):
-            label = _old_index_label_map[label]
-        return self._controls[label]
-
-    def get_control_labels(self):
-        return list(self._controls.keys())
-
     def _set_up_controls(self):
         """
         Setup the operators.
         We use 2π σ/2 as the single-qubit control Hamiltonian and
         -2πZX/4 as the two-qubit Hamiltonian.
         """
-        num_qubits = self.params["num_qubits"]
-        dims = self.params["dims"]
+        num_qubits = self.num_qubits
+        dims = self.dims
         controls = {}
 
         for m in range(num_qubits):
@@ -192,7 +199,7 @@ class SCQubitsModel(Model):
         """
         Compute the dressed frequency and the interaction strength.
         """
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         for name in ["alpha", "omega_single", "omega_cr"]:
             self.params[name] = _to_array(self.params[name], num_qubits)
         self.params["wr"] = _to_array(self.params["wr"], num_qubits - 1)
@@ -265,15 +272,15 @@ class SCQubitsModel(Model):
         It is a 2-d nested list, in the plot,
         a different color will be used for each sublist.
         """
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         labels = [
             {f"sx{n}": f"$\sigma_x^{n}$" for n in range(num_qubits)},
             {f"sy{n}": f"$\sigma_y^{n}$" for n in range(num_qubits)},
         ]
         label_zx = {}
         for m in range(num_qubits - 1):
-            label_zx[f"zx{m}{m+1}"] = r"$ZX^{"+f"{m}{m+1}"+r"}$"
-            label_zx[f"zx{m+1}{m}"] = r"$ZX^{"+f"{m+1}{m}"+r"}$"
+            label_zx[f"zx{m}{m+1}"] = r"$ZX^{" + f"{m}{m+1}" + r"}$"
+            label_zx[f"zx{m+1}{m}"] = r"$ZX^{" + f"{m+1}{m}" + r"}$"
 
         labels.append(label_zx)
         return labels

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -274,8 +274,8 @@ class SCQubitsModel(Model):
         """
         num_qubits = self.num_qubits
         labels = [
-            {f"sx{n}": f"$\sigma_x^{n}$" for n in range(num_qubits)},
-            {f"sy{n}": f"$\sigma_y^{n}$" for n in range(num_qubits)},
+            {f"sx{n}": r"$\sigma_x" + f"^{n}$" for n in range(num_qubits)},
+            {f"sy{n}": r"$\sigma_y" + f"^{n}$" for n in range(num_qubits)},
         ]
         label_zx = {}
         for m in range(num_qubits - 1):

--- a/src/qutip_qip/device/circuitqed.py
+++ b/src/qutip_qip/device/circuitqed.py
@@ -1,10 +1,14 @@
+from copy import deepcopy
+
 import numpy as np
 
 from qutip import qeye, tensor, destroy, basis
-from .modelprocessor import ModelProcessor
+from .processor import Model
+from .modelprocessor import ModelProcessor, _to_array
 from ..transpiler import to_chain_structure
 from ..compiler import SCQubitsCompiler
 from ..noise import ZZCrossTalk
+from ..operations import expand_operator
 
 
 __all__ = ["SCQubits"]
@@ -66,54 +70,95 @@ class SCQubits(ModelProcessor):
         self.num_qubits = num_qubits
         self.dims = [3] * num_qubits
         self.pulse_mode = "continuous"
-        self.params = {
-            "wq": np.array(
-                ((5.15, 5.09) * int(np.ceil(self.num_qubits / 2)))[
-                    : self.num_qubits
-                ]
-            ),
-            "wr": self.to_array(5.96, num_qubits - 1),
-            "alpha": self.to_array(-0.3, num_qubits),
-            "g": self.to_array(0.1, 2 * (num_qubits - 1)),
-            "omega_single": self.to_array(0.01, num_qubits),
-            "omega_cr": self.to_array(0.01, num_qubits),
-        }
-        if params is not None:
-            self.params.update(params)
-        self.set_up_ops()
-        self.set_up_params()
+        params = {}
+        params["num_qubits"] = num_qubits
+        params["dims"] = self.dims
+        self.model = SCQubitsModel(**params)
+        self.params = self.model.params
         self.native_gates = ["RX", "RY", "CNOT"]
         self._default_compiler = SCQubitsCompiler
         if zz_crosstalk:
             self.add_noise(ZZCrossTalk(self.params))
 
-    def set_up_ops(self):
+    def topology_map(self, qc):
+        return to_chain_structure(qc)
+
+
+class SCQubitsModel(Model):
+    def __init__(self, **params):
+        self.params = {
+            "wq": np.array(
+                ((5.15, 5.09) * int(np.ceil(params["num_qubits"] / 2)))[
+                    : params["num_qubits"]
+                ]
+            ),
+            "wr": 5.96,
+            "alpha": -0.3,
+            "g": 0.1,
+            "omega_single": 0.01,
+            "omega_cr": 0.01,
+        }
+        self.params.update(deepcopy(params))
+        self._compute_params()
+        self._drift = []
+        self._set_up_drift()
+        self._controls = self._set_up_controls()
+
+    def _set_up_drift(self):
+        for m in range(self.params["num_qubits"]):
+            destroy_op = destroy(self.params["dims"][m])
+            coeff = 2 * np.pi * self.params["alpha"][m] / 2.0
+            self._drift.append(
+                (coeff * destroy_op.dag() ** 2 * destroy_op ** 2, [m])
+            )
+
+    def get_all_drift(self):
+        return self._drift
+
+    @property
+    def _old_index_label_map(self):
+        num_qubits = self.params["num_qubits"]
+        return (
+            ["sx" + str(i) for i in range(num_qubits)]
+            + ["sz" + str(i) for i in range(num_qubits)]
+            + ["zx" + str(i) + str(i + 1) for i in range(num_qubits)]
+            + ["zx" + str(i + 1) + str(i) for i in range(num_qubits)]
+        )
+
+    def get_control(self, label):
+        """label should be hashable"""
+        _old_index_label_map = self._old_index_label_map
+        if isinstance(label, int):
+            label = _old_index_label_map[label]
+        return self._controls[label]
+
+    def get_control_labels(self):
+        return list(self._controls.keys())
+
+    def _set_up_controls(self):
         """
         Setup the operators.
         We use 2π σ/2 as the single-qubit control Hamiltonian and
         -2πZX/4 as the two-qubit Hamiltonian.
         """
-        for m in range(self.num_qubits):
-            destroy_op = destroy(self.dims[m])
-            coeff = 2 * np.pi * self.params["alpha"][m] / 2.0
-            self.add_drift(
-                coeff * destroy_op.dag() ** 2 * destroy_op ** 2, targets=[m]
-            )
+        num_qubits = self.params["num_qubits"]
+        dims = self.params["dims"]
+        controls = {}
 
-        for m in range(self.num_qubits):
-            destroy_op = destroy(self.dims[m])
+        for m in range(num_qubits):
+            destroy_op = destroy(dims[m])
             op = destroy_op + destroy_op.dag()
-            self.add_control(2 * np.pi / 2 * op, [m], label="sx" + str(m))
+            controls["sx" + str(m)] = (2 * np.pi / 2 * op, [m])
 
-        for m in range(self.num_qubits):
-            destroy_op = destroy(self.dims[m])
+        for m in range(num_qubits):
+            destroy_op = destroy(dims[m])
             op = destroy_op * (-1.0j) + destroy_op.dag() * 1.0j
-            self.add_control(2 * np.pi / 2 * op, [m], label="sy" + str(m))
+            controls["sy" + str(m)] = (2 * np.pi / 2 * op, [m])
 
-        for m in range(self.num_qubits - 1):
+        for m in range(num_qubits - 1):
             # For simplicity, we neglect leakage in two-qubit gates.
-            d1 = self.dims[m]
-            d2 = self.dims[m + 1]
+            d1 = dims[m]
+            d2 = dims[m + 1]
             # projector to the 0 and 1 subspace
             projector1 = (
                 basis(d1, 0) * basis(d1, 0).dag()
@@ -133,38 +178,42 @@ class SCQubits(ModelProcessor):
             )
             destroy_op2 = destroy(d2)
             x = projector2 * (destroy_op2.dag() + destroy_op2) / 2 * projector2
-            self.add_control(
+            controls["zx" + str(m) + str(m + 1)] = (
                 2 * np.pi * tensor([z, x]),
                 [m, m + 1],
-                label="zx" + str(m) + str(m + 1),
             )
-            self.add_control(
+            controls["zx" + str(m + 1) + str(m)] = (
                 2 * np.pi * tensor([x, z]),
                 [m, m + 1],
-                label="zx" + str(m + 1) + str(m),
             )
+        return controls
 
-    def set_up_params(self):
+    def _compute_params(self):
         """
         Compute the dressed frequency and the interaction strength.
         """
+        num_qubits = self.params["num_qubits"]
+        for name in ["alpha", "omega_single", "omega_cr"]:
+            self.params[name] = _to_array(self.params[name], num_qubits)
+        self.params["wr"] = _to_array(self.params["wr"], num_qubits - 1)
+        self.params["g"] = _to_array(self.params["g"], 2 * (num_qubits - 1))
         g = self.params["g"]
         wq = self.params["wq"]
         wr = self.params["wr"]
         alpha = self.params["alpha"]
         # Dressed qubit frequency
         wq_dr = []
-        for i in range(self.num_qubits):
+        for i in range(num_qubits):
             tmp = wq[i]
             if i != 0:
                 tmp += g[2 * i - 1] ** 2 / (wq[i] - wr[i - 1])
-            if i != (self.num_qubits - 1):
+            if i != (num_qubits - 1):
                 tmp += g[2 * i] ** 2 / (wq[i] - wr[i])
             wq_dr.append(tmp)
         self.params["wq_dressed"] = wq_dr
         # Dressed resonator frequency
         wr_dr = []
-        for i in range(self.num_qubits - 1):
+        for i in range(num_qubits - 1):
             tmp = wr[i]
             tmp -= g[2 * i] ** 2 / (wq[i] - wr[i] + alpha[i])
             tmp -= g[2 * i + 1] ** 2 / (wq[i + 1] - wr[i] + alpha[i])
@@ -172,7 +221,7 @@ class SCQubits(ModelProcessor):
         self.params["wr_dressed"] = wr_dr
         # Effective qubit coupling strength
         J = []
-        for i in range(self.num_qubits - 1):
+        for i in range(num_qubits - 1):
             tmp = (
                 g[2 * i]
                 * g[2 * i + 1]
@@ -186,7 +235,7 @@ class SCQubits(ModelProcessor):
         # Effective ZX strength
         zx_coeff = []
         omega_cr = self.params["omega_cr"]
-        for i in range(self.num_qubits - 1):
+        for i in range(num_qubits - 1):
             tmp = (
                 J[i]
                 * omega_cr[i]
@@ -196,7 +245,7 @@ class SCQubits(ModelProcessor):
                 )
             )
             zx_coeff.append(tmp)
-        for i in range(self.num_qubits - 1, 0, -1):
+        for i in range(num_qubits - 1, 0, -1):
             tmp = (
                 J[i - 1]
                 * omega_cr[i]
@@ -209,23 +258,22 @@ class SCQubits(ModelProcessor):
         # Times 2 because we use -2πZX/4 as operators
         self.params["zx_coeff"] = np.asarray(zx_coeff) * 2
 
-    def get_operators_labels(self):
+    def get_latex_str(self):
         """
         Get the labels for each Hamiltonian.
         It is used in the method method :meth:`.Processor.plot_pulses`.
         It is a 2-d nested list, in the plot,
         a different color will be used for each sublist.
         """
+        num_qubits = self.params["num_qubits"]
         labels = [
-            [r"$\sigma_x^%d$" % n for n in range(self.num_qubits)],
-            [r"$\sigma_y^%d$" % n for n in range(self.num_qubits)],
+            {f"sx{n}": f"$\sigma_x^{n}$" for n in range(num_qubits)},
+            {f"sy{n}": f"$\sigma_y^{n}$" for n in range(num_qubits)},
         ]
-        label_zx = []
-        for m in range(self.num_qubits - 1):
-            label_zx.append(r"$ZX^{%d%d}$" % (m, m + 1))
-            label_zx.append(r"$ZX^{%d%d}$" % (m + 1, m))
+        label_zx = {}
+        for m in range(num_qubits - 1):
+            label_zx[f"zx{m}{m+1}"] = r"$ZX^{"+f"{m}{m+1}"+r"}$"
+            label_zx[f"zx{m+1}{m}"] = r"$ZX^{"+f"{m+1}{m}"+r"}$"
+
         labels.append(label_zx)
         return labels
-
-    def topology_map(self, qc):
-        return to_chain_structure(qc)

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -27,36 +27,40 @@ class ModelProcessor(Processor):
 
     Parameters
     ----------
-    num_qubits: int
+    num_qubits: int, optional
         The number of component systems.
+        It replaces the old API ``N``.
+
+    dims: list, optional
+        The dimension of each component system.
+        Default value is a qubit system of ``dim=[2,2,2,...,2]``.
 
     correct_global_phase: boolean, optional
         If true, the analytical solution will track the global phase. It
         has no effect on the numerical solution.
 
-    t1: list or float
-        Characterize the decoherence of amplitude damping for
-        each qubit. A list of size `num_qubits` or a float for all qubits.
-
-    t2: list of float
-        Characterize the decoherence of dephasing for
-        each qubit. A list of size `num_qubits` or a float for all qubits.
-
-    Attributes
-    ----------
-    correct_global_phase: float
-        Save the global phase, the analytical solution
-        will track the global phase.
-        It has no effect on the numerical solution.
+    **params:
+        - t1: float or list, optional
+            Characterize the amplitude damping for each qubit.
+            A list of size `num_qubits` or a float for all qubits.
+        - t2: float or list, optional
+            Characterize the total dephasing for each qubit.
+            A list of size `num_qubits` or a float for all qubits.
     """
 
     def __init__(
-        self, num_qubits, correct_global_phase=True, t1=None, t2=None, N=None
+        self,
+        num_qubits=None,
+        dims=None,
+        correct_global_phase=True,
+        model=None,
+        **params
     ):
-        super(ModelProcessor, self).__init__(num_qubits, t1=t1, t2=t2, N=None)
+        super(ModelProcessor, self).__init__(
+            num_qubits=num_qubits, dims=dims, model=model, **params
+        )
         self.correct_global_phase = correct_global_phase
         self.global_phase = 0.0
-        self.params = {}
         self.native_gates = None
         self.transpile_functions = []
         self._default_compiler = None

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -8,6 +8,7 @@ from ..operations import globalphase
 from ..circuit import QubitCircuit
 from .processor import Processor
 from ..compiler import GateCompiler
+from ..pulse import Pulse
 
 
 __all__ = ["ModelProcessor"]
@@ -55,19 +56,10 @@ class ModelProcessor(Processor):
         super(ModelProcessor, self).__init__(num_qubits, t1=t1, t2=t2, N=None)
         self.correct_global_phase = correct_global_phase
         self.global_phase = 0.0
-        self._params = {}
+        self.params = {}
         self.native_gates = None
         self.transpile_functions = []
         self._default_compiler = None
-
-    def to_array(self, params, num_qubits):
-        """
-        Transfer a parameter to an array.
-        """
-        if isinstance(params, numbers.Real):
-            return np.asarray([params] * num_qubits)
-        elif isinstance(params, Iterable):
-            return np.asarray(params)
 
     def set_up_params(self):
         """
@@ -79,19 +71,6 @@ class ModelProcessor(Processor):
         All parameters will be multiplied by 2*pi for simplicity
         """
         raise NotImplementedError("Parameters should be defined in subclass.")
-
-    @property
-    def params(self):
-        """
-        dict: A Python dictionary contains the name
-        and the value of the parameters
-        in the physical realization, such as laser frequency, detuning etc.
-        """
-        return self._params
-
-    @params.setter
-    def params(self, par):
-        self._params = par
 
     def run_state(
         self, init_state=None, analytical=False, qc=None, states=None, **kwargs
@@ -256,6 +235,16 @@ class ModelProcessor(Processor):
         else:
             raise ValueError("No compiler defined.")
         # Save compiler pulses
-        self.set_all_coeffs(coeffs)
-        self.set_all_tlist(tlist)
+        self.set_coeffs(coeffs)
+        self.set_tlist(tlist)
         return tlist, coeffs
+
+
+def _to_array(params, num_qubits):
+    """
+    Transfer a parameter to an array.
+    """
+    if isinstance(params, numbers.Real):
+        return np.asarray([params] * num_qubits)
+    elif isinstance(params, Iterable):
+        return np.asarray(params)

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -28,7 +28,7 @@ class ModelProcessor(Processor):
     Parameters
     ----------
     num_qubits: int, optional
-        The number of component systems.
+        The number of qubits.
         It replaces the old API ``N``.
 
     dims: list, optional

--- a/src/qutip_qip/device/optpulseprocessor.py
+++ b/src/qutip_qip/device/optpulseprocessor.py
@@ -45,12 +45,12 @@ class OptPulseProcessor(Processor):
             A list of size `num_qubits` or a float for all qubits.
     """
 
-    def __init__(self, num_qubits, drift=None, dims=None, **params):
+    def __init__(self, num_qubits=None, drift=None, dims=None, **params):
         super(OptPulseProcessor, self).__init__(
             num_qubits, dims=dims, **params
         )
         if drift is not None:
-            self.add_drift(drift, list(range(num_qubits)))
+            self.add_drift(drift, list(range(self.num_qubits)))
         self.spline_kind = "step_func"
 
     def load_circuit(
@@ -77,11 +77,11 @@ class OptPulseProcessor(Processor):
 
         >>> from qutip_qip.circuit import QubitCircuit
         >>> from qutip_qip.device import OptPulseProcessor
-        >>> qc = QubitCircuit(num_qubits=1)
+        >>> qc = QubitCircuit(1)
         >>> qc.add_gate("SNOT", 0)
         >>> num_tslots = 10
         >>> evo_time = 10
-        >>> processor = OptPulseProcessor(num_qubits=1, drift=sigmaz())
+        >>> processor = OptPulseProcessor(1, drift=sigmaz())
         >>> processor.add_control(sigmax())
         >>> # num_tslots and evo_time are two keyword arguments
         >>> tlist, coeffs = processor.load_circuit(\
@@ -91,12 +91,11 @@ class OptPulseProcessor(Processor):
 
         >>> from qutip_qip.circuit import QubitCircuit
         >>> from qutip_qip.device import OptPulseProcessor
-        >>> qc = QubitCircuit(num_qubits=2)
+        >>> qc = QubitCircuit(2)
         >>> qc.add_gate("SNOT", 0)
         >>> qc.add_gate("SWAP", targets=[0, 1])
         >>> qc.add_gate('CNOT', controls=1, targets=[0])
-        >>> processor = OptPulseProcessor(\
-                num_qubits=2, drift=tensor([sigmaz()]*2))
+        >>> processor = OptPulseProcessor(2, drift=tensor([sigmaz()]*2))
         >>> processor.add_control(sigmax(), cyclic_permutation=True)
         >>> processor.add_control(sigmay(), cyclic_permutation=True)
         >>> processor.add_control(tensor([sigmay(), sigmay()]))

--- a/src/qutip_qip/device/optpulseprocessor.py
+++ b/src/qutip_qip/device/optpulseprocessor.py
@@ -192,8 +192,11 @@ class OptPulseProcessor(Processor):
                         qobj, len(self.dims), targets=targets, dims=self.dims
                     )
                     for (qobj, targets) in self.model.get_all_drift()
-                ]
-                ,start=Qobj(np.zeros(full_ctrls_hams[0].shape), dims=[self.dims, self.dims])
+                ],
+                Qobj(
+                    np.zeros(full_ctrls_hams[0].shape),
+                    dims=[self.dims, self.dims],
+                ),
             )
 
             result = cpo.optimize_pulse_unitary(

--- a/src/qutip_qip/device/optpulseprocessor.py
+++ b/src/qutip_qip/device/optpulseprocessor.py
@@ -26,30 +26,31 @@ class OptPulseProcessor(Processor):
 
     Parameters
     ----------
-    N: int
+    num_qubits : int
         The number of component systems.
 
     drift: `:class:`qutip.Qobj`
         The drift Hamiltonian. The size must match the whole quantum system.
 
-    t1: list or float
-        Characterize the decoherence of amplitude damping for
-        each qubit. A list of size `N` or a float for all qubits.
-
-    t2: list of float
-        Characterize the decoherence of dephasing for
-        each qubit. A list of size `N` or a float for all qubits.
-
     dims: list
         The dimension of each component system.
-        Default value is a
-        qubit system of ``dim=[2,2,2,...,2]``
+        Default value is a qubit system of ``dim=[2,2,2,...,2]``
+
+    **params:
+        - t1 : float or list, optional
+            Characterize the amplitude damping for each qubit.
+            A list of size `num_qubits` or a float for all qubits.
+        - t2 : float or list, optional
+            Characterize the total dephasing for each qubit.
+            A list of size `num_qubits` or a float for all qubits.
     """
 
-    def __init__(self, N, drift=None, t1=None, t2=None, dims=None):
-        super(OptPulseProcessor, self).__init__(N, t1=t1, t2=t2, dims=dims)
+    def __init__(self, num_qubits, drift=None, dims=None, **params):
+        super(OptPulseProcessor, self).__init__(
+            num_qubits, dims=dims, **params
+        )
         if drift is not None:
-            self.add_drift(drift, list(range(N)))
+            self.add_drift(drift, list(range(num_qubits)))
         self.spline_kind = "step_func"
 
     def load_circuit(
@@ -76,11 +77,11 @@ class OptPulseProcessor(Processor):
 
         >>> from qutip_qip.circuit import QubitCircuit
         >>> from qutip_qip.device import OptPulseProcessor
-        >>> qc = QubitCircuit(N=1)
+        >>> qc = QubitCircuit(num_qubits=1)
         >>> qc.add_gate("SNOT", 0)
         >>> num_tslots = 10
         >>> evo_time = 10
-        >>> processor = OptPulseProcessor(N=1, drift=sigmaz())
+        >>> processor = OptPulseProcessor(num_qubits=1, drift=sigmaz())
         >>> processor.add_control(sigmax())
         >>> # num_tslots and evo_time are two keyword arguments
         >>> tlist, coeffs = processor.load_circuit(\
@@ -90,12 +91,12 @@ class OptPulseProcessor(Processor):
 
         >>> from qutip_qip.circuit import QubitCircuit
         >>> from qutip_qip.device import OptPulseProcessor
-        >>> qc = QubitCircuit(N=2)
+        >>> qc = QubitCircuit(num_qubits=2)
         >>> qc.add_gate("SNOT", 0)
         >>> qc.add_gate("SWAP", targets=[0, 1])
         >>> qc.add_gate('CNOT', controls=1, targets=[0])
         >>> processor = OptPulseProcessor(\
-                N=2, drift=tensor([sigmaz()]*2))
+                num_qubits=2, drift=tensor([sigmaz()]*2))
         >>> processor.add_control(sigmax(), cyclic_permutation=True)
         >>> processor.add_control(sigmay(), cyclic_permutation=True)
         >>> processor.add_control(tensor([sigmay(), sigmay()]))

--- a/src/qutip_qip/device/optpulseprocessor.py
+++ b/src/qutip_qip/device/optpulseprocessor.py
@@ -176,16 +176,6 @@ class OptPulseProcessor(Processor):
             if gates is not None and setting_args:
                 kwargs.update(setting_args[gates[prop_ind]])
 
-            # FIXME use model
-            full_drift_ham = sum(
-                [
-                    expand_operator(
-                        qobj, len(self.dims), targets=targets, dims=self.dims
-                    )
-                    for (qobj, targets) in self.model.get_all_drift()
-                ]
-            )
-
             control_labels = self.model.get_control_labels()
             full_ctrls_hams = []
             for label in control_labels:
@@ -195,6 +185,17 @@ class OptPulseProcessor(Processor):
                         qobj, len(self.dims), targets=targets, dims=self.dims
                     )
                 )
+
+            full_drift_ham = sum(
+                [
+                    expand_operator(
+                        qobj, len(self.dims), targets=targets, dims=self.dims
+                    )
+                    for (qobj, targets) in self.model.get_all_drift()
+                ]
+                ,start=Qobj(np.zeros(full_ctrls_hams[0].shape), dims=[self.dims, self.dims])
+            )
+
             result = cpo.optimize_pulse_unitary(
                 full_drift_ham, full_ctrls_hams, U_0, U_targ, **kwargs
             )

--- a/src/qutip_qip/device/optpulseprocessor.py
+++ b/src/qutip_qip/device/optpulseprocessor.py
@@ -27,7 +27,7 @@ class OptPulseProcessor(Processor):
     Parameters
     ----------
     num_qubits : int
-        The number of component systems.
+        The number of qubits.
 
     drift: `:class:`qutip.Qobj`
         The drift Hamiltonian. The size must match the whole quantum system.

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -59,13 +59,13 @@ class Processor(object):
         If other parameters, such as `t1` is given as input,
         it will overwrite those saved in :obj:`Processor.model.params`.
 
-    **params:
-        - t1 : float or list, optional
-            Characterize the amplitude damping for each qubit.
-            A list of size `num_qubits` or a float for all qubits.
-        - t2 : float or list, optional
-            Characterize the total dephasing for each qubit.
-            A list of size `num_qubits` or a float for all qubits.
+    t1 : float or list, optional
+        Characterize the amplitude damping for each qubit.
+        A list of size `num_qubits` or a float for all qubits.
+
+    t2 : float or list, optional
+        Characterize the total dephasing for each qubit.
+        A list of size `num_qubits` or a float for all qubits.
     """
 
     def __init__(
@@ -75,18 +75,15 @@ class Processor(object):
         spline_kind="step_func",
         model=None,
         N=None,
-        **params
+        t1=None,
+        t2=None,
     ):
         num_qubits = num_qubits if num_qubits is not None else N
         if model is None:
-            self.model = Model(num_qubits=num_qubits, dims=dims, **params)
+            self.model = Model(num_qubits=num_qubits, dims=dims, t1=t1, t2=t2)
         else:
             self.model = model
-            self.model.num_qubits = (
-                num_qubits if num_qubits is not None else self.model.num_qubits
-            )
-            self.model.dims = dims if dims is not None else self.model.dims
-            self.model.params.update(deepcopy(params))
+
         self.pulses = []
         # FIXME # Think about the handling of spline_kind.
         self.spline_kind = spline_kind
@@ -751,7 +748,7 @@ class Processor(object):
 
         num_steps: int, optional
             Number of time steps in the plot.
-        
+
         pulse_labels: list of dict, optional
             A map between pulse labels and the labels shown in the y axis.
             E.g. ``[{"sx": "sigmax"}]``.
@@ -796,8 +793,9 @@ class Processor(object):
 
         # choose labels
         if pulse_labels is None:
-            if use_control_latex and \
-                not hasattr(self.model, "get_control_latex"):
+            if use_control_latex and not hasattr(
+                self.model, "get_control_latex"
+            ):
                 warnings.warn(
                     "No method get_control_latex defined in the model. "
                     "Switch to using the labels defined in each pulse."
@@ -1229,7 +1227,7 @@ class Model:
     """
 
     def __init__(self, num_qubits, dims=None, **params):
-        self.num_qubits = num_qubits
+        self.num_qubits = num_qubits if num_qubits is not None else N
         self.dims = dims if dims is not None else num_qubits * [2]
         self.params = deepcopy(params)
         self._controls = {}

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -273,7 +273,8 @@ class Processor(object):
         Returns
         -------
         label_list : list
-            A list of hashable objects each corresponds to an available control Hamiltonian.
+            A list of hashable objects each corresponds to
+            an available control Hamiltonian.
         """
         return self.model.get_control_labels()
 
@@ -659,7 +660,6 @@ class Processor(object):
         return True
 
     def get_pulse_dict(self):
-        # FIXME
         label_list = {}
         for i, pulse in enumerate(self.pulses):
             if pulse.label is not None:
@@ -742,6 +742,15 @@ class Processor(object):
         num_steps: int, optional
             Number of time steps in the plot.
 
+        pulse_labels: list of dict, optional
+            A map between pulse labels and the labels shown on the y axis.
+            E.g. ``["sx", "sigmax"]``.
+            If not given and ``use_control_latex==False``,
+            the string label defined in each :obj:`.Pulse` is used.
+
+        use_control_latex: bool, optional
+            Use labels defined in ``Processor.model.get_control_latex``.
+
         Returns
         -------
         fig: matplotlib.figure.Figure
@@ -755,10 +764,11 @@ class Processor(object):
         :meth:.Processor.plot_pulses` only works for array_like coefficients.
         """
         if hasattr(self, "get_operators_labels"):
-            warnings.warn("Using the get_operators_labels to provide labels "
-            "for plotting is deprecated. Please use get_control_latex instead.")
-
-        # FIXME fix if pulse is not fully defined.
+            warnings.warn(
+                "Using the get_operators_labels to provide labels "
+                "for plotting is deprecated. "
+                "Please use get_control_latex instead."
+            )
         import matplotlib.pyplot as plt
         import matplotlib.gridspec as gridspec
 
@@ -1151,7 +1161,8 @@ def _pulse_interpolate(pulse, tlist):
 class Model:
     """
     Template class for a physical model representing quantum hardware.
-    The concrete model class does not have to inherit from this, as long as the following methods are defined.
+    The concrete model class does not have to inherit from this,
+    as long as the following methods are defined.
 
     Parameters
     ----------

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -277,7 +277,7 @@ class Processor(object):
         """
         return self.model.get_control_labels()
 
-    def get_latex_str(self):
+    def get_control_latex(self):
         """
         Get the latex string for each Hamiltonian.
         It is used in the method :meth:`.Processor.plot_pulses`.
@@ -290,8 +290,8 @@ class Processor(object):
         nested_latex_str : list of dict
             E.g.: ``[{"sx": "\sigma_z"}, {"sy": "\sigma_y"}]``.
         """
-        if hasattr(self.model, "get_latex_str"):
-            return self.model.get_latex_str()
+        if hasattr(self.model, "get_control_latex"):
+            return self.model.get_control_latex()
         labels = self.model.get_control_labels()
         return [{label: label for label in labels}]
 
@@ -754,6 +754,10 @@ class Processor(object):
         -----
         :meth:.Processor.plot_pulses` only works for array_like coefficients.
         """
+        if hasattr(self, "get_operators_labels"):
+            warnings.warn("Using the get_operators_labels to provide labels "
+            "for plotting is deprecated. Please use get_control_latex instead.")
+
         # FIXME fix if pulse is not fully defined.
         import matplotlib.pyplot as plt
         import matplotlib.gridspec as gridspec
@@ -776,7 +780,7 @@ class Processor(object):
 
         pulse_ind = 0
         axis = []
-        for i, label_group in enumerate(self.get_latex_str()):
+        for i, label_group in enumerate(self.get_control_latex()):
             for j, (label, latex_str) in enumerate(label_group.items()):
                 try:
                     pulse = self.find_pulse(label)

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import warnings
 from copy import deepcopy
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Hashable
 
 import numpy as np
 from scipy.interpolate import CubicSpline
@@ -1177,7 +1177,7 @@ class Model:
         self._drift = []
         self._noise = []
 
-    def get_all_drift(self) -> List[Tuple[Qobj, List[str]]]:
+    def get_all_drift(self) -> List[Tuple[Qobj, List[int]]]:
         """
         Get all the drift Hamiltonians.
 
@@ -1189,13 +1189,13 @@ class Model:
         """
         return self._drift
 
-    def get_control(self, label: Any) -> Tuple[Qobj, List[str]]:
+    def get_control(self, label: Hashable) -> Tuple[Qobj, List[int]]:
         """
         Get the control Hamiltonian corresponding to the label.
 
         Parameters
         ----------
-        label :
+        label : hashable object
             A label that identifies the Hamiltonian.
 
         Returns
@@ -1209,13 +1209,13 @@ class Model:
                 label = _old_index_label_map[label]
         return self._controls[label]
 
-    def get_control_labels(self) -> List[Any]:
+    def get_control_labels(self) -> List[Hashable]:
         """
         Get a list of all available control Hamiltonians.
 
         Returns
         -------
-        label_list : list
+        label_list : list of hashable objects
             A list of hashable objects each corresponds to
             an available control Hamiltonian.
         """

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -33,7 +33,7 @@ class Processor(object):
     Parameters
     ----------
     num_qubits : int, optional
-        The number of component systems.
+        The number of qubits.
         It replaces the old API ``N``.
 
     dims : list, optional
@@ -1208,8 +1208,8 @@ class Model:
 
     Parameters
     ----------
-    num_qubits : int, optional
-        The number of component systems.
+    num_The number of qubits
+        The number of qubits.
     dims : list, optional
         The dimension of each component system.
         Default value is a qubit system of ``dim=[2,2,2,...,2]``.
@@ -1218,8 +1218,8 @@ class Model:
 
     Attributes
     ----------
-    num_qubits : int, optional
-        The number of component systems.
+    num_The number of qubits
+        The number of qubits.
     dims : list, optional
         The dimension of each component system.
     params : dict

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -512,6 +512,9 @@ class Processor(object):
         """
         self._is_pulses_valid()
         coeffs = np.array(self.get_full_coeffs())
+
+        if not all([isinstance(pulse.label, str) for pulse in self.pulses]):
+            raise NotImplementedError("Only string labels are supported.")
         header = ";".join([str(pulse.label) for pulse in self.pulses])
         if inctime:
             shp = coeffs.T.shape

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1216,6 +1216,8 @@ class Model:
     def get_control_labels(self) -> List[Hashable]:
         """
         Get a list of all available control Hamiltonians.
+        Optional, required only when plotting the pulses or
+        using the optimal control algorithm.
 
         Returns
         -------

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -128,7 +128,6 @@ class LinearSpinChain(SpinChain):
             num_qubits,
             correct_global_phase=correct_global_phase,
             model=model,
-            **params,
         )
 
     @property
@@ -193,7 +192,6 @@ class CircularSpinChain(SpinChain):
             num_qubits,
             correct_global_phase=correct_global_phase,
             model=model,
-            **params,
         )
 
     @property

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -221,12 +221,12 @@ class CircularSpinChain(SpinChain):
 
 class SpinChainModel(Model):
     """
-    Physical model for a spin chain qubits system.
+    Physical model for :obj:`CircularSpinChain` and :obj`LinearSpinChain`.
 
     Parameters
     ----------
     num_qubits: int
-        The number of component systems.
+        The number of qubits.
     setup : str
         "linear" for an open end and "circular" for a closed end chain.
     **params :

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -327,7 +327,7 @@ class SpinChainModel(Model):
         computed_params["sxsy"] = _to_array(self.params["sxsy"], num_coupling)
         return computed_params
 
-    def get_latex_str(self):
+    def get_control_latex(self):
         """
         Get the labels for each Hamiltonian.
         It is used in the method method :meth:`.Processor.plot_pulses`.

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -340,7 +340,7 @@ class SpinChainModel(Model):
             {f"sx{m}": f"$\sigma_x^{m}$" for m in range(num_qubits)},
             {f"sz{m}": f"$\sigma_z^{m}$" for m in range(num_qubits)},
             {
-                f"g{m}": f"$\sigma_x^{m}\sigma_x^{m} + \sigma_y^{m}\sigma_y^{m}$"
+                f"g{m}": f"$\sigma_x^{m}\sigma_x^{(m + 1) % num_qubits} + \sigma_y^{m}\sigma_y^{(m + 1) % num_qubits}$"
                 for m in range(num_coupling)
             },
         ]

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -337,10 +337,13 @@ class SpinChainModel(Model):
         num_qubits = self.num_qubits
         num_coupling = self._get_num_coupling()
         return [
-            {f"sx{m}": f"$\sigma_x^{m}$" for m in range(num_qubits)},
-            {f"sz{m}": f"$\sigma_z^{m}$" for m in range(num_qubits)},
+            {f"sx{m}": r"$\sigma_x^{}$".format(m) for m in range(num_qubits)},
+            {f"sz{m}": r"$\sigma_z^{}$".format(m) for m in range(num_qubits)},
             {
-                f"g{m}": f"$\sigma_x^{m}\sigma_x^{(m + 1) % num_qubits} + \sigma_y^{m}\sigma_y^{(m + 1) % num_qubits}$"
+                f"g{m}": r"$\sigma_x^{}\sigma_x^{} +"
+                r" \sigma_y^{}\sigma_y^{}$".format(
+                    m, (m + 1) % num_qubits, m, (m + 1) % num_qubits
+                )
                 for m in range(num_coupling)
             },
         ]

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -34,42 +34,19 @@ class SpinChain(ModelProcessor):
         will track the global phase.
         It has no effect on the numerical solution.
 
-    t1: list or float, optional
-        Characterize the decoherence of amplitude damping for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
-    t2: list of float, optional
-        Characterize the decoherence of dephasing for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
     **params:
-        Keyword argument for hardware parameters, in the unit of frequency
-        (MHz, GHz etc, the unit of time list needs to be adjusted accordingly).
-        Qubit parameters can either be a float or an array of the length
-        ``num_qubits``.
-        ``sxsy``, should be either a float or an array of the length
-        ``num_qubits-1`` (for :class:`.LinearSpinChain`) or ``num_qubits``
-        (for :`.CircularSpinChain`).
-
-        - ``sx``: the pulse strength of sigma-x control, default ``0.25``
-        - ``sz``: the pulse strength of sigma-z control, default ``1.0``
-        - ``sxsy``: the pulse strength for the exchange interaction,
-          default ``0.1``
+        Hardware parameters. See :obj:`.SpinChainModel`.
     """
 
     def __init__(
-        self, num_qubits, correct_global_phase, t1, t2, N=None, **params
+        self, num_qubits, correct_global_phase=True, model=None, **params
     ):
         super(SpinChain, self).__init__(
-            num_qubits,
+            num_qubits=num_qubits,
             correct_global_phase=correct_global_phase,
-            t1=t1,
-            t2=t2,
-            N=N,
+            model=model,
+            **params,
         )
-        self.params["num_qubits"] = num_qubits
-        if params is not None:
-            self.params.update(params)
         self.correct_global_phase = correct_global_phase
         self.spline_kind = "step_func"
         self.native_gates = ["SQRTISWAP", "ISWAP", "RX", "RZ"]
@@ -124,8 +101,7 @@ class SpinChain(ModelProcessor):
 
 class LinearSpinChain(SpinChain):
     """
-    Spin chain model with open-end topology. See :class:`.SpinChain`
-    for details.
+    Spin chain model with open-end topology.
 
     Parameters
     ----------
@@ -137,47 +113,23 @@ class LinearSpinChain(SpinChain):
         will track the global phase.
         It has no effect on the numerical solution.
 
-    t1: list or float, optional
-        Characterize the decoherence of amplitude damping for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
-    t2: list of float, optional
-        Characterize the decoherence of dephasing for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
     **params:
-        Keyword argument for hardware parameters, in the unit of frequency
-        (MHz, GHz etc, the unit of time list needs to be adjusted accordingly).
-        Qubit parameters can either be a float or an array of the length
-        ``num_qubits``.
-        ``sxsy``, should be either a float or an array of the length
-        ``num_qubits-1``.
-
-        - ``sx``: the pulse strength of sigma-x control, default ``0.25``
-        - ``sz``: the pulse strength of sigma-z control, default ``1.0``
-        - ``sxsy``: the pulse strength for the exchange interaction,
-          default ``0.1``
+        Hardware parameters. See :obj:`.SpinChainModel`.
     """
 
     def __init__(
         self,
         num_qubits=None,
         correct_global_phase=True,
-        t1=None,
-        t2=None,
-        N=None,
         **params,
     ):
+        model = SpinChainModel(num_qubits=num_qubits, setup="linear", **params)
         super(LinearSpinChain, self).__init__(
             num_qubits,
             correct_global_phase=correct_global_phase,
-            t1=t1,
-            t2=t2,
-            N=N,
+            model=model,
             **params,
         )
-        self.model = SpinChainModel(setup="linear", **self.params)
-        self.params = self.model.params
 
     @property
     def sxsy_ops(self):
@@ -211,43 +163,22 @@ class CircularSpinChain(SpinChain):
 
     Parameters
     ----------
-    num_qubits: int
+    num_qubits : int
         The number of qubits in the system.
 
-    correct_global_phase: float, optional
+    correct_global_phase : float, optional
         Save the global phase, the analytical solution
         will track the global phase.
         It has no effect on the numerical solution.
 
-    t1: list or float, optional
-        Characterize the decoherence of amplitude damping for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
-    t2: list of float, optional
-        Characterize the decoherence of dephasing for
-        each qubit. A list of size ``num_qubits`` or a float for all qubits.
-
     **params:
-        Keyword argument for hardware parameters, in the unit of frequency
-        (MHz, GHz etc, the unit of time list needs to be adjusted accordingly).
-        Qubit parameters can either be a float or an array of the length
-        ``num_qubits``.
-        ``sxsy``, should be either a float or an array of the length
-        ``num_qubits``.
-
-        - ``sx``: the pulse strength of sigma-x control, default ``0.25``
-        - ``sz``: the pulse strength of sigma-z control, default ``1.0``
-        - ``sxsy``: the pulse strength for the exchange interaction,
-          default ``0.1``
+        Hardware parameters. See :obj:`.SpinChainModel`.
     """
 
     def __init__(
         self,
         num_qubits=None,
         correct_global_phase=True,
-        t1=None,
-        t2=None,
-        N=None,
         **params,
     ):
         if num_qubits <= 1:
@@ -255,16 +186,15 @@ class CircularSpinChain(SpinChain):
                 "Circuit spin chain must have at least 2 qubits. "
                 "The number of qubits is increased to 2."
             )
+        model = SpinChainModel(
+            num_qubits=num_qubits, setup="circular", **params
+        )
         super(CircularSpinChain, self).__init__(
             num_qubits,
             correct_global_phase=correct_global_phase,
-            t1=t1,
-            t2=t2,
-            N=N,
+            model=model,
             **params,
         )
-        self.model = SpinChainModel(setup="circular", **self.params)
-        self.params = self.model.params
 
     @property
     def sxsy_ops(self):
@@ -292,7 +222,41 @@ class CircularSpinChain(SpinChain):
 
 
 class SpinChainModel(Model):
-    def __init__(self, **params):
+    """
+    Physical model for a spin chain qubits system.
+
+    Parameters
+    ----------
+    num_qubits: int
+        The number of component systems.
+    setup : str
+        "linear" for an open end and "circular" for a closed end chain.
+    **params :
+        Keyword arguments for hardware parameters, in the unit of frequency
+        (MHz, GHz etc, the unit of time list needs to be adjusted accordingly).
+        Parameters can either be a float or list with parameters
+        for each qubits.
+
+        - sx : float or list, optional
+            The pulse strength of sigma-x control, default ``0.25``.
+        - sz : float or list, optional
+            The pulse strength of sigma-z control, default ``1.0``.
+        - sxsy : float or list, optional
+            The pulse strength for the exchange interaction,
+            default ``0.1``.
+            It should be either a float or an array of the length
+            ``num_qubits-1`` for the linear setup or ``num_qubits`` for
+            the circular setup.
+        - t1 : float or list, optional
+            Characterize the amplitude damping for each qubit.
+        - t2 : list of list, optional
+            Characterize the total dephasing for each qubit.
+    """
+
+    def __init__(self, num_qubits, setup, **params):
+        self.num_qubits = num_qubits
+        self.dims = num_qubits * [2]
+        self.setup = setup
         self.params = {  # default parameters, in the unit of frequency
             "sx": 0.25,
             "sz": 1.0,
@@ -300,36 +264,24 @@ class SpinChainModel(Model):
         }
         self._drift = []
         self.params.update(deepcopy(params))
-        self._controls = self._set_up_controls(self.params["num_qubits"])
         self.params.update(self._compute_params())
-
-    def get_all_drift(self):
-        return self._drift
+        self._controls = self._set_up_controls(self.num_qubits)
+        self._noise = []
 
     @property
     def _old_index_label_map(self):
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         return (
             ["sx" + str(i) for i in range(num_qubits)]
             + ["sz" + str(i) for i in range(num_qubits)]
             + ["g" + str(i) for i in range(num_qubits)]
         )
 
-    def get_control(self, label):
-        """label should be hashable"""
-        _old_index_label_map = self._old_index_label_map
-        if isinstance(label, int):
-            label = _old_index_label_map[label]
-        return self._controls[label]
-
-    def get_control_labels(self):
-        return list(self._controls.keys())
-
     def _get_num_coupling(self):
-        if self.params["setup"] == "linear":
-            num_coupling = self.params["num_qubits"] - 1
-        elif self.params["setup"] == "circular":
-            num_coupling = self.params["num_qubits"]
+        if self.setup == "linear":
+            num_coupling = self.num_qubits - 1
+        elif self.setup == "circular":
+            num_coupling = self.num_qubits
         else:
             raise ValueError(
                 "Parameter setup needs to be linear or circular, "
@@ -367,7 +319,7 @@ class SpinChainModel(Model):
         return controls
 
     def _compute_params(self):
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         computed_params = {}
         computed_params["sx"] = _to_array(self.params["sx"], num_qubits)
         computed_params["sz"] = _to_array(self.params["sz"], num_qubits)
@@ -382,10 +334,13 @@ class SpinChainModel(Model):
         It is a 2-d nested list, in the plot,
         a different color will be used for each sublist.
         """
-        num_qubits = self.params["num_qubits"]
+        num_qubits = self.num_qubits
         num_coupling = self._get_num_coupling()
         return [
             {f"sx{m}": f"$\sigma_x^{m}$" for m in range(num_qubits)},
             {f"sz{m}": f"$\sigma_z^{m}$" for m in range(num_qubits)},
-            {f"g{m}": f"$\sigma_x^{m}\sigma_x^{m} + \sigma_y^{m}\sigma_y^{m}$" for m in range(num_coupling)},
+            {
+                f"g{m}": f"$\sigma_x^{m}\sigma_x^{m} + \sigma_y^{m}\sigma_y^{m}$"
+                for m in range(num_coupling)
+            },
         ]

--- a/src/qutip_qip/device/spinchain.py
+++ b/src/qutip_qip/device/spinchain.py
@@ -221,7 +221,8 @@ class CircularSpinChain(SpinChain):
 
 class SpinChainModel(Model):
     """
-    Physical model for :obj:`CircularSpinChain` and :obj`LinearSpinChain`.
+    The physical model for the spin chian processor
+    (:obj:`CircularSpinChain` and :obj`LinearSpinChain`).
 
     Parameters
     ----------

--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -38,10 +38,10 @@ def process_noise(
         Dimension of the system.
         If int, we assume it is the number of qubits in the system.
         If list, it is the dimension of the component systems.
-    t1: list or float, optional
+    t1: float or list, optional
         Characterize the decoherence of amplitude damping for
         each qubit. A list of size `N` or a float for all qubits.
-    t2: list of float, optional
+    t2: float or list, optional
         Characterize the decoherence of dephasing for
         each qubit. A list of size `N` or a float for all qubits.
     device_noise: bool
@@ -283,7 +283,7 @@ class RelaxationNoise(Noise):
 
         Parameters
         ----------
-        T: list of float
+        T: float or list
             The relaxation time
         N: int
             The number of component systems.

--- a/src/qutip_qip/noise.py
+++ b/src/qutip_qip/noise.py
@@ -286,7 +286,7 @@ class RelaxationNoise(Noise):
         T: float or list
             The relaxation time
         N: int
-            The number of component systems.
+            The number of qubits.
 
         Returns
         -------

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -22,13 +22,16 @@ def test_compiling_with_scheduler():
     circuit.add_gate("X", 0)
     circuit.add_gate("X", 1)
     processor = DispersiveCavityQED(2)
+
     processor.load_circuit(circuit, schedule_mode=None)
     tlist = processor.get_full_tlist()
     time_not_scheduled = tlist[-1]-tlist[0]
-    coeffs, tlist = processor.load_circuit(circuit, schedule_mode="ASAP")
+
+    processor.load_circuit(circuit, schedule_mode="ASAP")
     tlist = processor.get_full_tlist()
     time_scheduled1 = tlist[-1]-tlist[0]
-    coeffs, tlist = processor.load_circuit(circuit, schedule_mode="ALAP")
+
+    processor.load_circuit(circuit, schedule_mode="ALAP")
     tlist = processor.get_full_tlist()
     time_scheduled2 = tlist[-1]-tlist[0]
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -188,7 +188,9 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     assert _tol > abs(1 - qutip.metrics.fidelity(result.final_state, target))
 
 
-@pytest.mark.parametrize("processor_class", [DispersiveCavityQED, LinearSpinChain, CircularSpinChain, SCQubits])
+@pytest.mark.parametrize(
+    "processor_class",
+    [DispersiveCavityQED, LinearSpinChain, CircularSpinChain, SCQubits])
 def test_pulse_plotting(processor_class):
     try:
         import matplotlib.pyplot as plt

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -186,3 +186,19 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     elif isinstance(device, SCQubits):
         target = _ket_expaned_dims(target, device.dims)
     assert _tol > abs(1 - qutip.metrics.fidelity(result.final_state, target))
+
+
+@pytest.mark.parametrize("processor_class", [DispersiveCavityQED, LinearSpinChain, CircularSpinChain, SCQubits])
+def test_pulse_plotting(processor_class):
+    try:
+        import matplotlib.pyplot as plt
+    except Exception:
+        return True
+    qc = QubitCircuit(3)
+    qc.add_gate("CNOT", 1, 0)
+    qc.add_gate("X", 1)
+
+    processor = processor_class(3)
+    processor.load_circuit(qc)
+    fig, ax = processor.plot_pulses()
+    plt.close(fig)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -91,3 +91,7 @@ def test_define_model_in_processor():
     assert noise_object in processor.noise
     with pytest.raises(TypeError):
         processor.add_noise("non-noise-object")
+
+def test_change_parameters_in_processor():
+    processor = LinearSpinChain(0, sx=0.1)
+    assert(all(processor.params["sx"] == [0.1]))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,6 +92,7 @@ def test_define_model_in_processor():
     with pytest.raises(TypeError):
         processor.add_noise("non-noise-object")
 
+
 def test_change_parameters_in_processor():
     processor = LinearSpinChain(0, sx=0.1)
     assert(all(processor.params["sx"] == [0.1]))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,93 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+
+import qutip
+from qutip_qip.device import (
+    Model,
+    Processor,
+    DispersiveCavityQED,
+    LinearSpinChain,
+    CircularSpinChain,
+    SCQubits,
+)
+from qutip_qip.noise import RelaxationNoise
+
+
+def test_cavityqed_model():
+    model = DispersiveCavityQED(3, epsmax=[1.1, 1, 0, 0.8], w0=7.0)
+    assert model.get_all_drift() == []
+    model.get_control_labels()
+    model.get_control("g1")
+    model.get_control("sx0")
+    assert_array_equal(model.params["deltamax"], np.array([1.0] * 3))
+    assert_array_equal(model.params["w0"], 7.0)
+    assert_array_equal(model.params["epsmax"], [1.1, 1, 0, 0.8])
+    assert model.get_control(0) == model.get_control("sx0")
+    model.get_latex_str()
+
+
+@pytest.mark.parametrize(("model_class"), [LinearSpinChain, CircularSpinChain])
+def test_spinchain_model(model_class):
+    model = LinearSpinChain(3, sx=[1.1, 1, 0, 0.8], sz=7.0, t1=10.0)
+    assert model.get_all_drift() == []
+    model.get_control_labels()
+    if isinstance(model, LinearSpinChain):
+        assert len(model.get_control_labels()) == 3 * 3 - 1
+    elif isinstance(model, CircularSpinChain):
+        assert len(model.get_control_labels()) == 3 * 3
+    model.get_control("g1")
+    model.get_control("sx0")
+    assert_array_equal(model.params["sz"], 7.0)
+    assert_array_equal(model.params["sx"], [1.1, 1, 0, 0.8])
+    assert model.get_control(0) == model.get_control("sx0")
+    model.get_latex_str()
+    assert model.params["t1"] == 10.0
+
+
+def test_scqubits_model():
+    model = SCQubits(
+        3, dims=[4, 3, 4], omega_single=0.02, alpha=[-0.02, -0.015, -0.025]
+    )
+    assert model.dims == [4, 3, 4]
+    model.get_all_drift()
+    model.get_control_labels()
+    model.get_control("sx2")
+    model.get_control("zx10")
+    assert_array_equal(model.params["omega_single"], np.array([0.02] * 3))
+    assert_array_equal(model.params["alpha"], [-0.02, -0.015, -0.025])
+    assert model.get_control(0) == model.get_control("sx0")
+    model.get_latex_str()
+
+
+def test_define_model_in_processor():
+    processor = Processor(3)
+
+    # Define Hamiltonian model
+    processor.add_drift(qutip.sigmax(), 1)
+    assert processor.get_all_drift() == [(qutip.sigmax(), [1])]
+    processor.add_drift(qutip.sigmaz(), cyclic_permutation=True)
+    assert len(processor.drift) == 4
+    processor.add_control(qutip.sigmaz(), targets=2, label="sz")
+    processor.set_coeffs({"sz": np.array([[0.0, 1.0]])})
+    processor.controls[0] == qutip.tensor(
+        [qutip.qeye(2), qutip.qeye(2), qutip.sigmax()]
+    )
+    processor.add_control(qutip.sigmax(), label="sx", cyclic_permutation=True)
+    label_dict = {"sz", ("sx", (0,)), ("sx", (1,)), ("sx", (2,))}
+    for label in processor.get_control_labels():
+        assert label in label_dict
+    assert processor.get_control("sz") == (qutip.sigmaz(), [2])
+
+    # Relaxation time
+    processor.t1 = 100.0
+    processor.t2 = 60.0
+    assert processor.t1 == 100.0
+    assert processor.t2 == 60.0
+
+    # Noise
+    noise_object = RelaxationNoise(t1=20.0)
+    processor.add_noise(noise_object)
+    assert noise_object in processor.noise
+    with pytest.raises(TypeError):
+        processor.add_noise("non-noise-object")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -24,7 +24,7 @@ def test_cavityqed_model():
     assert_array_equal(model.params["w0"], 7.0)
     assert_array_equal(model.params["epsmax"], [1.1, 1, 0, 0.8])
     assert model.get_control(0) == model.get_control("sx0")
-    model.get_latex_str()
+    model.get_control_latex()
 
 
 @pytest.mark.parametrize(("model_class"), [LinearSpinChain, CircularSpinChain])
@@ -41,7 +41,7 @@ def test_spinchain_model(model_class):
     assert_array_equal(model.params["sz"], 7.0)
     assert_array_equal(model.params["sx"], [1.1, 1, 0, 0.8])
     assert model.get_control(0) == model.get_control("sx0")
-    model.get_latex_str()
+    model.get_control_latex()
     assert model.params["t1"] == 10.0
 
 
@@ -57,7 +57,7 @@ def test_scqubits_model():
     assert_array_equal(model.params["omega_single"], np.array([0.02] * 3))
     assert_array_equal(model.params["alpha"], [-0.02, -0.015, -0.025])
     assert model.get_control(0) == model.get_control("sx0")
-    model.get_latex_str()
+    model.get_control_latex()
 
 
 def test_define_model_in_processor():

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -107,8 +107,13 @@ class TestOptPulseProcessor:
         qc = QubitCircuit(3)
         qc.add_gate("CNOT", 1, 0)
         qc.add_gate("X", 2)
-        processor.load_circuit(qc, merge_gates=True, num_tslots=10, evo_time=2.0)
+        processor.load_circuit(
+            qc, merge_gates=True, num_tslots=10, evo_time=2.0
+        )
         init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
         num_result = processor.run_state(init_state=init_state).states[-1]
         ideal_result = qc.run(init_state)
-        assert pytest.approx(qutip.fidelity(num_result, ideal_result), 1.0e-6) == 1.0
+        assert (
+            pytest.approx(qutip.fidelity(num_result, ideal_result), 1.0e-6)
+            == 1.0
+        )

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -39,17 +39,6 @@ class TestOptPulseProcessor:
         result = test.run_state(rho0)
         assert_allclose(fidelity(result.states[-1], plus), 1, rtol=1.0e-6)
 
-        # test add/remove ctrl
-        test.add_control(sigmay())
-        test.remove_pulse(0)
-        assert_(
-            len(test.pulses) == 1,
-            msg="Method of remove_pulse could be wrong.")
-        assert_allclose(test.drift.drift_hamiltonians[0].qobj, H_d)
-        assert_(
-            sigmay() in test.ctrls,
-            msg="Method of remove_pulse could be wrong.")
-
     def test_multi_qubits(self):
         """
         Test for multi-qubits system.
@@ -68,11 +57,7 @@ class TestOptPulseProcessor:
         # test periodically adding ctrls
         sx = sigmax()
         iden = identity(2)
-        # print(test.ctrls)
-        # print(Qobj(tensor([sx, iden, sx])))
-        assert_(Qobj(tensor([sx, iden, sx])) in test.ctrls)
-        assert_(Qobj(tensor([iden, sx, sx])) in test.ctrls)
-        assert_(Qobj(tensor([sx, sx, iden])) in test.ctrls)
+        assert(len(test.get_control_labels()) == 3)
         test.add_control(sigmax(), cyclic_permutation=True)
         test.add_control(sigmay(), cyclic_permutation=True)
 
@@ -85,17 +70,6 @@ class TestOptPulseProcessor:
         result = test.run_state(
             rho0, options=Options(store_states=True))
         assert_(fidelity(result.states[-1], rho1) > 1-1.0e-6)
-
-        # # test save and read coeffs
-        # test.save_coeff("qutip_test_multi_qubits.txt")
-        # test2 = OptPulseProcessor(N, H_d, H_c)
-        # test2.drift = test.drift
-        # test2.ctrls = test.ctrls
-        # test2.read_coeff("qutip_test_multi_qubits.txt")
-        # os.remove("qutip_test_multi_qubits.txt")
-        # assert_(np.max((test.coeffs-test2.coeffs)**2) < 1.0e-13)
-        # result = test2.run_state(rho0,)
-        # assert_(fidelity(result.states[-1], rho1) > 1-1.0e-6)
 
     def test_multi_gates(self):
         N = 2

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -52,12 +52,16 @@ class TestCircuitProcessor:
         proc2.add_control(sigmaz(), label="sz")
         proc2.add_control(sigmax(), label="sx")
         # TODO generalize to different tlist
-        tlist = np.array([0., 0.1, 0.2, 0.3, 0.4, 0.5])
+        tlist = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         amp1 = np.arange(0, 5, 1)
         amp2 = np.arange(5, 0, -1)
 
-
-        proc.set_all_coeffs({label: amp for label, amp in zip(proc.get_control_labels(), [amp1, amp2])})
+        proc.set_all_coeffs(
+            {
+                label: amp
+                for label, amp in zip(proc.get_control_labels(), [amp1, amp2])
+            }
+        )
         proc.set_all_tlist(tlist)
         proc.save_coeff("qutip_test_CircuitProcessor.txt")
         proc1.read_coeff("qutip_test_CircuitProcessor.txt")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -133,7 +133,7 @@ class TestCircuitProcessor:
             err_msg="Error in t1 & t2 simulation, "
                     "with t1={} and t2={}".format(t1, t2))
 
-    def testPlot(self):
+    def test_plot(self):
         """
         Test for plotting functions
         """
@@ -147,7 +147,7 @@ class TestCircuitProcessor:
         processor.add_control(sigmaz(), label="sz")
         processor.set_all_coeffs({"sz": np.array([np.sin(t) for t in tlist])})
         processor.set_all_tlist(tlist)
-        fig, _ = processor.plot_pulses()
+        fig, _ = processor.plot_pulses(use_control_latex=False)
         # testing under Xvfb with pytest-xvfb complains if figure windows are
         # left open, so we politely close it:
         plt.close(fig)
@@ -158,8 +158,7 @@ class TestCircuitProcessor:
         processor.add_control(sigmaz(), label="sz")
         processor.set_all_coeffs({"sz": np.array([np.sin(t) for t in tlist])})
         processor.set_all_tlist(tlist)
-        processor.plot_pulses()
-        fig, _ = processor.plot_pulses()
+        fig, _ = processor.plot_pulses(use_control_latex=False)
         # testing under Xvfb with pytest-xvfb complains if figure windows are
         # left open, so we politely close it:
         plt.close(fig)


### PR DESCRIPTION
Previously, the Hamiltonian model in `Processor` is saved as partially initialized pulses. This PR separate the Hamiltonian model from pulse and the `Processor` class. It can now be defined independently and includes only the information of the Hamiltonian. The pulses will only be generated after the circuit is loaded.

The main changes are in `processor.py`.  In particular in the initialization. The others are either docs change or internal updates to fit this new structure. A bunch of getter functions are added to support the old way of building the Hamiltonians using the `Processor`. The data is, however, always saved in `Model`.

In principle `ModelProcessor` can be merged into `Processor`, but it is best to wait for another PR.

There are a few FIXME that are used to remind me to revisit some details later in a different PR. They are unrelated to the Hamiltonian model.

@nathanshammah @quantshah 

Issue #98

**TODO**
- [x] Add more tests
- [ ] Check compatibility with existing notebooks.

**Breaking changes**
- The pulse will not be generated before loading the circuit. So inquiring the Hamiltonian operator through pulse will only return an empty list. One should now use e.g. `Processor.get_control("sx0")` for this.
- `Processor.get_operators_labels()` is renamed as `get_latex_str` for clearity.