### PR TITLE
Bug fix in the VQA module

### DIFF
--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -778,11 +778,7 @@ class OptimizationResult:
         display: bool, optional
             Display the plot with the pyplot plot.show() method
         """
-        try:
-            import matplotlib.pyplot as plt
-        except Exception:
-            print("could not import matplotlib.pyplot")
-            quit()
+        import matplotlib.pyplot as plt
         state = self.final_state
         min_cost = self.min_cost
 

--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -28,8 +28,7 @@ class VQA:
         number of layers used by the algorihtm
     cost_method: str
         method used to compute the cost of an instance of the circuit
-        constructed by fixing its free parameters. Can be one of `OBSERVABLE`,
-        `BITSTRING` or `STATE`.
+        constructed by fixing its free parameters. Can be one of `OBSERVABLE` or `STATE`.
 
         #.  If `OBSERVABLE` is set, then the attribute
             ``VQA.cost_observable`` needs to be specified as a ``Qobj``.
@@ -38,9 +37,6 @@ class VQA:
         #.  If `STATE` is set, then ``VQA.cost_func`` needs to be specified
             as a callable that takes in a quantum state, as a ``Qobj``, and
             returns a float.
-        #.  If `BITSTRING` is set, then ``VQA.cost_func`` needs to be
-            specified as a callable that takes in a bitstring and returns
-            a float.
     """
 
     def __init__(self, num_qubits, num_layers=1, cost_method="OBSERVABLE"):
@@ -48,7 +44,7 @@ class VQA:
         self.num_layers = num_layers
         self.blocks = []
         self.user_gates = {}
-        self._cost_methods = ["OBSERVABLE", "STATE", "BITSTRING"]
+        self._cost_methods = ["OBSERVABLE", "STATE"]
         self.cost_method = cost_method
         self.cost_func = None
         self.cost_observable = None
@@ -223,17 +219,7 @@ class VQA:
         cost: float
         """
         final_state = self.get_final_state(angles)
-        if self.cost_method == "BITSTRING":
-            if self.cost_func is None:
-                raise ValueError(
-                    "To use BITSTRING as the cost method, please"
-                    " specify the attribute cost_func"
-                )
-            else:
-                return self.cost_func(
-                    self._sample_bitstring_from_state(final_state)
-                )
-        elif self.cost_method == "STATE":
+        if self.cost_method == "STATE":
             if self.cost_func is None:
                 raise ValueError(
                     "To use STATE as the cost method, please"

--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -765,6 +765,7 @@ class OptimizationResult:
             Display the plot with the pyplot plot.show() method
         """
         import matplotlib.pyplot as plt
+
         state = self.final_state
         min_cost = self.min_cost
 

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -60,7 +60,7 @@ class TestVQA:
         with pytest.raises(TypeError):
             vqa = VQA(num_qubits=n[1][0], num_layers=n[1][1])
 
-    @pytest.mark.parametrize("method", ["OBSERVABLE", "STATE", "BITSTRING"])
+    @pytest.mark.parametrize("method", ["OBSERVABLE", "STATE"])
     def test_cost_methods(self, method):
         vqa = VQA(num_qubits=1, num_layers=1, cost_method=method)
 
@@ -197,15 +197,6 @@ class TestVQACircuit:
         vqa.cost_func = lambda s: 0
         res = vqa.optimize_parameters([0., 0., 0., 0.])
         res.plot(top_ten=todo, display=False)
-
-    def test_bitstring_cost(self):
-        "Check the bitstring sampling function"
-        vqa = VQA(num_qubits=1, cost_method="BITSTRING")
-        vqa.add_block(VQABlock(qutip.sigmax()))
-        # target the |1> state by giving the "1" string a cost of 0
-        vqa.cost_func = lambda s: 1 - int(s)
-        res = vqa.optimize_parameters(initial=[np.pi / 2 + 1e-3])
-        assert res.get_top_bitstring() == "|1>"
 
     def test_optimization_errors(self):
         """

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -118,8 +118,8 @@ class TestVQACircuit:
         vqa = VQA(num_qubits=1, cost_method="STATE")
         vqa.add_block(block)
         # try to reach the |1> state from the |0> state
-        vqa.cost_func = lambda s: 1 - s.overlap(qutip.basis(2, 1)).real
-        res = vqa.optimize_parameters(initial=[np.pi / 2])
+        vqa.cost_func = lambda s: 1 - np.abs(s.overlap(qutip.basis(2, 1)))
+        res = vqa.optimize_parameters(initial=[np.pi / 3.])
         assert res.get_top_bitstring() == "|1>"
 
     def test_layer_by_layer(self):
@@ -129,9 +129,9 @@ class TestVQACircuit:
         vqa = VQA(num_qubits=1, cost_method="STATE", num_layers=4)
         block = VQABlock(qutip.sigmax())
         vqa.add_block(block)
-        vqa.cost_func = lambda s: 1 - s.overlap(qutip.basis(2, 1)).real
+        vqa.cost_func = lambda s: 1 - np.abs(s.overlap(qutip.basis(2, 1)))
         res = vqa.optimize_parameters(
-            initial=[np.pi / 2, 0, 0, 0], layer_by_layer=True
+            initial=[np.pi / 3., 0, 0, 0], layer_by_layer=True
         )
         assert res.get_top_bitstring() == "|1>"
 

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import numpy as np
 import qutip
+from qutip_qip.operations import expand_operator
 from qutip_qip.vqa import (
     VQA,
     VQABlock,
@@ -191,7 +192,7 @@ class TestVQACircuit:
         vqa = VQA(num_qubits=4, num_layers=1, cost_method="STATE")
         for i in range(4):
             vqa.add_block(VQABlock(
-                qutip.expand_operator(
+                expand_operator(
                     qutip.sigmax(), dims=[2]*4, targets=[i])
                 ))
         vqa.cost_func = lambda s: 0

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -190,9 +190,12 @@ class TestVQACircuit:
         # Only test on environments that have the matplotlib dependency
         vqa = VQA(num_qubits=4, num_layers=1, cost_method="STATE")
         for i in range(4):
-            vqa.add_block(VQABlock("X", targets=[i]))
+            vqa.add_block(VQABlock(
+                qutip.expand_operator(
+                    qutip.sigmax(), dims=[2]*4, targets=[i])
+                ))
         vqa.cost_func = lambda s: 0
-        res = vqa.optimize_parameters()
+        res = vqa.optimize_parameters([0., 0., 0., 0.])
         res.plot(top_ten=todo, display=False)
 
     def test_bitstring_cost(self):


### PR DESCRIPTION
- Fix a bug in vqa test
The overlap computes the inner product, which is unfortunately imaginary in this test case, so the cost function 1-overlap has always real part 1.
This should never work. However, since the test was initialized in the right answer, pi/2, the optimizer always stopped pretty close to the right answer. So it seldom reports an error. But the changes in SciPy 1.16.0 somehow make the optimizer bolder and explore large values in the beginning, causing the test to fail.
- Adapt the test example
This is a trivial example to test the plotting function. Before, it was a VQA with no parameters, but since Scipy 1.16 the minimize function raises an error if there is no value to optimize. So I adapted the test.
- Remove the VQA bitstring cost function
I do not understand how the cost function can be based on one bit string sampling. Sampling over a quantum state is a statistical process; information is needed for the whole distribution. Sampling one bit string does not tell anything.
The test was passing just because it was initialized in state 1.