### PR TITLE
Install qutip-qtrl in the test action for qutip5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,12 @@ jobs:
         python -m pip install numpy scipy cython
         python -m pip install 'git+https://github.com/qutip/qutip.git${{ matrix.qutip-version }}'
 
+    # For qutip-v5 qutip.control is replaced by qutip-qtrl
+    - name: Install qutip-qtrl from PyPI
+      if: ${{ matrix.qutip-version == '@master'}}
+      run: |
+        python -m pip install qutip-qtrl
+
     - name: Install Qiskit from PyPI
       if: ${{ matrix.qiskit-version != '' }}
       run: python -m pip install 'qiskit${{ matrix.qiskit-version }}'


### PR DESCRIPTION
The module `qutip.control` is replaced by the package `qutip-qtrl`, see https://github.com/qutip/qutip/pull/2116.