### PR TITLE
Added qutip-qip tutorials to documentation on Read the docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,7 +8,7 @@ readthedocs-sphinx-search==0.1.2
 numpydoc==1.4.0
 matplotlib==3.5.2
 docutils==0.17.1
-sphinxcontrib-bibtex==2.4.2
+sphinxcontrib.bibtex==2.4.2
 pyqir-generator==0.6.2
 pyqir-parser==0.6.2
 qiskit==0.37.2

--- a/doc/source/html2rst.py
+++ b/doc/source/html2rst.py
@@ -1,0 +1,9 @@
+import subprocess
+
+def convert_html_to_rst(html_file_path, rst_file_path):
+    # Use the subprocess module to call the pandoc command-line tool
+    subprocess.run(['pandoc', html_file_path, '-o', rst_file_path])
+
+html_file_path = 'qutip-qip.html'
+rst_file_path = 'tutorials.rst'
+convert_html_to_rst(html_file_path, rst_file_path)

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -4,7 +4,19 @@
 Tutorials
 ************
 
-Tutorials related to using quantum gates and circuits in ``qutip-qip`` can be
-found `here <https://qutip.org/tutorials#quantum-information-processing>`_ and
-those related to using noise simulators are available at this
-`link <https://qutip.org/tutorials#nisq>`_.
+Quantum circuits and algorithms
+
+- `Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qip-toffoli-cnot.ipynb>`_
+- `Imports and Exports QASM circuit <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/qasm.ipynb>`_
+- `QuTiP example: Quantum Gates and their usage <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/quantum-gates.ipynb>`_
+- `Quantum Teleportation Circuit <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/quantum-circuits/teleportation.ipynb>`_
+
+Pulse-level circuit simulation 
+
+- `Compiling and simulating a 10-qubit Quantum Fourier Transform (QFT) algorithmn <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-10-qubit-QFT-algorithm.ipynb>`_
+- `Custimize the pulse-level simulation <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-customize-device.ipynb>`_
+- `Examples for OptPulseProcessor <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-optpulseprocessor.ipynb>`_
+- `Scheduler for quantum gates and instructions <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-scheduler.ipynb>`_
+- `Simulating randomized benchmarking <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-randomized-benchmarking.ipynb>`_
+- `Simulating the Deutsch–Jozsa algorithm at the pulse level <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.ipynb>`_
+- `Measuring the relaxation time with the idling gate <https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v4/pulse-level-circuit-simulation/qip-relaxation-measurement-with-the-idling-gate.ipynb>`_


### PR DESCRIPTION
Closes: Add qutip-qip tutorials to documentation on Read the docs #204
Did not add the examples in the gallery form like in Mitiq. can be converted to that form easily tho 

<img width="1440" alt="Screenshot 2023-05-28 at 8 07 08 PM" src="https://github.com/qutip/qutip-qip/assets/57267583/4c17285f-b9ee-474b-bd61-347d2531b80e">


Just added the links to the text