### PR TITLE
Fix add_gate behavior when supplied multiple indices

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -343,7 +343,8 @@ class QubitCircuit:
         arg_label: string
             Label for gate representation.
         index : list
-            Positions to add the gate.
+            Positions to add the gate. Each index in the supplied list refers
+            to a position in the original list of gates.
         classical_controls : int or list of int, optional
             indices of classical bits to control gate on.
         control_value : int, optional
@@ -378,7 +379,10 @@ class QubitCircuit:
             self.gates.append(gate)
 
         else:
-            for position in index:
+            # NOTE: Every insertion shifts the indices in the original list of
+            #       gates by an additional position to the right.
+            shifted_inds = np.sort(index) + np.arange(len(index))
+            for position in shifted_inds:
                 gate = Gate(
                     name,
                     targets=targets,

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -230,6 +230,52 @@ class TestQubitCircuit:
             # Single control
             pytest.raises(ValueError, qc.add_gate, gate, [0], [1])
 
+        dummy_gate1 = Gate("DUMMY1")
+        inds = [1, 3, 4, 6]
+        qc.add_gate(dummy_gate1, index=inds)
+
+        # Test adding gates at multiple (sorted) indices at once.
+        # NOTE: Every insertion shifts the indices in the original list of
+        #       gates by an additional position to the right.
+        expected_gate_names = [
+            'CNOT',     # 0
+            'DUMMY1',   # 1
+            'SWAP',     # 2
+            'TOFFOLI',  # 3
+            'DUMMY1',   # 4
+            'SWAP',     # 5
+            'DUMMY1',   # 6
+            'SNOT',     # 7
+            'RY',       # 8
+            'DUMMY1',   # 9
+            'RY',       # 10
+        ]
+        actual_gate_names = [gate.name for gate in qc.gates]
+        assert actual_gate_names == expected_gate_names
+
+        dummy_gate2 = Gate("DUMMY2")
+        inds = [11, 0]
+        qc.add_gate(dummy_gate2, index=inds)
+
+        # Test adding gates at multiple (unsorted) indices at once.
+        expected_gate_names = [
+            'DUMMY2',   # 0
+            'CNOT',     # 1
+            'DUMMY1',   # 2
+            'SWAP',     # 3
+            'TOFFOLI',  # 4
+            'DUMMY1',   # 5
+            'SWAP',     # 6
+            'DUMMY1',   # 7
+            'SNOT',     # 8
+            'RY',       # 9
+            'DUMMY1',   # 10
+            'RY',       # 11
+            'DUMMY2',   # 12
+        ]
+        actual_gate_names = [gate.name for gate in qc.gates]
+        assert actual_gate_names == expected_gate_names
+
     def test_add_circuit(self):
         """
         Addition of a circuit to a `QubitCircuit`
@@ -522,7 +568,6 @@ class TestQubitCircuit:
 
         teleportation_sim_results = teleportation_sim.run(state)
         state_final = teleportation_sim_results.get_final_states(0)
-        probability = teleportation_sim_results.get_probabilities(0)
 
         final_measurement = Measurement("start", targets=[2])
         _, final_probabilities = final_measurement.measurement_comp_basis(state_final)
@@ -611,10 +656,6 @@ class TestQubitCircuit:
         qc = read_qasm(filepath)
 
         rand_state = rand_ket(2)
-        wstate = (tensor(basis(2, 0), basis(2, 0), basis(2, 1))
-                  + tensor(basis(2, 0), basis(2, 1), basis(2, 0))
-                  + tensor(basis(2, 1), basis(2, 0), basis(2, 0))).unit()
-
         state = tensor(tensor(basis(2, 0), basis(2, 0), basis(2, 0)),
                        rand_state)
 


### PR DESCRIPTION
**Description**
The fix pertains to `add_gate` behaviour when multiple insertion indices are supplied. Prior to the proposed fix, the insertion loop doesn't take into account the fact that inserting an element in the gates list, modifies the indices in the original list, whereas the caller of `add_gate` supplies a list of indices, with positions with respect to the indices in the original list.

Additionally, the PR removes unused variables and unused function (that has also not been imported).

**Related issues or PRs**
N/A (this is the `qutip-qip` equivalent of https://github.com/qutip/qutip/issues/1497 / https://github.com/qutip/qutip/pull/1892).

**Changelog**
Fixed add_gate behavior when inserting a gate at multiple indices.
