### PR TITLE
Update the github actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
           options: "--check --diff"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # For the sdist we should be as conservative as possible with our
@@ -68,7 +68,7 @@ jobs:
           # dependencies are specified by our setup code.
           python -m build --sdist .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -83,9 +83,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
@@ -105,7 +105,7 @@ jobs:
           # dependencies are specified by our setup code.
           python -m build --wheel --outdir wheelhouse .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -124,9 +124,9 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -39,7 +39,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: qutip_qip_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,47 +6,48 @@ on:
   pull_request:
 
 jobs:
-  test:
+  cases:
+    name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - case-name: Ubuntu qutip@dev.major
+          - case-name: qutip@dev.major
             os: ubuntu-latest
             qutip-version: '@dev.major'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.10'
-          - case-name: Ubuntu qutip@master
+          - case-name: qutip@master
             os: ubuntu-latest
             qutip-version: '@master'
             pyqir-version: ''
             python-version: '3.11'
-          - case-name: Windows qutip@4.6
+          - case-name: qutip@4.6
             os: windows-latest
             qutip-version: '==4.6.*'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.8'
-          - case-name: Mac qutip@4.7
+          - case-name: qutip@4.7
             os: macOS-latest
             qutip-version: '==4.7.*'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.9'
-          - case-name: Windows full
+          - case-name: full
             os: windows-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'
             pyqir-version: '==0.6.2'
             python-version: '3.8'
-          - case-name: Mac full
+          - case-name: full
             os: macOS-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'
             pyqir-version: '==0.6.2'
             python-version: '3.9'
-          - case-name: Ubuntu full
+          - case-name: full
             os: ubuntu-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
 
   finalise:
     name: Finalise coverage reporting
-    needs: [test]
+    needs: [cases]
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,45 +11,52 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - case-name: Ubuntu qutip@dev.major
+            os: ubuntu-latest
             qutip-version: '@dev.major'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.10'
-          - os: windows-latest
+          - case-name: Ubuntu qutip@master
+            os: ubuntu-latest
+            qutip-version: '@master'
+            pyqir-version: ''
+            python-version: '3.11'
+          - case-name: Windows qutip@4.6
+            os: windows-latest
             qutip-version: '==4.6.*'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.8'
-          - os: windows-latest
-            qutip-version: '==4.6.*'
-            qiskit-version: ''
-            pyqir-version: '==0.6.2'
-            python-version: '3.8'
-          - os: macOS-latest
+          - case-name: Mac qutip@4.7
+            os: macOS-latest
             qutip-version: '==4.7.*'
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.9'
-          - os: macOS-latest
-            qutip-version: '==4.7.*'
-            qiskit-version: ''
-            pyqir-version: '==0.6.2'
-            python-version: '3.9'
-          - os: ubuntu-latest
+          - case-name: Windows full
+            os: windows-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'
-            pyqir-version: ''
-            python-version: '3.7'
-          - os: ubuntu-latest
+            pyqir-version: '==0.6.2'
+            python-version: '3.8'
+          - case-name: Mac full
+            os: macOS-latest
             qutip-version: ''
+            qiskit-version: '==0.36.*'
+            pyqir-version: '==0.6.2'
+            python-version: '3.9'
+          - case-name: Ubuntu full
+            os: ubuntu-latest
+            qutip-version: ''
+            qiskit-version: '==0.36.*'
             pyqir-version: '==0.6.2'
             python-version: '3.7'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -90,9 +97,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,19 @@ jobs:
             qiskit-version: ''
             pyqir-version: ''
             python-version: '3.9'
-          - case-name: full
+          - case-name: qiskit+qir
             os: windows-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'
             pyqir-version: '==0.6.2'
             python-version: '3.8'
-          - case-name: full
+          - case-name: qiskit+qir
             os: macOS-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'
             pyqir-version: '==0.6.2'
             python-version: '3.9'
-          - case-name: full
+          - case-name: qiskit+qir
             os: ubuntu-latest
             qutip-version: ''
             qiskit-version: '==0.36.*'


### PR DESCRIPTION
- Add back the test against qutip@master (which was removed because @master was labelled as version 5.0.0 and could not be distinguished from @dev.major)
- Add a test against python 3.11
- Redistribute the test cases
- Update the versions of the GitHub built-in actions