### PR TITLE
Remove the check on the initial state dimension

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -2403,8 +2403,6 @@ class CircuitSimulator:
         self.state = None
 
         if state is not None:
-            if state.shape[0] != 2**self.qc.N:
-                raise ValueError("dimension of state is incorrect")
             if self.mode == "density_matrix_simulator" and state.isket:
                 self.state = ket2dm(state)
             else:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -480,7 +480,7 @@ class TestQubitCircuit:
         """
         Test for circuit with N-level system.
         """
-        mat3 = rand_dm(3, density=1.)
+        mat3 = qp.rand_unitary_haar(3)
 
         def controlled_mat3(arg_value):
             """
@@ -495,7 +495,13 @@ class TestQubitCircuit:
         qc.user_gates = {"CTRLMAT3": controlled_mat3}
         qc.add_gate("CTRLMAT3", targets=[1, 0], arg_value=1)
         props = qc.propagators()
-        np.testing.assert_allclose(mat3, ptrace(props[0], 0) - 1)
+        final_fid = qp.average_gate_fidelity(mat3, ptrace(props[0], 0) - 1)
+        assert pytest.approx(final_fid, 1.0e-6) == 1
+
+        init_state = basis([3, 2], [0, 1])
+        result = qc.run(init_state)
+        final_fid = qp.fidelity(result, props[0] * init_state)
+        assert pytest.approx(final_fid, 1.0e-6) == 1.
 
     @pytest.mark.repeat(10)
     def test_run_teleportation(self):


### PR DESCRIPTION
Remove the wrong check on the initial state dimension. It assumes a qubit state. However, we also support multilevel systems such as qudits.