### PR TITLE
Fix Plotting Dimensions and Aspect Ratio Consistency

### DIFF
--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -292,7 +292,7 @@ QuTiP-QIP offers three distinct methods for visualizing quantum circuits. Below 
   qc.add_gate("ISWAP", targets=[0,1])
   qc.add_measurement("M0", targets=1, classical_store=0)
 
-  qc.draw("matplotlib", dpi=300, fig_width=4)
+  qc.draw("matplotlib", dpi=300)
 
 **Customization Examples**:
 
@@ -309,7 +309,7 @@ QuTiP-QIP offers three distinct methods for visualizing quantum circuits. Below 
   qc.add_gate("ISWAP", targets=[0,1])
   qc.add_measurement("M0", targets=1, classical_store=0)
 
-  qc.draw("matplotlib", bulge=False, theme='dark', title="Plotting Quantum Circuit", dpi=300, fig_width=4)
+  qc.draw("matplotlib", bulge=False, theme='dark', title="Plotting Quantum Circuit", dpi=300)
 
 .. 
   _To further explore the customization examples, refer to `tutorial notebook <link to tutorial notebook>`.
@@ -341,10 +341,6 @@ QuTiP-QIP offers three distinct methods for visualizing quantum circuits. Below 
       - Padding between the gate and the gate label.
     * - ``label_pad : float = 0.1``
       - Padding between the wire label and the wire.
-    * - ``fig_height : Optional[float] = None``
-      - Height of the figure.
-    * - ``fig_width : Optional[float] = 10``
-      - Width of the figure.
     * - ``bulge : Union[str, bool] = True``
       - Bulge style of the gate. Renders non-bulge gates if False.
     * - ``align_layer : bool = False``

--- a/src/qutip_qip/circuit/base_renderer.py
+++ b/src/qutip_qip/circuit/base_renderer.py
@@ -47,12 +47,6 @@ class StyleConfig:
     label_pad : float, optional
         Padding between the wire label and the wire. The default is 0.1.
 
-    fig_height : float, optional
-        Height of the figure. The default is None.
-
-    fig_width : float, optional
-        Width of the figure. The default is None.
-
     bulge : Union[str, bool], optional
         Bulge style of the gate. Renders non-bulge gates if False. The default is True.
 
@@ -92,8 +86,6 @@ class StyleConfig:
     layer_sep: float = 0.5
     gate_pad: float = 0.05
     label_pad: float = 0.1
-    fig_height: Optional[float] = None
-    fig_width: Optional[float] = 10
     bulge: Union[str, bool] = True
     align_layer: bool = False
     theme: Optional[Union[str, Dict]] = "qutip"

--- a/src/qutip_qip/circuit/mat_renderer.py
+++ b/src/qutip_qip/circuit/mat_renderer.py
@@ -644,7 +644,14 @@ class MatRenderer(BaseRenderer):
 
         else:
 
-            adj_targets = [i + self._cwires for i in sorted(gate.targets)]
+            adj_targets = [
+                i + self._cwires
+                for i in sorted(
+                    gate.targets
+                    if gate.targets is not None
+                    else list(range(self._qwires)) # adaptation for globalphase
+                )
+            ]
             text_width = self._get_text_width(
                 self.text,
                 self.fontsize,
@@ -687,7 +694,7 @@ class MatRenderer(BaseRenderer):
                 zorder=self._zorder["gate"],
             )
 
-            if len(gate.targets) > 1:
+            if gate.targets is not None and len(gate.targets) > 1:
                 for i in range(len(gate.targets)):
                     connector_l = Circle(
                         (
@@ -845,10 +852,16 @@ class MatRenderer(BaseRenderer):
 
                 # multi-qubit gate
                 if (
-                    len(gate.targets) > 1
+                    gate.targets is None
+                    or len(gate.targets) > 1
                     or getattr(gate, "controls", False) is not None
                 ):
-                    self.merged_wires = gate.targets.copy()
+                    # If targets=None, it implies globalphase. Adaptation for the renderer: targets=all-qubits.
+                    self.merged_wires = (
+                        gate.targets.copy()
+                        if gate.targets is not None
+                        else list(range(self._qwires))
+                    )
                     if gate.controls is not None:
                         self.merged_wires += gate.controls.copy()
                     self.merged_wires.sort()

--- a/src/qutip_qip/circuit/mat_renderer.py
+++ b/src/qutip_qip/circuit/mat_renderer.py
@@ -81,11 +81,6 @@ class MatRenderer(BaseRenderer):
             "gate_label": 3,
             "node_label": 3,
         }
-        self.style.fig_height = (
-            ((self._qwires + self._cwires) * self.style.wire_sep)
-            if self.style.fig_height is None
-            else self.style.fig_height
-        )
         if self._ax is None:
             self.fig = plt.figure()
             self._ax = self.fig.add_subplot(111)
@@ -881,25 +876,37 @@ class MatRenderer(BaseRenderer):
         Configure the figure settings.
         """
         self.fig.set_facecolor(self.style.bgcolor)
-        self.fig.set_size_inches(
-            self.style.fig_width, self.style.fig_height, forward=True
+        xlim = (
+            -self.style.padding - self.max_label_width - self.style.label_pad,
+            self.style.padding
+            + self.style.end_wire_ext * self.style.layer_sep
+            + max(sum(self._layer_list[i]) for i in range(self._qwires)),
         )
-        self._ax.set_ylim(
+        ylim = (
             -self.style.padding,
             self.style.padding
             + (self._qwires + self._cwires - 1) * self.style.wire_sep,
         )
-        self._ax.set_xlim(
-            -self.style.padding - self.max_label_width - self.style.label_pad,
-            self.style.padding
-            + self.style.end_wire_ext * self.style.layer_sep
-            + max([sum(self._layer_list[i]) for i in range(self._qwires)]),
-        )
+        self._ax.set_xlim(xlim)
+        self._ax.set_ylim(ylim)
+
         if self.style.title is not None:
             self._ax.set_title(
-                self.style.title, pad=10, color=self.style.wire_color
+                self.style.title,
+                pad=10,
+                color=self.style.wire_color,
+                fontdict={"fontsize": self.style.fontsize},
             )
-        self._ax.set_aspect("equal")
+
+        try:
+            get_ipython()
+            max_dim = max(xlim[1] - xlim[0], ylim[1] - ylim[0])
+            self.fig.set_size_inches(max_dim, max_dim, forward=True)
+        except NameError:
+            self.fig.set_size_inches(
+                xlim[1] - xlim[0], ylim[1] - ylim[0], forward=True
+            )
+        self._ax.set_aspect("equal", adjustable="box")
         self._ax.axis("off")
 
     def save(self, filename: str, **kwargs) -> None:

--- a/src/qutip_qip/circuit/mat_renderer.py
+++ b/src/qutip_qip/circuit/mat_renderer.py
@@ -898,6 +898,7 @@ class MatRenderer(BaseRenderer):
                 fontdict={"fontsize": self.style.fontsize},
             )
 
+        # Adjusting to square dimensions in jupyter to prevent small fig size with equal-aspect cmd
         try:
             get_ipython()
             max_dim = max(xlim[1] - xlim[0], ylim[1] - ylim[0])

--- a/src/qutip_qip/circuit/mat_renderer.py
+++ b/src/qutip_qip/circuit/mat_renderer.py
@@ -649,7 +649,9 @@ class MatRenderer(BaseRenderer):
                 for i in sorted(
                     gate.targets
                     if gate.targets is not None
-                    else list(range(self._qwires)) # adaptation for globalphase
+                    else list(
+                        range(self._qwires)
+                    )  # adaptation for globalphase
                 )
             ]
             text_width = self._get_text_width(


### PR DESCRIPTION
### BUG / ISSUE:
 - Single-qubit circuit plotting faced dimensional inconsistencies, particularly with figure aspect ratios when title is added. Also, particular case of Single Qubit Circuit the visible plot size in IPython is not visible. 
 - Unable to plot globalphase gate

### FIX:
- Separate plotting dimensions specifically for IPython environments
- Adjusted figure sizing to be dynamic, removing direct user control over figure size to maintain aspect ratio.