### PR TITLE
Do not install cython independently from qutip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,6 @@ jobs:
     - name: Install QuTiP from GitHub
       if: ${{ startsWith( matrix.qutip-version, '@') }}
       run: |
-        python -m pip install numpy scipy cython
         python -m pip install 'git+https://github.com/qutip/qutip.git${{ matrix.qutip-version }}'
 
     # For qutip-v5 qutip.control is replaced by qutip-qtrl


### PR DESCRIPTION
qutip currently limits to cython 0.29, let qutip decide which version of cython to use.