### PR TITLE
Remove qutip.qip importation

### DIFF
--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -112,8 +112,9 @@ class Measurement:
         else:
             raise ValueError("target is not valid")
 
+        measurement_ops = [expand_operator(op, N=n, targets=self.targets) for op in measurement_ops]
         return measurement_statistics(
-            state, measurement_ops, targets=self.targets
+            state, measurement_ops
         )
 
     def __str__(self):

--- a/src/qutip_qip/circuit.py
+++ b/src/qutip_qip/circuit.py
@@ -112,10 +112,11 @@ class Measurement:
         else:
             raise ValueError("target is not valid")
 
-        measurement_ops = [expand_operator(op, N=n, targets=self.targets) for op in measurement_ops]
-        return measurement_statistics(
-            state, measurement_ops
-        )
+        measurement_ops = [
+            expand_operator(op, N=n, targets=self.targets)
+            for op in measurement_ops
+        ]
+        return measurement_statistics(state, measurement_ops)
 
     def __str__(self):
         str_name = ("Measurement(%s, target=%s, classical_store=%s)") % (

--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -3,10 +3,10 @@ import types
 import random
 import numpy as np
 from qutip import basis, tensor, Qobj, qeye, expect
-from qutip.qip.circuit import QubitCircuit
+from qutip_qip.circuit import QubitCircuit
 from scipy.optimize import minimize
 from scipy.linalg import expm_frechet
-from qutip.qip.operations.gates import gate_sequence_product
+from qutip_qip.operations.gates import gate_sequence_product
 
 
 class VQA:


### PR DESCRIPTION
The VQA module wrongly used the qutip.qip module, which is removed in qutip-v5