### PR TITLE
Make circuit latex code accessible in QubitCircuit

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -2041,7 +2041,7 @@ class QubitCircuit:
                 code += r" & %s" % rows[m][n]
             code += r" & \qw \\ " + "\n"
 
-        return code
+        return _latex_template % code
 
     # This slightly convoluted dance with the conversion formats is because
     # image conversion has optional dependencies.  We always want the `png` and
@@ -2101,6 +2101,17 @@ class QubitCircuit:
 
         for op in self.gates:
             op._to_qasm(qasm_out)
+
+
+_latex_template = r"""
+\documentclass{standalone}
+\usepackage[braket]{qcircuit}
+\renewcommand{\qswap}{*=<0em>{\times}}
+\begin{document}
+\Qcircuit @C=1cm @R=1cm {
+%s}
+\end{document}
+"""
 
 
 class CircuitResult:

--- a/src/qutip_qip/circuit_latex.py
+++ b/src/qutip_qip/circuit_latex.py
@@ -7,16 +7,6 @@ import subprocess
 import tempfile
 import warnings
 
-_latex_template = r"""
-\documentclass{standalone}
-\usepackage[braket]{qcircuit}
-\renewcommand{\qswap}{*=<0em>{\times}}
-\begin{document}
-\Qcircuit @C=1cm @R=1cm {
-%s}
-\end{document}
-"""
-
 
 def _run_command(command, *args, **kwargs):
     """
@@ -215,7 +205,7 @@ if _pdflatex is not None:
             try:
                 os.chdir(temporary_dir)
                 with open(filename + ".tex", "w") as file:
-                    file.write(_latex_template % code)
+                    file.write(code)
                 try:
                     _run_command(
                         (_pdflatex, "-interaction", "batchmode", filename)
@@ -225,6 +215,11 @@ if _pdflatex is not None:
                         "pdflatex failed."
                         " Perhaps you do not have it installed, or you are"
                         " missing the LaTeX package 'qcircuit'."
+                    )
+                    message += (
+                        "The latex code is printed below. "
+                        "Please try to compile locally using pdflatex:\n"
+                        + code
                     )
                     raise RuntimeError(message) from e
                 _crop_pdf(filename + ".pdf")

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -626,10 +626,20 @@ class TestQubitCircuit:
                 np.testing.assert_allclose(probs_initial, probs_final)
                 assert sum(result_cbits[i]) == 1
 
+    _latex_template = r"""
+\documentclass{standalone}
+\usepackage[braket]{qcircuit}
+\renewcommand{\qswap}{*=<0em>{\times}}
+\begin{document}
+\Qcircuit @C=1cm @R=1cm {
+%s}
+\end{document}
+"""
+
     def test_latex_code_teleportation_circuit(self):
         qc = _teleportation_circuit()
         latex = qc.latex_code()
-        assert latex == "\n".join([
+        assert latex == self._latex_template % "\n".join([
             r" & \lstick{c1} &  \qw  &  \qw  &  \qw  &  \qw"
             r"  &  \qw \cwx[4]  &  \qw  &  \qw  &  \ctrl{2}  & \qw \\ ",
             r" & \lstick{c0} &  \qw  &  \qw  &  \qw  &  \qw"


### PR DESCRIPTION
- `QubitCircuit.latex_code()` now returns the full latex code (before only the code body without header), which can be saved as a tex file and compiled externally.
- The algorithm will print the latex code if pdflatex failed. This simplifies the debugging process.

@purva-thakre This should also simplify your debugging I guess?