### PR TITLE
Update the RTD configuration file to execute create_tutorials_html.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,14 +1,29 @@
-# File: .readthedocs.yaml
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
+# Required
 version: 2
 
-# Build from the doc/ directory with Sphinx
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  apt_packages:
+    - pandoc
+  jobs:
+    pre_build:
+      # Each command is executed in a new shell process
+      - cd doc; python source/tutorials-website/create_tutorials_html.py
+
+# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/source/conf.py
 
-# Explicitly set the version of Python and its requirements
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-  version: 3.8
   install:
     - requirements: doc/requirements.txt
     - method: pip

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.22.4
 scipy==1.10.0
-qutip==4.7.0
+qutip==4.7.3
 cython==0.29.30
 sphinx==5.0.2
 sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
By default, RTD does not execute the python files under `doc/source`. This update explicitly executes the python file.

Fix #219 