### PR TITLE
Incorrect spelling of Hadamard

### DIFF
--- a/doc/source/Hadamard
+++ b/doc/source/Hadamard
@@ -1,0 +1,1 @@
+M	doc/source/qip-basics.rst

--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -149,7 +149,7 @@ Gate name                           Description
 "S"                   Single-qubit rotation or Z90
 "T"                   Square root of S gate
 "SQRTNOT"             Square root of NOT gate
-"SNOT"                Hardmard gate
+"SNOT"                Hadamard gate
 "PHASEGATE"           Add a phase one the state 1
 "CRX"                 Controlled rotation around x axis
 "CRY"                 Controlled rotation around y axis


### PR DESCRIPTION
There is a typo in [qip-basics.rst line 152](https://github.com/qutip/qutip-qip/edit/master/doc/source/qip-basics.rst#L152); it should be `Hadamard` instead of `Hardmard`