### PR TITLE
Remove comments after meaningful statements in QASM reader

### DIFF
--- a/src/qutip_qip/qasm.py
+++ b/src/qutip_qip/qasm.py
@@ -886,7 +886,15 @@ def read_qasm(qasm_input, mode="qiskit", version="2.0", strmode=False):
     # split input into lines and ignore comments
     qasm_lines = [line.strip() for line in qasm_lines]
     qasm_lines = list(filter(lambda x: x[:2] != "//" and x != "", qasm_lines))
-
+    # QASMBench Benchmark Suite has lines that have comments after instructions.
+    # Not sure if QASM standard allows this.
+    for i in range(len(qasm_lines)):
+       qasm_line = qasm_lines[i]
+       loc_comment = qasm_line.find("//")
+       if loc_comment >= 0:
+          qasm_line = qasm_line[0:loc_comment]
+       qasm_lines[i] = qasm_line
+        
     if version != "2.0":
         raise NotImplementedError(
             "QASM: Only OpenQASM 2.0 \

--- a/src/qutip_qip/qasm.py
+++ b/src/qutip_qip/qasm.py
@@ -889,12 +889,12 @@ def read_qasm(qasm_input, mode="qiskit", version="2.0", strmode=False):
     # QASMBench Benchmark Suite has lines that have comments after instructions.
     # Not sure if QASM standard allows this.
     for i in range(len(qasm_lines)):
-       qasm_line = qasm_lines[i]
-       loc_comment = qasm_line.find("//")
-       if loc_comment >= 0:
-          qasm_line = qasm_line[0:loc_comment]
-       qasm_lines[i] = qasm_line
-        
+        qasm_line = qasm_lines[i]
+        loc_comment = qasm_line.find("//")
+        if loc_comment >= 0:
+            qasm_line = qasm_line[0:loc_comment]
+        qasm_lines[i] = qasm_line
+
     if version != "2.0":
         raise NotImplementedError(
             "QASM: Only OpenQASM 2.0 \

--- a/tests/qasm_files/w-state_with_comments.qasm
+++ b/tests/qasm_files/w-state_with_comments.qasm
@@ -1,0 +1,33 @@
+
+// Name of Experiment: W-state v1
+
+OPENQASM 2.0;
+include "qelib1.inc";
+
+
+qreg q[4]; // This comments also should be handled.
+creg c[3]; // QASMBench has this type of comments.
+gate cH a,b {
+h b;
+sdg b;
+cx a,b;
+h b;
+t b;
+cx a,b;
+t b;
+h b;
+s b;
+x b;
+s a;
+}
+
+u3(1.91063,0,0) q[0];
+cH q[0],q[1];
+ccx q[0],q[1],q[2];
+x q[0];
+x q[1];
+cx q[0],q[1];
+
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+measure q[2] -> c[2];

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -145,5 +145,5 @@ def test_read_qasm():
         qc = read_qasm(filepath)
         qc2 = read_qasm(filepath2)
         assert True
-    except SyntaxError: # inline comments caused SyntaxError
+    except SyntaxError:  # inline comments caused SyntaxError
         assert False

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -134,3 +134,15 @@ def test_export_import():
 
     for u0, u1 in zip(props, read_props):
         assert (u0 - u1).norm() < 1e-12
+
+def test_read_qasm():
+    filename = "w-state.qasm"
+    filepath = Path(__file__).parent / 'qasm_files' / filename
+    filename2 = "w-state_with_comments.qasm"
+    filepath2 = Path(__file__).parent / 'qasm_files' / filename2
+    try:
+        qc = read_qasm(filepath)
+        qc2 = read_qasm(filepath2)
+        assert True
+    except:
+        assert False

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -141,9 +141,7 @@ def test_read_qasm():
     filepath = Path(__file__).parent / 'qasm_files' / filename
     filename2 = "w-state_with_comments.qasm"
     filepath2 = Path(__file__).parent / 'qasm_files' / filename2
-    try:
-        qc = read_qasm(filepath)
-        qc2 = read_qasm(filepath2)
-        assert True
-    except SyntaxError:  # inline comments caused SyntaxError
-        assert False
+    
+    qc = read_qasm(filepath)
+    qc2 = read_qasm(filepath2)
+    assert True

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -145,5 +145,5 @@ def test_read_qasm():
         qc = read_qasm(filepath)
         qc2 = read_qasm(filepath2)
         assert True
-    except:
+    except SyntaxError: # inline comments caused SyntaxError
         assert False

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -135,6 +135,7 @@ def test_export_import():
     for u0, u1 in zip(props, read_props):
         assert (u0 - u1).norm() < 1e-12
 
+
 def test_read_qasm():
     filename = "w-state.qasm"
     filepath = Path(__file__).parent / 'qasm_files' / filename

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -141,7 +141,7 @@ def test_read_qasm():
     filepath = Path(__file__).parent / 'qasm_files' / filename
     filename2 = "w-state_with_comments.qasm"
     filepath2 = Path(__file__).parent / 'qasm_files' / filename2
-    
+
     qc = read_qasm(filepath)
     qc2 = read_qasm(filepath2)
     assert True


### PR DESCRIPTION
QASMBench has lines that have comments after instructions, and those lines cause errors. This fix remove such comments.