### PR TITLE
Final time calculation in `_concatenate_pulses`.

### DIFF
--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -249,7 +249,7 @@ class GateCompiler(object):
                 compiled_tlist[pulse_ind].append(execution_time)
                 compiled_coeffs[pulse_ind].append(coeffs)
 
-        final_time = np.max([tlist[-1] for tlist in compiled_tlist])
+        final_time = np.max([tlist[-1][-1] for tlist in compiled_tlist])
         for pulse_ind in range(num_controls):
             if not compiled_tlist[pulse_ind]:
                 continue

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -89,7 +89,7 @@ def test_compiling_gates_different_sampling_number():
     )
 
 
-#### Test the compiler with a physical model.
+# Test the compiler with a physical model.
 class MyCompiler(GateCompiler):  # compiler class
     def __init__(self, num_qubits, params):
         super(MyCompiler, self).__init__(num_qubits, params=params)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -39,11 +39,57 @@ def test_compiling_with_scheduler():
     assert(abs(time_scheduled2 * 2 - time_not_scheduled) < 1.0e-10)
 
 
-def gauss_dist(t, sigma, amplitude, duration):
-    return amplitude/np.sqrt(2*np.pi) /sigma*np.exp(-0.5*((t-duration/2)/sigma)**2)
+def test_compiling_gates_different_sampling_number():
+    """
+    Define compiler without a physical model.
+    Test compiling gates to pulses with different sampling number.
+    """
+
+    class MockCompiler(GateCompiler):
+        def __init__(self, num_qubits, params=None):
+            super().__init__(num_qubits, params=params)
+            self.gate_compiler["U1"] = self.single_qubit_gate_compiler
+            self.gate_compiler["U2"] = self.two_qubit_gate_compiler
+            self.args.update({"params": params})
+
+        def single_qubit_gate_compiler(self, gate, args):
+            pulse_info = [("x", np.array([1.0] * 3))]
+            return [
+                Instruction(
+                    gate, tlist=np.linspace(0, 2, 3), pulse_info=pulse_info
+                )
+            ]
+
+        def two_qubit_gate_compiler(self, gate, args):
+            pulse_info = [("xx", np.array([2.0] * 5))]
+            return [
+                Instruction(
+                    gate, tlist=np.linspace(0, 4, 5), pulse_info=pulse_info
+                )
+            ]
+
+    num_qubits = 2
+    circuit = QubitCircuit(num_qubits)
+    circuit.add_gate("U1", targets=0, arg_value=1.0)
+    circuit.add_gate("U2", targets=[0, 1], arg_value=1.0)
+    circuit.add_gate("U1", targets=0, arg_value=1.0)
+
+    compiler = MockCompiler(num_qubits=2)
+    compiled_tlists, compiled_coeffs = compiler.compile(circuit)
+
+    # Filter out the nonzero part of the pulse
+    # and check if they are correct.
+    np.testing.assert_array_equal(
+        compiled_tlists["x"][np.nonzero(compiled_coeffs["x"])[0]],
+        np.array([1, 2, 7, 8]),
+    )
+    np.testing.assert_array_equal(
+        compiled_tlists["xx"][np.nonzero(compiled_coeffs["xx"])[0]],
+        np.array([3, 4, 5, 6]),
+    )
 
 
-from qutip_qip.compiler import GateCompiler
+#### Test the compiler with a physical model.
 class MyCompiler(GateCompiler):  # compiler class
     def __init__(self, num_qubits, params):
         super(MyCompiler, self).__init__(num_qubits, params=params)


### PR DESCRIPTION
The calculation of `final_time` was done by taking the last element of the `tlist` in `compiled_tlist`. However, the elements in `compiled_tlist` are again lists, where the first element is just a list and the second element are the actual times.
E.g. `tlist = [[0.0], np.array([...])]`

 So we have to take the second ( i.e. last) element from that and then the last element to get the largest time.
The previous version sometimes produced errors when using `processor.load_circuit(...)`.

