### PR TITLE
Ensure `expand_operator` output dtype

### DIFF
--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -1326,7 +1326,7 @@ def expand_operator(
     for i, ind in enumerate(rest_pos):
         new_order[ind] = rest_qubits[i]
     id_list = [identity(dims[i]) for i in rest_pos]
-    return tensor([oper] + id_list).permute(new_order)
+    return tensor([oper] + id_list).permute(new_order).to(dtype)
 
 
 def gate_sequence_product(

--- a/src/qutip_qip/operations/gates.py
+++ b/src/qutip_qip/operations/gates.py
@@ -1326,7 +1326,10 @@ def expand_operator(
     for i, ind in enumerate(rest_pos):
         new_order[ind] = rest_qubits[i]
     id_list = [identity(dims[i]) for i in rest_pos]
-    return tensor([oper] + id_list).permute(new_order).to(dtype)
+    out = tensor([oper] + id_list).permute(new_order)
+    if parse_version(qutip.__version__) >= parse_version("5.dev"):
+        out = out.to(dtype)
+    return out
 
 
 def gate_sequence_product(


### PR DESCRIPTION
Recent changes in qutip give priority to sparse format in `tensor`, breaking a test:
`tensor( CSR, Dense) -> CSR`

This ensure the output of `expand_operator` is the expected dtype.