### PR TITLE
Cleaning a few warnings in the test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Test with pytest and generate coverage report
       run: |
         pip install pytest-cov coveralls
-        pytest tests --strict-markers --cov=qutip_qip --cov-report=
+        pytest tests -Werror --strict-markers --cov=qutip_qip --cov-report= --color=yes
     - name: Upload to Coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Test with pytest and generate coverage report
       run: |
         pip install pytest-cov coveralls
-        pytest tests -Werror --strict-markers --cov=qutip_qip --cov-report= --color=yes
+        pytest tests --strict-markers --cov=qutip_qip --cov-report= --color=yes
     - name: Upload to Coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -220,7 +220,7 @@ class DispersiveCavityQED(ModelProcessor):
 
 
 class CavityQEDModel(Model):
-    """
+    r"""
     The physical model for a dispersive cavity-QED processor
     (:obj:`.DispersiveCavityQED`).
     It is a qubit-resonator model that describes a system composed of

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -331,7 +331,7 @@ class Processor(object):
         return self.model.get_control_labels()
 
     def get_control_latex(self):
-        """
+        r"""
         Get the latex string for each Hamiltonian.
         It is used in the method :meth:`.Processor.plot_pulses`.
         It is a list of dictionaries.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,9 @@ markers =
     requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.
 filterwarnings =
     error
+    ; ImportWarning: PyxImporter.find_spec() not found
+    ignore:PyxImporter:ImportWarning
+    ; DeprecationWarning: Please use `upcast` from the `scipy.sparse` namespace
     ignore::DeprecationWarning:qutip.fastsparse*:
     ignore:matplotlib not found:UserWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,8 +3,8 @@ markers =
     slow: Mark a test as taking a long time to run, and so can be skipped with `pytest -m "not slow"`.
     repeat(n): Repeat the given test 'n' times.
     requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.
-
 filterwarnings =
+    error
     ignore:matplotlib not found:UserWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore:Dedicated options class are no longer needed, options should be passed as dict to solvers.:FutureWarning

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,7 @@ markers =
     requires_cython: Mark that the given test requires Cython to be installed.  Such tests will be skipped if Cython is not available.
 filterwarnings =
     error
+    ignore::DeprecationWarning:qutip.fastsparse*:
     ignore:matplotlib not found:UserWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore:Dedicated options class are no longer needed, options should be passed as dict to solvers.:FutureWarning

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -195,10 +195,7 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     "processor_class",
     [DispersiveCavityQED, LinearSpinChain, CircularSpinChain, SCQubits])
 def test_pulse_plotting(processor_class):
-    try:
-        import matplotlib.pyplot as plt
-    except Exception:
-        return True
+    plt = pytest.importorskip("matplotlib.pyplot")
     qc = QubitCircuit(3)
     qc.add_gate("CNOT", 1, 0)
     qc.add_gate("X", 1)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -143,10 +143,8 @@ class TestCircuitProcessor:
         """
         Test for plotting functions
         """
-        try:
-            import matplotlib.pyplot as plt
-        except Exception:
-            return True
+        plt = pytest.importorskip("matplotlib.pyplot")
+
         # step_func
         tlist = np.linspace(0., 2*np.pi, 20)
         processor = Processor(N=1, spline_kind="step_func")

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -186,11 +186,8 @@ class TestVQACircuit:
         """
         Check plotting function returns without error
         """
+        plt = pytest.importorskip("matplotlib.pyplot")
         # Only test on environments that have the matplotlib dependency
-        try:
-            import matplotlib.pyplot as plt
-        except Exception:
-            return True
         vqa = VQA(num_qubits=4, num_layers=1, cost_method="STATE")
         for i in range(4):
             vqa.add_block(VQABlock("X", targets=[i]))


### PR DESCRIPTION
- pytest warning to error
- Use raw string literals for docstrings with LaTeX
- Skip plotting tests correctly when matplotlib not installed