### PR TITLE
Fix Circuit Plotting for non-reversed states

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -2011,7 +2011,8 @@ class QubitCircuit:
                     if n in measurement.targets:
                         col.append(r" \meter")
                     elif (n - self.N) == measurement.classical_store:
-                        store_tag = n - measurement.targets[0]
+                        sgn = 1 if self.reverse_states else -1
+                        store_tag = sgn * (n - measurement.targets[0])
                         col.append(r" \qw \cwx[%d] " % store_tag)
                     else:
                         col.append(r" \qw ")

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -688,3 +688,17 @@ class TestQubitCircuit:
         final_output = valid_input.compute_unitary()
         assert(isinstance(final_output, Qobj))
         assert(final_output == correct_result)
+
+    def test_latex_code(self):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=True)
+        qc.add_measurement("M0", targets=0, classical_store=0)
+        exp = \
+            ' &  &  \\qw \\cwx[1]  & \\qw \\\\ \n &  &  \\meter & \\qw \\\\ \n'
+        assert qc.latex_code() == exp
+
+    def test_latex_code_non_reversed(self):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=False)
+        qc.add_measurement("M0", targets=0, classical_store=0)
+        exp = ' &  &  \\meter & \\qw \\\\ \n &  ' + \
+              '&  \\qw \\cwx[-1]  & \\qw \\\\ \n'
+        assert qc.latex_code() == exp

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -694,11 +694,11 @@ class TestQubitCircuit:
         qc.add_measurement("M0", targets=0, classical_store=0)
         exp = \
             ' &  &  \\qw \\cwx[1]  & \\qw \\\\ \n &  &  \\meter & \\qw \\\\ \n'
-        assert qc.latex_code() == exp
+        assert qc.latex_code() == self._latex_template % exp
 
     def test_latex_code_non_reversed(self):
         qc = QubitCircuit(1, num_cbits=1, reverse_states=False)
         qc.add_measurement("M0", targets=0, classical_store=0)
         exp = ' &  &  \\meter & \\qw \\\\ \n &  ' + \
               '&  \\qw \\cwx[-1]  & \\qw \\\\ \n'
-        assert qc.latex_code() == exp
+        assert qc.latex_code() == self._latex_template % exp


### PR DESCRIPTION
The plotting of circuits had an error for setting `reversed=False`. This was already discussed in a PR for the QuTiP repository. 
See: https://github.com/qutip/qutip/pull/1847
 