### PR TITLE
Fix bug resulting from changing v5's default solver

### DIFF
--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1221,7 +1221,7 @@ class Processor(object):
             )
         elif solver == "mcsolve":
             evo_result = mcsolve(
-                H=noisy_qobjevo, state=init_state, tlist=tlist, **kwargs
+                noisy_qobjevo, init_state, tlist=tlist, **kwargs
             )
 
         return evo_result

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1206,9 +1206,9 @@ class Processor(object):
         else:
             total_circuit_time = 0.0
         if is_qutip5:
-            options = kwargs.get("options", qutip.SolverOptions())
-            if options["max_step"] == 0.0:
-                options["max_step"] = total_circuit_time / 10
+            options = kwargs.get("options", qutip.Options())
+            if options.get("max_step", 0.0) == 0.0:
+                options["max_step"] = total_circuit_time / 25
         else:
             options = kwargs.get("options", qutip.Options())
             if options.max_step == 0.0:
@@ -1221,7 +1221,7 @@ class Processor(object):
             )
         elif solver == "mcsolve":
             evo_result = mcsolve(
-                H=noisy_qobjevo, psi0=init_state, tlist=tlist, **kwargs
+                H=noisy_qobjevo, state=init_state, tlist=tlist, **kwargs
             )
 
         return evo_result

--- a/src/qutip_qip/qiskit/backend.py
+++ b/src/qutip_qip/qiskit/backend.py
@@ -209,7 +209,7 @@ class QiskitCircuitSimulator(QiskitSimulatorBase):
         )[0]
 
         exp_res_data = ExperimentResultData(
-            counts=counts, statevector=Statevector(data=np.array(statevector))
+            counts=counts, statevector=Statevector(data=statevector.full())
         )
 
         header = QobjExperimentHeader.from_dict(
@@ -366,9 +366,9 @@ class QiskitPulseSimulator(QiskitSimulatorBase):
 
         exp_res_data = ExperimentResultData(
             counts=counts,
-            statevector=Statevector(data=np.array(final_state))
+            statevector=Statevector(data=final_state.full())
             if final_state.type == "ket"
-            else DensityMatrix(data=np.array(final_state)),
+            else DensityMatrix(data=final_state.full()),
         )
 
         header = QobjExperimentHeader.from_dict(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,10 +13,7 @@ from qutip_qip.device import (DispersiveCavityQED, LinearSpinChain,
                                 CircularSpinChain, SCQubits)
 
 from packaging.version import parse as parse_version
-if parse_version(qutip.__version__) < parse_version('5.dev'):
-    from qutip import Options as SolverOptions
-else:
-    from qutip import SolverOptions
+from qutip import Options
 
 _tol = 3.e-2
 
@@ -126,7 +123,7 @@ def test_numerical_evolution(
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = SolverOptions(store_final_state=True, nsteps=50_000)
+    options = Options(store_final_state=True, nsteps=50_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)
@@ -183,7 +180,7 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = SolverOptions(store_final_state=True, nsteps=50_000)
+    options = Options(store_final_state=True, nsteps=50_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)


### PR DESCRIPTION
We removed the old solvers that were existing in parallel to the new ones in qutip v5. This broke a few tests.

- Solvers options are now simple dict. The default options are per solver basis and unknown to `qutip.Options`.
- `qutip.Options` and `qutip.SolverOptions` are equivalent and deprecated.
- `mcsolve` can accept density matrix input, it use `state=` instead of `rho0=`.
- `array(qobj)` should have been not working for a while now, `full()` is the method preferred when converting to a numpy array.
- I had to reduce the `max_step` for one test... Unless there was a pulse thinner than the previous value and the solver happen to be lucky and find it previously, I don't understand why I had to reduce it that much. I hope that the idea in #184, when implemented, will be able to bring some light on the issue.