### PR TITLE
Remove run_module_suite

### DIFF
--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -805,20 +805,20 @@ class OptimizationResult:
             labels = [
                 self._label_to_sets(S, bitstring) for bitstring in bitstrings
             ]
-        plt.bar(
+        fig, ax = plt.subplots()
+        ax.bar(
             list(range(len(bitstrings))),
             probs,
             tick_label=labels if label_sets else bitstrings,
             width=0.8,
         )
-        plt.xticks(rotation=30)
-        plt.tight_layout()
-        plt.xlabel("Measurement outcome")
-        plt.ylabel("Probability")
-        plt.title(
+        ax.tick_params(axis="x", labelrotation=30)
+        ax.set_xlabel("Measurement outcome")
+        ax.set_ylabel("Probability")
+        ax.set_title(
             "Measurement Outcomes after Optimisation. "
             f"Cost: {round(min_cost, 2)}"
         )
-        plt.tight_layout()
+        fig.tight_layout()
         if display:
-            plt.show()
+            fig.show()

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, run_module_suite, assert_allclose
+from numpy.testing import assert_, assert_allclose
 import numpy as np
 import pytest
 

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -1,6 +1,6 @@
 import os
 
-from numpy.testing import (assert_, run_module_suite, assert_allclose,
+from numpy.testing import (assert_, assert_allclose,
                            assert_equal)
 import numpy as np
 import pytest

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -2,7 +2,7 @@ import os
 
 from packaging.version import parse as parse_version
 from numpy.testing import (
-    assert_, run_module_suite, assert_allclose, assert_equal)
+    assert_, assert_allclose, assert_equal)
 import numpy as np
 import pytest
 

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -1,6 +1,6 @@
 from packaging.version import parse as parse_version
 import numpy as np
-from numpy.testing import assert_, run_module_suite, assert_allclose
+from numpy.testing import assert_, assert_allclose
 import pytest
 
 import qutip

--- a/tests/test_qft.py
+++ b/tests/test_qft.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal, assert_string_equal, run_module_suite
+from numpy.testing import assert_, assert_equal, assert_string_equal
 from qutip_qip.algorithms.qft import qft, qft_steps, qft_gate_sequence
 from qutip_qip.operations import gate_sequence_product
 
@@ -59,6 +59,3 @@ class TestQFT:
             circuit = qft_gate_sequence(N, swapping=False, to_cnot=True)
 
         assert not any([gate.name == "CPHASE" for gate in circuit.gates])
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/tests/test_qubits.py
+++ b/tests/test_qubits.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 from qutip_qip.qubits import qubit_states
 from qutip import (tensor,  basis) 
 
@@ -22,7 +22,3 @@ class TestQubits:
         psi01_a = tensor(psi0_a, psi1_a)
         psi01_b = qubit_states(N=2, states=[0, 1])
         assert_(psi01_a == psi01_b)
-
-
-if __name__ == "__main__":
-    run_module_suite()


### PR DESCRIPTION
It hasn't been used for a long time since we move to pytest. It is removed from `numpy.testing` now.