### PR TITLE
Update the build action for 0.2.X

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,15 +46,15 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
           # means that no unsupported syntax can sneak through.
-          python-version: '3.6'
+          python-version: '3.7'
 
       - name: Install pip build
         run: |
@@ -68,7 +68,7 @@ jobs:
           # dependencies are specified by our setup code.
           python -m build --sdist .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -83,9 +83,9 @@ jobs:
       OVERRIDE_VERSION: ${{ github.event.inputs.override_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           # This is about the build environment, not the released wheel version.
@@ -105,7 +105,7 @@ jobs:
           # dependencies are specified by our setup code.
           python -m build --wheel --outdir wheelhouse .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -124,9 +124,9 @@ jobs:
 
     steps:
       - name: Download build artifacts to local runner
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.7'


### PR DESCRIPTION
Use Python 3.7 for the build environment. Python 3.6 is already removed from the latest machine for Github Action.

The build was successful. https://github.com/BoxiLi/qutip-qip/actions/runs/3679944891