### PR TITLE
Added qutip-qip tutorials links to documentation (#204)

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -5,6 +5,6 @@ Tutorials
 ************
 
 Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
-found `here <https://qutip.org/tutorials#quantum-information-processing>`_ and
+found `here <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_ and
 those related to using noise simulators are available at this
-`link <https://qutip.org/tutorials#nisq>`_.
+`link <https://qutip.org/qutip-tutorials/#quantum-information-processing>`_.

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -8,3 +8,43 @@ Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
 found `here <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_ and
 those related to using noise simulators are available at this
 `link <https://qutip.org/qutip-tutorials/#quantum-information-processing>`_.
+
+
+
+Quantum information processing
+This section requires an additional package qutip-qip.  `Link <https://github.com/qutip/qutip-qip>`_
+
+- Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_
+
+- Imports and Exports QASM circuit
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qasm.ipynb>`_
+
+- QuTiP example: Quantum Gates and their usage
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/quantum-gates.ipynb>`_
+
+- Quantum Teleportation Circuit
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/teleportation.ipynb>`_
+
+Pulse-level circuit simulation:
+
+- Compiling and simulating a 10-qubit Quantum Fourier Transform (QFT) algorithm
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-10-qubit-QFT-algorithm.ipynb>`_
+
+- Customize the pulse-level simulation
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-customize-device.ipynb>`_
+
+- Examples for OptPulseProcessor
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-optpulseprocessor.ipynb>`_
+
+- Scheduler for quantum gates and instructions
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-scheduler.ipynb>`_
+
+- Simulating randomized benchmarking
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-randomized-benchmarking.ipynb>`_
+
+- Simulating the Deutsch–Jozsa algorithm at the pulse level
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.ipynb>`_
+
+- Measuring the relaxation time with the idling gate
+  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-relaxation-measurement-with-the-idling-gate.ipynb>`_

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -4,47 +4,32 @@
 Tutorials
 ************
 
-Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
-found `here <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_ and
-those related to using noise simulators are available at this
-`link <https://qutip.org/qutip-tutorials/#quantum-information-processing>`_.
+Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be found at the following links:
 
+- Quantum information processing: `Link <https://github.com/qutip/qutip-qip>`_
 
+- Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_
 
-Quantum information processing
-This section requires an additional package qutip-qip.  `Link <https://github.com/qutip/qutip-qip>`_
+- Imports and Exports QASM circuit: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qasm.ipynb>`_
 
-- Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_
+- QuTiP example: Quantum Gates and their usage: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/quantum-gates.ipynb>`_
 
-- Imports and Exports QASM circuit
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qasm.ipynb>`_
-
-- QuTiP example: Quantum Gates and their usage
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/quantum-gates.ipynb>`_
-
-- Quantum Teleportation Circuit
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/teleportation.ipynb>`_
+- Quantum Teleportation Circuit: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/teleportation.ipynb>`_
 
 Pulse-level circuit simulation:
 
-- Compiling and simulating a 10-qubit Quantum Fourier Transform (QFT) algorithm
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-10-qubit-QFT-algorithm.ipynb>`_
+- Compiling and simulating a 10-qubit Quantum Fourier Transform (QFT) algorithm: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-10-qubit-QFT-algorithm.ipynb>`_
 
-- Customize the pulse-level simulation
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-customize-device.ipynb>`_
+- Customize the pulse-level simulation: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-customize-device.ipynb>`_
 
-- Examples for OptPulseProcessor
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-optpulseprocessor.ipynb>`_
+- Examples for OptPulseProcessor: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-optpulseprocessor.ipynb>`_
 
-- Scheduler for quantum gates and instructions
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-scheduler.ipynb>`_
+- Scheduler for quantum gates and instructions: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-scheduler.ipynb>`_
 
-- Simulating randomized benchmarking
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-randomized-benchmarking.ipynb>`_
+- Simulating randomized benchmarking: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-randomized-benchmarking.ipynb>`_
 
-- Simulating the Deutsch–Jozsa algorithm at the pulse level
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.ipynb>`_
+- Simulating the Deutsch–Jozsa algorithm at the pulse level: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.ipynb>`_
 
-- Measuring the relaxation time with the idling gate
-  `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-relaxation-measurement-with-the-idling-gate.ipynb>`_
+- Measuring the relaxation time with the idling gate: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-relaxation-measurement-with-the-idling-gate.ipynb>`_
+
+For additional tutorials and resources related to quantum information processing, please visit the `qutip-qip documentation <https://qutip-qip.readthedocs.io/en/stable/>`_ and the `qutip-tutorials <https://qutip.org/qutip-tutorials/#quantum-information-processing>`_.

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -4,9 +4,15 @@
 Tutorials
 ************
 
-Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be found at the following links:
+Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
+found `here <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_ and
+those related to using noise simulators are available at this
+`link <https://qutip.org/qutip-tutorials/#quantum-information-processing>`_.
 
-- Quantum information processing: `Link <https://github.com/qutip/qutip-qip>`_
+
+Tutorials related to using quantum gates and circuits in ``qutip-qip`` `Link <https://github.com/qutip/qutip-qip>`_ can be found at the following links:
+
+Quantum information processing:
 
 - Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations: `Link <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_
 


### PR DESCRIPTION
Hello @nathanshammah and the Qutip-Qip team!

I've addressed issue #204 by adding the qutip-qip tutorials links to the documentation as requested.

The tutorials can now be accessed at https://qutip-qip.readthedocs.io/en/stable/, providing users with easy access to valuable resources while using the qutip-qip documentation.

I've made sure to include the tutorials without duplicating any files, maintaining consistency with the source files from qutip-tutorials.

Your feedback on the changes would be greatly appreciated. If there are any further improvements or modifications needed, please let me know. I'm here to ensure the documentation is accurate and helpful, especially for beginners.

Thank you for your attention to this matter. I look forward to hearing from you.

Best regards,
Biraj Karki