### PR TITLE
Define max_step separately for CavityQED

### DIFF
--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -206,6 +206,18 @@ class DispersiveCavityQED(ModelProcessor):
             range(1, len(final_processor_state.dims[0]))
         )
 
+    def _get_max_step(self):
+        """
+        Define the maximal sampling step for the solver.
+        """
+        full_tlist = self.get_full_tlist()
+        if full_tlist is not None:
+            # For this model, discrete pulses are used.
+            # Hence we use half of the gate time as the step size.
+            return np.min(np.diff(full_tlist)) / 2
+        else:
+            return 0.0
+
 
 class CavityQEDModel(Model):
     """

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1200,20 +1200,15 @@ class Processor(object):
         # A better solution is to use the gate, which
         # is however, much harder to implement at this stage, see also
         # https://github.com/qutip/qutip-qip/issues/184.
-        full_tlist = self.get_full_tlist()
-        if full_tlist is not None:
-            total_circuit_time = (full_tlist)[-1]
-        else:
-            total_circuit_time = 0.0
         if is_qutip5:
             options = kwargs.get("options", qutip.Options())
             if options.get("max_step", 0.0) == 0.0:
-                options["max_step"] = total_circuit_time / 25
+                options["max_step"] = self._get_max_step()
             options["progress_bar"] = False
         else:
             options = kwargs.get("options", qutip.Options())
             if options.max_step == 0.0:
-                options.max_step = total_circuit_time / 10
+                options.max_step = self._get_max_step()
             options.progress_bar = False
         kwargs["options"] = options
         # choose solver:
@@ -1227,6 +1222,17 @@ class Processor(object):
             )
 
         return evo_result
+
+    def _get_max_step(self):
+        """
+        Define the maximal sampling step for the solver.
+        """
+        full_tlist = self.get_full_tlist()
+        if full_tlist is not None:
+            total_circuit_time = (full_tlist)[-1]
+        else:
+            total_circuit_time = 0.0
+        return total_circuit_time / 10
 
     def load_circuit(self, qc):
         """


### PR DESCRIPTION
The CavityQED processor uses discrete pulses and different gates may vary a lot in terms of the gate time. This often results in a piece of pulses being neglected by the adaptive ODE solver. Ideally, the `max_step` option should be set as half of the shortest gate time but this information is lost during the compilation and can only be estimated from the compiled pulses. This PR allows the calculation of `max_step` to be defined for each type of Processor.

This should fix the failing tests.