### PR TITLE
Ignore deprecation warning for matplotlib 3.9.4

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -13,4 +13,6 @@ filterwarnings =
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore:Dedicated options class are no longer needed, options should be passed as dict to solvers.:FutureWarning
     ignore::DeprecationWarning:qiskit.utils.algorithm_globals:
+    # Deprecation warning for python = 3.9 with matplotlib 3.9.4
+    ignore:'mode' parameter is deprecated
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -164,8 +164,6 @@ def test_render_str_len(request, qc_fixture):
 
 
 @pytest.mark.parametrize("qc_fixture", ["qc1", "qc2", "qc3"])
-# Deprecation warning for python = 3.9 with matplotlib 3.9.4
-@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test_matrenderer(request, qc_fixture):
     """
     Check if Matplotlib renderer works without error.
@@ -177,8 +175,6 @@ def test_matrenderer(request, qc_fixture):
 
 
 @pytest.mark.parametrize("qc_fixture", ["qc1", "qc2", "qc3"])
-# Deprecation warning for python = 3.9 with matplotlib 3.9.4
-@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test_circuit_saving(request, qc_fixture, tmpdir):
     """
     Test if the different renderers can save the circuit in different formats.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -164,6 +164,8 @@ def test_render_str_len(request, qc_fixture):
 
 
 @pytest.mark.parametrize("qc_fixture", ["qc1", "qc2", "qc3"])
+# Deprecation warning for python = 3.9 with matplotlib 3.9.4
+@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test_matrenderer(request, qc_fixture):
     """
     Check if Matplotlib renderer works without error.
@@ -175,6 +177,8 @@ def test_matrenderer(request, qc_fixture):
 
 
 @pytest.mark.parametrize("qc_fixture", ["qc1", "qc2", "qc3"])
+# Deprecation warning for python = 3.9 with matplotlib 3.9.4
+@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test_circuit_saving(request, qc_fixture, tmpdir):
     """
     Test if the different renderers can save the circuit in different formats.


### PR DESCRIPTION
Ignore the Deprecation warning for python = 3.9 with matplotlib 3.9.4