### PR TITLE
SWAP gate for (non-) reversed circuit

### DIFF
--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -967,7 +967,9 @@ class QubitCircuit:
                                 distance = abs(
                                     gate.targets[1] - gate.targets[0]
                                 )
-                                col.append(r" \qswap \qwx[-%d] \qw" % distance)
+                                if self.reverse_states:
+                                    distance = -distance
+                                col.append(r" \qswap \qwx[%d] \qw" % distance)
                                 _swap_processing = True
 
                             elif (


### PR DESCRIPTION
SWAP needs to be treated differently for circuits with reversed and non-reversed states order.

The fix in https://github.com/qutip/qutip-qip/pull/170 was not complete. The reason for using `\qwx[%d]` without the minus sign is actually because in `qutip-qip` the order of states is reversed.