### PR TITLE
Add phi parameter to expand_operator call

### DIFF
--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -802,7 +802,7 @@ def molmer_sorensen(theta, phi=0.0, N=None, targets=[0, 1]):
     if N is not None:
         _deprecation_warnings_gate_expansion()
         return expand_operator(
-            molmer_sorensen(theta), dims=[2] * N, targets=targets
+            molmer_sorensen(theta, phi), dims=[2] * N, targets=targets
         )
 
     return Qobj(


### PR DESCRIPTION
Just fixing a very small bug.  The optional phi parameter was not sent to the iterative call to the molmer_sorensen gate when expand_operator is used.