### PR TITLE
Improve the scheduling algorithm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/qutip_qip/compiler/scheduler.py
+++ b/src/qutip_qip/compiler/scheduler.py
@@ -308,31 +308,6 @@ class InstructionsGraph:
             - self.nodes[ind2].distance_to_start
         )
 
-    def add_constraint_dependency(self, constraint_dependency):
-        """
-        Add the dependency caused by hardware constraint to the graph.
-
-        Parameters
-        ----------
-        constraint_dependency: list
-            `constraint_dependency` obtained by the method
-            `find_topological_order`.
-        """
-        for ind1, ind2 in constraint_dependency:
-            self.nodes[ind1].successors.add(ind2)
-            self.nodes[ind2].predecessors.add(ind1)
-
-        # Update the start and end nodes of the graph
-        start = []
-        end = []
-        for i, instruction in enumerate(self.nodes):
-            if not instruction.successors:
-                end.append(i)
-            if not instruction.predecessors:
-                start.append(i)
-        self.start = start
-        self.end = end
-
 
 class Scheduler:
     """

--- a/src/qutip_qip/compiler/scheduler.py
+++ b/src/qutip_qip/compiler/scheduler.py
@@ -410,6 +410,7 @@ class Scheduler:
         return_cycles_list=False,
         random_shuffle=False,
         repeat_num=0,
+        allow_permutation=True,
     ):
         """
         Schedule a `QubitCircuit`,
@@ -526,8 +527,12 @@ class Scheduler:
 
         # Generate the quantum operations dependency graph.
         instructions_graph = InstructionsGraph(gates)
+        if allow_permutation:
+            commutation_rules = self.commutation_rules
+        else:
+            commutation_rules = lambda *args, **kwargs: False
         instructions_graph.generate_dependency_graph(
-            commuting=self.commutation_rules
+            commuting=commutation_rules
         )
         if self.method == "ALAP":
             instructions_graph.reverse_graph()

--- a/src/qutip_qip/compiler/scheduler.py
+++ b/src/qutip_qip/compiler/scheduler.py
@@ -568,27 +568,38 @@ class Scheduler:
         instruction1 = instructions[ind1]
         instruction2 = instructions[ind2]
         if instruction1.name != instruction2.name:
-            instruction1, instruction2 = sorted([instruction1, instruction2], key=lambda instruction: instruction.name)
-            if instruction1.name == "CNOT" and instruction2.name in ("X", "RX"):
+            instruction1, instruction2 = sorted(
+                [instruction1, instruction2],
+                key=lambda instruction: instruction.name,
+            )
+            if instruction1.name == "CNOT" and instruction2.name in (
+                "X",
+                "RX",
+            ):
                 if instruction1.targets == instruction2.targets:
-                    return True
+                    commute = True
                 else:
-                    return False
-            elif instruction1.name == "CNOT" and instruction2.name in ("Z", "RZ"):
+                    commute = False
+            elif instruction1.name == "CNOT" and instruction2.name in (
+                "Z",
+                "RZ",
+            ):
                 if instruction1.controls == instruction2.targets:
-                    return True
+                    commute = True
                 else:
-                    return False
+                    commute = False
             else:
-                return False
+                commute = False
+            return commute
         if (instruction1.controls) and (
             instruction1.controls == instruction2.controls
         ):
-            return True
+            commute = True
         elif instruction1.targets == instruction2.targets:
-            return True
+            commute = True
         else:
-            return False
+            commute = False
+        return commute
 
     def apply_constraint(self, ind1, ind2, instructions):
         """
@@ -612,7 +623,6 @@ def qubit_constraint(ind1, ind2, instructions):
     """
     Determine if two instructions have overlap in the used qubits.
     """
-    # FIXME think about the constraint. replace it with commutation.
     if instructions[ind1].used_qubits & instructions[ind2].used_qubits:
         return False
     else:

--- a/src/qutip_qip/compiler/scheduler.py
+++ b/src/qutip_qip/compiler/scheduler.py
@@ -99,11 +99,11 @@ class InstructionsGraph:
         qubits_cycle_current = [set() for i in range(num_qubits)]
 
         # Generate instruction (gate) dependency for each qubit
-        for next_gate_ind, instruction in enumerate(self.nodes):
+        for gate_index, instruction in enumerate(self.nodes):
             for qubit in instruction.used_qubits:
                 dependent = False
                 for dependent_ind in qubits_cycle_current[qubit]:
-                    if not commuting(next_gate_ind, dependent_ind, self.nodes):
+                    if not commuting(gate_index, dependent_ind, self.nodes):
                         dependent = True
                 # Assume that if A, B and C use the same qubit, we have
                 # [A,B]=0, [B,C]=0 -> [A,C]=0.
@@ -114,8 +114,9 @@ class InstructionsGraph:
                         qubits_cycle_last[qubit], qubits_cycle_current[qubit]
                     )
                     qubits_cycle_last[qubit] = qubits_cycle_current[qubit]
-                    qubits_cycle_current[qubit] = {next_gate_ind}
-                qubits_cycle_current[qubit].add(next_gate_ind)
+                    qubits_cycle_current[qubit] = {gate_index}
+                else:
+                    qubits_cycle_current[qubit].add(gate_index)
 
         for qubit in range(num_qubits):
             self._add_dependency(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,7 +7,10 @@ from qutip_qip.operations import Gate, gate_sequence_product
 from qutip import process_fidelity, qeye, tracedist
 
 
-def _varify_scheduled_circuit(circuit, gate_cycle_indices):
+def _verify_scheduled_circuit(circuit, gate_cycle_indices):
+    """
+    Compare results between the original and the scheduled circuit.
+    """
     result0 = gate_sequence_product(circuit.propagators())
     scheduled_gate = [[] for i in range(max(gate_cycle_indices) + 1)]
     for i, cycles in enumerate(gate_cycle_indices):
@@ -60,7 +63,7 @@ def test_commutation_rules(circuit, expected_length):
     scheduler = Scheduler("ASAP")
     gate_cycle_indices = scheduler.schedule(circuit)
     assert (max(gate_cycle_indices) + 1) == expected_length
-    assert _varify_scheduled_circuit(circuit, gate_cycle_indices)
+    assert _verify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 def _circuit1():
@@ -142,7 +145,7 @@ def test_scheduling_gates1(
     )
 
     assert max(gate_cycle_indices) == expected_length
-    _varify_scheduled_circuit(circuit, gate_cycle_indices)
+    _verify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 # There is some problem with circuit2 on Mac.
@@ -172,7 +175,7 @@ def test_scheduling_gates2(
     )
 
     assert max(gate_cycle_indices) == expected_length
-    _varify_scheduled_circuit(circuit, gate_cycle_indices)
+    _verify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 @pytest.mark.parametrize(
@@ -204,7 +207,7 @@ def test_scheduling_gates3(
     )
 
     assert max(gate_cycle_indices) == expected_length
-    _varify_scheduled_circuit(circuit, gate_cycle_indices)
+    _verify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 @pytest.mark.parametrize(
@@ -236,7 +239,7 @@ def test_scheduling_gates4(
     )
 
     assert max(gate_cycle_indices) == expected_length
-    _varify_scheduled_circuit(circuit, gate_cycle_indices)
+    _verify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,6 +10,8 @@ from qutip import process_fidelity, qeye, tracedist
 def _verify_scheduled_circuit(circuit, gate_cycle_indices):
     """
     Compare results between the original and the scheduled circuit.
+    The input gate_cycle_indices is the scheduling result,
+    i.e., a list of integers denoting the execution cycle of each gate in the circuit.
     """
     result0 = gate_sequence_product(circuit.propagators())
     scheduled_gate = [[] for i in range(max(gate_cycle_indices) + 1)]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,6 +7,62 @@ from qutip_qip.operations import Gate, gate_sequence_product
 from qutip import process_fidelity, qeye, tracedist
 
 
+def _varify_scheduled_circuit(circuit, gate_cycle_indices):
+    result0 = gate_sequence_product(circuit.propagators())
+    scheduled_gate = [[] for i in range(max(gate_cycle_indices) + 1)]
+    for i, cycles in enumerate(gate_cycle_indices):
+        scheduled_gate[cycles].append(circuit.gates[i])
+    circuit.gates = sum(scheduled_gate, [])
+    result1 = gate_sequence_product(circuit.propagators())
+    return tracedist(result0 * result1.dag(), qeye(result0.dims[0])) < 1.0e-7
+
+
+def test_allow_permutation():
+    circuit = QubitCircuit(2)
+    circuit.add_gate("X", 0)
+    circuit.add_gate("CNOT", 0, 1)
+    circuit.add_gate("X", 1)
+    result0 = gate_sequence_product(circuit.propagators())
+
+    scheduler = Scheduler("ASAP", allow_permutation=True)
+    gate_cycle_indices = scheduler.schedule(circuit)
+    assert (max(gate_cycle_indices) + 1) == 2
+
+    scheduler = Scheduler("ASAP", allow_permutation=False)
+    gate_cycle_indices = scheduler.schedule(circuit)
+    assert (max(gate_cycle_indices) + 1) == 3
+
+
+def _circuit_cnot_x():
+    circuit = QubitCircuit(2)
+    circuit.add_gate("X", 0)
+    circuit.add_gate("CNOT", 0, 1)
+    circuit.add_gate("X", 1)
+    return circuit
+
+
+def _circuit_cnot_z():
+    circuit = QubitCircuit(2)
+    circuit.add_gate("Z", 0)
+    circuit.add_gate("CNOT", 0, 1)
+    circuit.add_gate("Z", 1)
+    return circuit
+
+
+@pytest.mark.parametrize(
+    "circuit, expected_length",
+    [
+        pytest.param(_circuit_cnot_x(), 2, id="cnot x commutation"),
+        pytest.param(_circuit_cnot_z(), 2, id="cnot z commutation"),
+    ],
+)
+def test_commutation_rules(circuit, expected_length):
+    scheduler = Scheduler("ASAP")
+    gate_cycle_indices = scheduler.schedule(circuit)
+    assert (max(gate_cycle_indices) + 1) == expected_length
+    assert _varify_scheduled_circuit(circuit, gate_cycle_indices)
+
+
 def _circuit1():
     circuit1 = QubitCircuit(6)
     circuit1.add_gate("SNOT", 2)
@@ -17,6 +73,7 @@ def _circuit1():
     circuit1.add_gate("CNOT", 1, 5)
     circuit1.add_gate("SWAP", [0, 1])
     return circuit1
+
 
 def _circuit2():
     circuit2 = QubitCircuit(8)
@@ -35,6 +92,7 @@ def _circuit2():
     circuit2.add_gate("CNOT", 1, 6)
     circuit2.add_gate("CNOT", 1, 7)
     return circuit2
+
 
 def _instructions1():
     circuit3 = QubitCircuit(6)
@@ -60,11 +118,17 @@ def _instructions1():
 @pytest.mark.parametrize(
     "circuit, method, expected_length, random_shuffle, gates_schedule",
     [
-        pytest.param(deepcopy(_circuit1()), "ASAP", 4, False, False, id="circuit1 ASAP)"),
-        pytest.param(deepcopy(_circuit1()), "ALAP", 4, False, False, id="circuit1 ALAP)")
-    ])
+        pytest.param(
+            deepcopy(_circuit1()), "ASAP", 4, False, False, id="circuit1 ASAP)"
+        ),
+        pytest.param(
+            deepcopy(_circuit1()), "ALAP", 4, False, False, id="circuit1 ALAP)"
+        ),
+    ],
+)
 def test_scheduling_gates1(
-        circuit, method, expected_length, random_shuffle, gates_schedule):
+    circuit, method, expected_length, random_shuffle, gates_schedule
+):
     if random_shuffle:
         repeat_num = 5
     else:
@@ -74,18 +138,11 @@ def test_scheduling_gates1(
     # run the scheduler
     scheduler = Scheduler(method)
     gate_cycle_indices = scheduler.schedule(
-        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num)
+        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num
+    )
 
-    # check if the scheduled length is expected
-    assert(max(gate_cycle_indices) == expected_length)
-    scheduled_gate = [[] for i in range(max(gate_cycle_indices)+1)]
-
-    # check if the scheduled circuit is correct
-    for i, cycles in enumerate(gate_cycle_indices):
-        scheduled_gate[cycles].append(circuit.gates[i])
-    circuit.gates = sum(scheduled_gate, [])
-    result1 = gate_sequence_product(circuit.propagators())
-    assert(tracedist(result0*result1.dag(), qeye(result0.dims[0])) < 1.0e-7)
+    assert max(gate_cycle_indices) == expected_length
+    _varify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 # There is some problem with circuit2 on Mac.
@@ -94,10 +151,14 @@ def test_scheduling_gates1(
 @pytest.mark.parametrize(
     "circuit, method, expected_length, random_shuffle, gates_schedule",
     [
-        pytest.param(deepcopy(_circuit2()), "ASAP", 4, False, False, id="circuit2 ASAP"),
-    ])
+        pytest.param(
+            deepcopy(_circuit2()), "ASAP", 4, False, False, id="circuit2 ASAP"
+        ),
+    ],
+)
 def test_scheduling_gates2(
-        circuit, method, expected_length, random_shuffle, gates_schedule):
+    circuit, method, expected_length, random_shuffle, gates_schedule
+):
     if random_shuffle:
         repeat_num = 5
     else:
@@ -107,26 +168,29 @@ def test_scheduling_gates2(
     # run the scheduler
     scheduler = Scheduler(method)
     gate_cycle_indices = scheduler.schedule(
-        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num)
+        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num
+    )
 
-    # check if the scheduled length is expected
-    assert(max(gate_cycle_indices) == expected_length)
-    scheduled_gate = [[] for i in range(max(gate_cycle_indices)+1)]
+    assert max(gate_cycle_indices) == expected_length
+    _varify_scheduled_circuit(circuit, gate_cycle_indices)
 
-    # check if the scheduled circuit is correct
-    for i, cycles in enumerate(gate_cycle_indices):
-        scheduled_gate[cycles].append(circuit.gates[i])
-    circuit.gates = sum(scheduled_gate, [])
-    result1 = gate_sequence_product(circuit.propagators())
-    assert(tracedist(result0*result1.dag(), qeye(result0.dims[0])) < 1.0e-7)
 
 @pytest.mark.parametrize(
     "circuit, method, expected_length, random_shuffle, gates_schedule",
     [
-        pytest.param(deepcopy(_circuit2()), "ALAP", 5, False, False, id="circuit2 ALAP no shuffle")
-    ])
+        pytest.param(
+            deepcopy(_circuit2()),
+            "ALAP",
+            5,
+            False,
+            False,
+            id="circuit2 ALAP no shuffle",
+        )
+    ],
+)
 def test_scheduling_gates3(
-        circuit, method, expected_length, random_shuffle, gates_schedule):
+    circuit, method, expected_length, random_shuffle, gates_schedule
+):
     if random_shuffle:
         repeat_num = 5
     else:
@@ -136,27 +200,29 @@ def test_scheduling_gates3(
     # run the scheduler
     scheduler = Scheduler(method)
     gate_cycle_indices = scheduler.schedule(
-        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num)
+        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num
+    )
 
-    # check if the scheduled length is expected
-    assert(max(gate_cycle_indices) == expected_length)
-    scheduled_gate = [[] for i in range(max(gate_cycle_indices)+1)]
-
-    # check if the scheduled circuit is correct
-    for i, cycles in enumerate(gate_cycle_indices):
-        scheduled_gate[cycles].append(circuit.gates[i])
-    circuit.gates = sum(scheduled_gate, [])
-    result1 = gate_sequence_product(circuit.propagators())
-    assert(tracedist(result0*result1.dag(), qeye(result0.dims[0])) < 1.0e-7)
+    assert max(gate_cycle_indices) == expected_length
+    _varify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 @pytest.mark.parametrize(
     "circuit, method, expected_length, random_shuffle, gates_schedule",
     [
-        pytest.param(deepcopy(_circuit2()), "ALAP", 4, True, False, id="circuit2 ALAP shuffle"),  # with random shuffling
-    ])
+        pytest.param(
+            deepcopy(_circuit2()),
+            "ALAP",
+            4,
+            True,
+            False,
+            id="circuit2 ALAP shuffle",
+        ),  # with random shuffling
+    ],
+)
 def test_scheduling_gates4(
-        circuit, method, expected_length, random_shuffle, gates_schedule):
+    circuit, method, expected_length, random_shuffle, gates_schedule
+):
     if random_shuffle:
         repeat_num = 5
     else:
@@ -166,34 +232,42 @@ def test_scheduling_gates4(
     # run the scheduler
     scheduler = Scheduler(method)
     gate_cycle_indices = scheduler.schedule(
-        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num)
+        circuit, gates_schedule=gates_schedule, repeat_num=repeat_num
+    )
 
-    # check if the scheduled length is expected
-    assert(max(gate_cycle_indices) == expected_length)
-    scheduled_gate = [[] for i in range(max(gate_cycle_indices)+1)]
-
-    # check if the scheduled circuit is correct
-    for i, cycles in enumerate(gate_cycle_indices):
-        scheduled_gate[cycles].append(circuit.gates[i])
-    circuit.gates = sum(scheduled_gate, [])
-    result1 = gate_sequence_product(circuit.propagators())
-    assert(tracedist(result0*result1.dag(), qeye(result0.dims[0])) < 1.0e-7)
+    assert max(gate_cycle_indices) == expected_length
+    _varify_scheduled_circuit(circuit, gate_cycle_indices)
 
 
 @pytest.mark.parametrize(
     "instructions, method, expected_length, random_shuffle, gates_schedule",
     [
-        pytest.param(deepcopy(_instructions1()), "ASAP", 7, False, False, id="circuit1 pulse ASAP)"),
-        pytest.param(deepcopy(_instructions1()), "ALAP", 7, False, False, id="circuit1 pulse ALAP)"),
-    ])
+        pytest.param(
+            deepcopy(_instructions1()),
+            "ASAP",
+            7,
+            False,
+            False,
+            id="circuit1 pulse ASAP)",
+        ),
+        pytest.param(
+            deepcopy(_instructions1()),
+            "ALAP",
+            7,
+            False,
+            False,
+            id="circuit1 pulse ALAP)",
+        ),
+    ],
+)
 def test_scheduling_pulse(
-        instructions, method, expected_length, random_shuffle, gates_schedule):
+    instructions, method, expected_length, random_shuffle, gates_schedule
+):
     circuit = QubitCircuit(4)
     for instruction in instructions:
         circuit.add_gate(
-            Gate(instruction.name,
-            instruction.targets,
-            instruction.controls))
+            Gate(instruction.name, instruction.targets, instruction.controls)
+        )
 
     if random_shuffle:
         repeat_num = 5
@@ -204,15 +278,6 @@ def test_scheduling_pulse(
     # run the scheduler
     scheduler = Scheduler(method)
     gate_cycle_indices = scheduler.schedule(
-        instructions, gates_schedule=gates_schedule, repeat_num=repeat_num)
-
-    # check if the scheduled length is expected
-    assert(max(gate_cycle_indices) == expected_length)
-    scheduled_gate = [[] for i in range(max(gate_cycle_indices)+1)]
-
-    # check if the scheduled circuit is correct
-    for i, cycles in enumerate(gate_cycle_indices):
-        scheduled_gate[cycles].append(circuit.gates[i])
-    circuit.gates = sum(scheduled_gate, [])
-    result1 = gate_sequence_product(circuit.propagators())
-    assert(tracedist(result0*result1.dag(), qeye(result0.dims[0])) < 1.0e-7)
+        instructions, gates_schedule=gates_schedule, repeat_num=repeat_num
+    )
+    assert max(gate_cycle_indices) == expected_length


### PR DESCRIPTION
- Improve the readability of the scheduling algorithm.
- Add more commutation rules, such as CNOT and X on the targets, CNOT and Z on the control.

Most of the changes in the test file are just because of black styling.

@nathanshammah @quantshah 