### PR TITLE
Remove tests again the `dev.major` branch of Qutip.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - case-name: qutip@qutip-4.7.X
+            os: ubuntu-latest
+            qutip-version: '@qutip-4.7.X'
+            pyqir-version: ''
+            python-version: '3.10'
           - case-name: qutip@master
             os: ubuntu-latest
             qutip-version: '@master'
@@ -28,7 +33,7 @@ jobs:
             qutip-version: '==4.7.*'
             qiskit-version: ''
             pyqir-version: ''
-            python-version: '3.10'
+            python-version: '3.9'
           - case-name: qiskit+qir
             os: windows-latest
             qutip-version: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - case-name: qutip@dev.major
-            os: ubuntu-latest
-            qutip-version: '@dev.major'
-            qiskit-version: ''
-            pyqir-version: ''
-            python-version: '3.10'
           - case-name: qutip@master
             os: ubuntu-latest
             qutip-version: '@master'
@@ -34,7 +28,7 @@ jobs:
             qutip-version: '==4.7.*'
             qiskit-version: ''
             pyqir-version: ''
-            python-version: '3.9'
+            python-version: '3.10'
           - case-name: qiskit+qir
             os: windows-latest
             qutip-version: ''


### PR DESCRIPTION
We merged the branch `dev.major` branch into `master` last Monday. Thus tests against both of these branches are redundant.
I remove the test using `qutip@dev.major` since all further work for v5 will be done in `master`. It was the only test using python 3.10, so updated another test to use it.

There are no longer any active development branch for v4, all test using qutip v4 are ran using released version.