### PR TITLE
Simplify the structure of `CircuitSimulator`

### DIFF
--- a/doc/source/qip-simulator.rst
+++ b/doc/source/qip-simulator.rst
@@ -202,7 +202,7 @@ precomputes the product of the unitaries (in between the measurements):
 .. testcode::
 
   sim = CircuitSimulator(qc, precompute_unitary=True)
-
+  sim.initialize()
   print(sim.ops)
 
 .. testoutput::

--- a/doc/source/qip-simulator.rst
+++ b/doc/source/qip-simulator.rst
@@ -169,7 +169,8 @@ The :class:`.CircuitSimulator` class also enables stepping through the circuit:
 
 .. testcode::
 
-  print(sim.step())
+  sim.step()
+  print(sim.state)
 
 **Output**:
 

--- a/doc/source/qip-simulator.rst
+++ b/doc/source/qip-simulator.rst
@@ -191,44 +191,6 @@ This only executes one gate in the circuit and
 allows for a better understanding of how the state evolution takes place.
 The method steps through both the gates and the measurements.
 
-Precomputing the unitary
-========================
-
-By default, the :class:`.CircuitSimulator` class is initialized such that
-the circuit evolution is conducted by applying each unitary to the state interactively.
-However, by setting the argument ``precompute_unitary=True``, :class:`.CircuitSimulator`
-precomputes the product of the unitaries (in between the measurements):
-
-.. testcode::
-
-  sim = CircuitSimulator(qc, precompute_unitary=True)
-  sim.initialize()
-  print(sim.ops)
-
-.. testoutput::
-  :options: +NORMALIZE_WHITESPACE
-
-  [Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False
-    Qobj data =
-    [[ 0.       0.57735  0.      -0.57735  0.       0.40825  0.      -0.40825]     
-     [ 0.57735  0.      -0.57735  0.       0.40825  0.      -0.40825  0.     ]     
-     [ 0.57735  0.       0.57735  0.       0.40825  0.       0.40825  0.     ]     
-     [ 0.       0.57735  0.       0.57735  0.       0.40825  0.       0.40825]     
-     [ 0.57735  0.       0.       0.      -0.8165   0.       0.       0.     ]     
-     [ 0.       0.57735  0.       0.       0.      -0.8165   0.       0.     ]     
-     [ 0.       0.       0.57735  0.       0.       0.      -0.8165   0.     ]     
-     [ 0.       0.       0.       0.57735  0.       0.       0.      -0.8165 ]],
-       Measurement(M0, target=[0], classical_store=0),
-       Measurement(M1, target=[1], classical_store=1),
-       Measurement(M2, target=[2], classical_store=2)]
-
-
-Here, ``sim.ops`` stores all the circuit operations that are going to be applied during
-state evolution. As observed above, all the unitaries of the circuit are compressed into
-a single unitary product with the precompute optimization enabled.
-This is more efficient if one runs the same circuit one multiple initial states.
-However, as the number of qubits increases, this will consume more and more memory
-and become unfeasible.
 
 Density Matrix Simulation
 =========================

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -479,10 +479,6 @@ class QubitCircuit:
             post-selection. If specified, the measurement results are
             set to the tuple of bits (sequentially) instead of being
             chosen at random.
-        precompute_unitary: Boolean, optional
-            Specify if computation is done by pre-computing and aggregating
-            gate unitaries. Possibly a faster method in the case of
-            large number of repeat runs with different state inputs.
 
         Returns
         -------
@@ -497,7 +493,6 @@ class QubitCircuit:
             raise TypeError("State is not a ket or a density matrix.")
         sim = CircuitSimulator(
             self,
-            U_list,
             mode,
             precompute_unitary,
         )
@@ -518,10 +513,6 @@ class QubitCircuit:
                 initialization of the classical bits.
         U_list: list of Qobj, optional
             list of predefined unitaries corresponding to circuit.
-        precompute_unitary: Boolean, optional
-            Specify if computation is done by pre-computing and aggregating
-            gate unitaries. Possibly a faster method in the case of
-            large number of repeat runs with different state inputs.
 
         Returns
         -------
@@ -535,12 +526,7 @@ class QubitCircuit:
             mode = "density_matrix_simulator"
         else:
             raise TypeError("State is not a ket or a density matrix.")
-        sim = CircuitSimulator(
-            self,
-            U_list,
-            mode,
-            precompute_unitary,
-        )
+        sim = CircuitSimulator(self, mode, precompute_unitary)
         return sim.run_statistics(state, cbits)
 
     def resolve_gates(self, basis=["CNOT", "RX", "RY", "RZ"]):

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -17,13 +17,12 @@ from ..operations import (
     Measurement,
     expand_operator,
     GATE_CLASS_MAP,
-    gate_sequence_product,
 )
 from .circuitsimulator import (
     CircuitSimulator,
     CircuitResult,
 )
-from qutip import basis, Qobj
+from qutip import Qobj, qeye
 
 
 try:
@@ -939,8 +938,9 @@ class QubitCircuit:
         circuit_unitary : :class:`qutip.Qobj`
             Product of all gate arrays in the quantum circuit.
         """
-        gate_list = self.propagators()
-        circuit_unitary = gate_sequence_product(gate_list)
+        sim = CircuitSimulator(self)
+        result = sim.run(qeye(self.dims))
+        circuit_unitary = result.get_final_states()[0]
         return circuit_unitary
 
     def latex_code(self):

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -304,7 +304,7 @@ class CircuitSimulator:
 
         if U_list:
             U_list = U_list
-            
+
         if any(p is not None for p in (state, cbits, measure_results)):
             warnings.warn(
                 "Initializing the quantum state, cbits and measure_results "
@@ -448,7 +448,7 @@ class CircuitSimulator:
                 self.state = state
 
         self.probability = 1
-        self.op_index = 0
+        self._op_index = 0
         self.measure_results = measure_results
         self.measure_ind = 0
 
@@ -505,7 +505,9 @@ class CircuitSimulator:
         """
         self.initialize(state, cbits, measure_results)
         for _ in range(len(self.ops)):
-            if self.step() is None:
+            result = self.step()
+            if result is None:
+                # TODO This only happens if there is predefined post-selection on the measurement results and the measurement results is exactly 0. This needs to be improved.
                 break
         return CircuitResult(self.state, self.probability, self.cbits)
 
@@ -561,7 +563,7 @@ class CircuitSimulator:
             binary = [int(s) for s in "{0:#b}".format(decimal)[2:]]
             return [0] * (length - len(binary)) + binary
 
-        op = self.ops[self.op_index]
+        op = self.ops[self._op_index]
         if isinstance(op, Measurement):
             self._apply_measurement(op)
         elif isinstance(op, tuple):
@@ -592,7 +594,7 @@ class CircuitSimulator:
             # For pre-computed unitary only.
             self._evolve_state(op)
 
-        self.op_index += 1
+        self._op_index += 1
         return self.state
 
     def _evolve_state(self, U):

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -261,9 +261,6 @@ class CircuitSimulator:
         U_list=None,
         mode="state_vector_simulator",
         precompute_unitary=False,
-        state=None,
-        cbits=None,
-        measure_results=None,
     ):
         """
         Simulate state evolution for Quantum Circuits.
@@ -303,14 +300,6 @@ class CircuitSimulator:
 
         if U_list:
             U_list = U_list
-
-        if any(p is not None for p in (state, cbits, measure_results)):
-            warnings.warn(
-                "Initializing the quantum state, cbits and measure_results "
-                "when initializing the simulator is deprecated. "
-                "The inputs are ignored. "
-                "They should, instead, be provided when running the simulation."
-            )
 
     @property
     def qc(self):

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -561,7 +561,7 @@ class CircuitSimulator:
                 apply_gate = True
             if apply_gate:
                 state = self._evolve_state(
-                    operation, current_state, expand=True
+                    operation, current_state
                 )
             else:
                 state = current_state
@@ -573,7 +573,7 @@ class CircuitSimulator:
         self._state = state
         return state
 
-    def _evolve_state(self, operation, state, expand=False):
+    def _evolve_state(self, operation, state):
         """
         Applies unitary to state.
 

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -583,15 +583,19 @@ class CircuitSimulator:
             unitary to be applied.
         """
         if isinstance(operation, Gate):
-            # We need to use the circuit because the custom gates
-            # are still saved in circuit instance.
-            # This should be changed once that is deprecated.
-            U = self.qc._get_gate_unitary(operation)
-            U = expand_operator(
-                U,
-                dims=self.dims,
-                targets=operation.get_all_qubits(),
-            )
+            if operation.name == "GLOBALPHASE":
+                # This is just a complex number.
+                U = np.exp(1.0j * operation.arg_value)
+            else:
+                # We need to use the circuit because the custom gates
+                # are still saved in circuit instance.
+                # This should be changed once that is deprecated.
+                U = self.qc._get_gate_unitary(operation)
+                U = expand_operator(
+                    U,
+                    dims=self.dims,
+                    targets=operation.get_all_qubits(),
+                )
         else:
             U = operation
         if self.mode == "state_vector_simulator":

--- a/src/qutip_qip/circuit/circuitsimulator.py
+++ b/src/qutip_qip/circuit/circuitsimulator.py
@@ -474,9 +474,7 @@ class CircuitSimulator:
             state = self._apply_measurement(op, current_state)
         elif isinstance(op, Gate):
             if op.classical_controls is not None:
-                apply_gate = _check_classical_control_value(
-                    op, self.cbits
-                )
+                apply_gate = _check_classical_control_value(op, self.cbits)
             else:
                 apply_gate = True
             if not apply_gate:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -646,6 +646,7 @@ class TestQubitCircuit:
             np.testing.assert_allclose(probs_initial, probs_final)
             assert sum(result_cbits[i]) == 1
 
+
     _latex_template = r"""
 \documentclass[border=3pt]{standalone}
 \usepackage[braket]{qcircuit}

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -61,24 +61,6 @@ def _measurement_circuit():
     return qc
 
 
-def _simulators_sv(qc):
-
-    sim_sv_precompute = CircuitSimulator(qc, mode="state_vector_simulator",
-                                         precompute_unitary=True)
-    sim_sv = CircuitSimulator(qc, mode="state_vector_simulator")
-
-    return [sim_sv_precompute, sim_sv]
-
-
-def _simulators_dm(qc):
-
-    sim_dm_precompute = CircuitSimulator(qc, mode="density_matrix_simulator",
-                                         precompute_unitary=True)
-    sim_dm = CircuitSimulator(qc, mode="density_matrix_simulator")
-
-    return [sim_dm_precompute, sim_dm]
-
-
 class TestQubitCircuit:
     """
     A test class for the QuTiP functions for Circuit resolution.
@@ -586,17 +568,16 @@ class TestQubitCircuit:
     def test_measurement_circuit(self):
 
         qc = _measurement_circuit()
-        simulators = _simulators_sv(qc)
+        simulator = CircuitSimulator(qc)
         labels = ["00", "01", "10", "11"]
 
         for label in labels:
             state = bell_state(label)
-            for i, simulator in enumerate(simulators):
-                simulator.run(state)
-                if label[0] == "0":
-                    assert simulator.cbits[0] == simulator.cbits[1]
-                else:
-                    assert simulator.cbits[0] != simulator.cbits[1]
+            simulator.run(state)
+            if label[0] == "0":
+                assert simulator.cbits[0] == simulator.cbits[1]
+            else:
+                assert simulator.cbits[0] != simulator.cbits[1]
 
     def test_circuit_with_selected_measurement_result(self):
         qc = QubitCircuit(N=1, num_cbits=1)
@@ -654,17 +635,16 @@ class TestQubitCircuit:
 
         _, probs_initial = fourth.measurement_comp_basis(state)
 
-        simulators = _simulators_sv(qc)
+        simulator = CircuitSimulator(qc)
 
-        for simulator in simulators:
-            result = simulator.run_statistics(state)
-            final_states = result.get_final_states()
-            result_cbits = result.get_cbits()
+        result = simulator.run_statistics(state)
+        final_states = result.get_final_states()
+        result_cbits = result.get_cbits()
 
-            for i, final_state in enumerate(final_states):
-                _, probs_final = fourth.measurement_comp_basis(final_state)
-                np.testing.assert_allclose(probs_initial, probs_final)
-                assert sum(result_cbits[i]) == 1
+        for i, final_state in enumerate(final_states):
+            _, probs_final = fourth.measurement_comp_basis(final_state)
+            np.testing.assert_allclose(probs_initial, probs_final)
+            assert sum(result_cbits[i]) == 1
 
     _latex_template = r"""
 \documentclass[border=3pt]{standalone}


### PR DESCRIPTION
Refactor the gate level `CircuitSimulator`
- Avoid expanding all propagators and then applying them one by one. Only expand when applying the unitary. This saves memory and also make it easier for further improvement, i.e., exploring other ways to perform the matrix multiplication (e.g. `einsum`).
- Switch some public members to private. Those members that track the execution of the circuit evaluation should not be public.
- Small changes to improve the clarity.