### PR TITLE
Filter the measured probability

### DIFF
--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -641,7 +641,7 @@ class CircuitSimulator:
             measured_tol = qutip.settings.core["atol"] ** 2
         except AttributeError:
             # qutip-v4
-            measured_tol = qutip.settings.atol ** 2
+            measured_tol = qutip.settings.atol**2
 
         if self.mode == "state_vector_simulator":
             if self.measure_results:

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -10,6 +10,7 @@ from ..operations import (
     expand_operator,
     gate_sequence_product,
 )
+import qutip
 from qutip import basis, ket2dm, Qobj, tensor
 import warnings
 
@@ -634,8 +635,13 @@ class CircuitSimulator:
         operation: :class:`.Measurement`
             Measurement gate in a circuit object.
         """
-
         states, probabilities = operation.measurement_comp_basis(self.state)
+        try:
+            # qutip-v5
+            measured_tol = qutip.settings.core["atol"] ** 2
+        except AttributeError:
+            # qutip-v4
+            measured_tol = qutip.settings.atol ** 2
 
         if self.mode == "state_vector_simulator":
             if self.measure_results:
@@ -644,15 +650,19 @@ class CircuitSimulator:
             else:
                 probabilities = [p / sum(probabilities) for p in probabilities]
                 i = np.random.choice([0, 1], p=probabilities)
-            self.probability *= probabilities[i]
-            self.state = states[i]
+            self.probability *= (
+                probabilities[i] if probabilities[i] > measured_tol else 0.0
+            )
+            self.state = states[i] if probabilities[i] > measured_tol else None
             if operation.classical_store is not None:
                 self.cbits[operation.classical_store] = i
-
         elif self.mode == "density_matrix_simulator":
-            states = list(filter(lambda x: x is not None, states))
-            probabilities = list(filter(lambda x: x != 0, probabilities))
-            self.state = sum(p * s for s, p in zip(states, probabilities))
+            states_probabilities_zipped = [
+                (s, p)
+                for (s, p) in zip(states, probabilities)
+                if p > measured_tol
+            ]
+            self.state = sum(p * s for s, p in states_probabilities_zipped)
         else:
             raise NotImplementedError(
                 "mode {} is not available.".format(self.mode)

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -641,7 +641,7 @@ class CircuitSimulator:
             measured_tol = qutip.settings.core["atol"] ** 2
         except AttributeError:
             # qutip-v4
-            measured_tol = qutip.settings.atol**2
+            measured_tol = qutip.settings.atol ** 2
 
         if self.mode == "state_vector_simulator":
             if self.measure_results:

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -8,6 +8,7 @@ from qutip import (Qobj, basis, ket2dm,
 from qutip.measurement import (measure_povm, measurement_statistics_povm,
                                 measure_observable,
                                 measurement_statistics_observable)
+import qutip
 
 
 @pytest.mark.repeat(10)
@@ -67,3 +68,11 @@ def test_measurement_collapse(index):
             states_11, probability_11 = Mprime.measurement_comp_basis(state)
             assert probability_11[1] == 1
             assert states_11[0] is None
+
+
+def test_against_numerical_error():
+    state = qutip.Qobj([[1], [1.e-12]])
+    measurement = Measurement("M", 0)
+    states, probabilites = measurement.measurement_comp_basis(state)
+    assert states[1] is None
+    assert probabilites[1] == 0.


### PR DESCRIPTION
Use the `atol` option in qutip to determine the tolerance for measurement. And filter out the states with a probability smaller than this.

See also: https://github.com/qutip/qutip/issues/2029
