### PR TITLE
fix circuit plot error for gates with classical controls when reverse_states=False

### DIFF
--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -1013,7 +1013,9 @@ class QubitCircuit:
                         gate.classical_controls
                         and (n - self.N) in gate.classical_controls
                     ):
-                        control_tag = n - gate.targets[0]
+                        control_tag = (-1 if self.reverse_states else 1) * (
+                            gate.targets[0] - n
+                        )
                         col.append(r" \ctrl{%d} " % control_tag)
 
                     elif not gate.controls and not gate.targets:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -692,6 +692,25 @@ class TestQubitCircuit:
             "",
         ])
 
+    def test_latex_code_classical_controls(self):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=True)
+        qc.add_gate("X", targets=0, classical_controls=[0])
+        latex = qc.latex_code()
+        assert latex == self._latex_template % "\n".join([
+            r" &  &  \ctrl{1}  & \qw \\ ",
+            r" &  &  \gate{X}  & \qw \\ ",
+            "",
+        ])
+
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=False)
+        qc.add_gate("X", targets=0, classical_controls=[0])
+        latex = qc.latex_code()
+        assert latex == self._latex_template % "\n".join([
+            r" &  &  \gate{X}  & \qw \\ ",
+            r" &  &  \ctrl{-1}  & \qw \\ ",
+            "",
+        ])
+
     H = Qobj([[1/np.sqrt(2), 1/np.sqrt(2)], [1/np.sqrt(2), -1/np.sqrt(2)]])
     H_zyz_gates = _ZYZ_rotation(H)
     H_zyz_quantum_circuit = QubitCircuit(1)


### PR DESCRIPTION
For circuits with a classical control and when `reverse_state=False`, the error reported in #220 occurs. This pull request changes the sign of the argument of `\ctrl` when `reverse_state=False`. With this change, the test circuit is plotted without errors:

```python
from qutip_qip.circuit import QubitCircuit
qc = QubitCircuit(1, num_cbits=1, reverse_states=False)
qc.add_gate("X", targets=0, classical_controls=[0])
print(qc.latex_code())
qc.png
```
```
\documentclass[border=3pt]{standalone}
\usepackage[braket]{qcircuit}
\begin{document}
\Qcircuit @C=1cm @R=1cm {
 &  &  \gate{X}  & \qw \\ 
 &  &  \ctrl{-1}  & \qw \\ 
}
\end{document}
```
![image](https://github.com/qutip/qutip-qip/assets/5942894/a9e3c973-909e-453b-9e40-98ce36969353)

A more complex test case:
```python
from qutip_qip.circuit import QubitCircuit, CircuitSimulator
from qutip_qip.operations import hadamard_transform

qc = QubitCircuit(3, num_cbits=2, reverse_states=False)
qc.user_gates = {"H": hadamard_transform(1)}
qc.add_gate("CNOT", targets=1, controls=2)
qc.add_gate("H", targets=2)
qc.add_measurement("M1", targets=1, classical_store=0)
qc.add_measurement("M2", targets=2, classical_store=1)
qc.add_gate("X", targets=0, classical_controls=0)
qc.add_gate("Z", targets=0, classical_controls=1)
qc.png
```
![image](https://github.com/qutip/qutip-qip/assets/5942894/d464349a-19db-4453-8a29-b6d6bf2118ef)

```python
from qutip_qip.circuit import QubitCircuit, CircuitSimulator
from qutip_qip.operations import hadamard_transform

qc = QubitCircuit(3, num_cbits=2, reverse_states=True)
qc.user_gates = {"H": hadamard_transform(1)}
qc.add_gate("CNOT", targets=1, controls=2)
qc.add_gate("H", targets=2)
qc.add_measurement("M1", targets=1, classical_store=0)
qc.add_measurement("M2", targets=2, classical_store=1)
qc.add_gate("X", targets=0, classical_controls=0)
qc.add_gate("Z", targets=0, classical_controls=1)
qc.png
```
![image](https://github.com/qutip/qutip-qip/assets/5942894/789e7d39-e6dc-4fd4-a39f-d3c86a9c0555)

