### PR TITLE
Add family package entry point with about information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,10 @@ setup_requires =
 [options.packages.find]
 where = src
 
+[options.entry_points]
+qutip.family =
+    qutip_qip = qutip_qip.family
+
 [options.extras_require]
 graphics = matplotlib>=1.3.0
 control = qutip-qtrl

--- a/src/qutip_qip/family.py
+++ b/src/qutip_qip/family.py
@@ -1,9 +1,7 @@
 """QuTiP family package entry point."""
 
+from . import __version__
 
-def about():
+def version():
     """Return information to include in qutip.about()."""
-    return "qutip-qip", [
-        "Moo: 1.5",
-        "Bar: 2.0",
-    ]
+    return "qutip-qip", __version__

--- a/src/qutip_qip/family.py
+++ b/src/qutip_qip/family.py
@@ -2,6 +2,7 @@
 
 from . import __version__
 
+
 def version():
     """Return information to include in qutip.about()."""
     return "qutip-qip", __version__

--- a/src/qutip_qip/family.py
+++ b/src/qutip_qip/family.py
@@ -1,0 +1,9 @@
+"""QuTiP family package entry point."""
+
+
+def about():
+    """Return information to include in qutip.about()."""
+    return "qutip-qip", [
+        "Moo: 1.5",
+        "Bar: 2.0",
+    ]

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -1,0 +1,12 @@
+""" Tests for qutip_qip.family. """
+
+import re
+
+from qutip_qip import family
+
+
+class TestVersion:
+    def test_version(self):
+        pkg, version = family.version()
+        assert pkg == "qutip-qip"
+        assert re.match(r"\d+\.\d+\.\d+.*", version)


### PR DESCRIPTION
A draft implementation of the `about` entrypoint for https://github.com/qutip/qutip/pull/2604.