### PR TITLE
Fix usage of `rand_unitary` and `rand_ket`

### DIFF
--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -479,7 +479,7 @@ class TestQubitCircuit:
         """
         Test for circuit with N-level system.
         """
-        mat3 = qp.rand_unitary_haar(3)
+        mat3 = qp.rand_unitary(3)
 
         def controlled_mat3(arg_value):
             """

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -349,7 +349,7 @@ def test_gates_class():
     if parse_version(qutip.__version__) < parse_version('5.dev'):
         init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
     else:
-        init_state = qutip.rand_ket([2,2,2])
+        init_state = qutip.rand_ket([2, 2, 2])
 
     circuit1 = QubitCircuit(3)
     circuit1.add_gate("X", 1)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -346,7 +346,10 @@ class Test_expand_operator:
             np.testing.assert_allclose(test.full(), expected.full())
 
 def test_gates_class():
-    init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
+    if parse_version(qutip.__version__) < parse_version('5.dev'):
+        init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
+    else:
+        init_state = qutip.rand_ket([2,2,2])
 
     circuit1 = QubitCircuit(3)
     circuit1.add_gate("X", 1)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from packaging.version import parse as parse_version
 import pytest
 import functools
 import itertools
@@ -23,7 +24,10 @@ def _infidelity(a, b):
 
 def _make_random_three_qubit_gate():
     """Create a random three-qubit gate."""
-    operation = qutip.rand_unitary(8, dims=[[2]*3]*2)
+    if parse_version(qutip.__version__) < parse_version('5.dev'):
+        operation = qutip.rand_unitary(8, dims=[[2] * 3] * 2)
+    else:
+        operation = qutip.rand_unitary([2] * 3)
 
     def gate(N=None, controls=None, target=None):
         if N is None:
@@ -272,7 +276,10 @@ class Test_expand_operator:
     def test_general_qubit_expansion(self, n_targets):
         # Test all permutations with the given number of targets.
         n_qubits = 5
-        operation = qutip.rand_unitary(2**n_targets, dims=[[2]*n_targets]*2)
+        if parse_version(qutip.__version__) < parse_version('5.dev'):
+            operation = qutip.rand_unitary(2**n_targets, dims=[[2]*n_targets]*2)
+        else:
+            operation = qutip.rand_unitary([2]*n_targets)
         for targets in itertools.permutations(range(n_qubits), n_targets):
             expected = _tensor_with_entanglement([qutip.qeye(2)] * n_qubits,
                                                  operation, targets)

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -116,7 +116,12 @@ class TestOptPulseProcessor:
         processor.load_circuit(
             qc, merge_gates=True, num_tslots=10, evo_time=2.0
         )
-        init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
+
+        if parse_version(qutip.__version__) < parse_version('5.dev'):
+            init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
+        else:
+            init_state = qutip.rand_ket([2, 2, 2])
+
         num_result = processor.run_state(init_state=init_state).states[-1]
         ideal_result = qc.run(init_state)
         assert (


### PR DESCRIPTION
The signature of `rand_unitary` has changed recently in QuTiP 5. The argument `dims` no longer exists. This PR changes the two usages of `rand_unitary` by checking the version of QuTiP and then using the corresponding definition. 
The same holds for `rand_ket`.

The tests were recently failing due to this change in QuTiP 5.