### PR TITLE
docs: harmonize Instruction duration and fix GateCompiler typos

### DIFF
--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -119,7 +119,7 @@ class GateCompiler(object):
 
     def compile(self, circuit, schedule_mode=None, args=None):
         """
-        Compile the the native gates into control pulse sequence.
+        Compile the native gates into control pulse sequence.
         It calls each compiling method and concatenates
         the compiled pulses.
 
@@ -144,7 +144,7 @@ class GateCompiler(object):
         Returns
         -------
         tlist, coeffs: array_like or dict
-            Compiled ime sequence and pulse coefficients.
+            Compiled time sequence and pulse coefficients.
             if ``return_array`` is true, return
             A 2d NumPy array of the shape ``(len(ctrls), len(tlist))``.
             Each row corresponds to the control pulse sequence for

--- a/src/qutip_qip/compiler/instruction.py
+++ b/src/qutip_qip/compiler/instruction.py
@@ -11,15 +11,15 @@ class Instruction:
     Parameters
     ----------
     gate: :class:`~.operations.Gate`
-        The logical quantum gate (e.g., RX, CNOT) associated with this 
+        The logical quantum gate (e.g., RX, CNOT) associated with this
         instruction.
     duration: float, optional
-        The total execution time for the instruction. If not provided, 
+        The total execution time for the instruction. If not provided,
         it is derived from the last element of the tlist.
     tlist: array_like, optional
         A list of time points at which the time-dependent coefficients are
-        applied. For the default piecewise constant (PWC) pulses used by 
-        most compilers, len(tlist) = len(coeffs) + 1. 
+        applied. For the default piecewise constant (PWC) pulses used by
+        most compilers, len(tlist) = len(coeffs) + 1.
         See :class:`.Pulse` for spline-based alternatives.
     pulse_info: list, optional
         A list of tuples, each tuple corresponding to a pair of pulse label

--- a/src/qutip_qip/compiler/instruction.py
+++ b/src/qutip_qip/compiler/instruction.py
@@ -11,12 +11,16 @@ class Instruction:
     Parameters
     ----------
     gate: :class:`~.operations.Gate`
-        The quantum gate.
-    duration: list, optional
-        The execution time needed for the instruction.
+        The logical quantum gate (e.g., RX, CNOT) associated with this 
+        instruction.
+    duration: float, optional
+        The total execution time for the instruction. If not provided, 
+        it is derived from the last element of the tlist.
     tlist: array_like, optional
-        A list of time at which the time-dependent coefficients are
-        applied. See :class:`.Pulse` for detailed information`
+        A list of time points at which the time-dependent coefficients are
+        applied. For the default piecewise constant (PWC) pulses used by 
+        most compilers, len(tlist) = len(coeffs) + 1. 
+        See :class:`.Pulse` for spline-based alternatives.
     pulse_info: list, optional
         A list of tuples, each tuple corresponding to a pair of pulse label
         and pulse coefficient, in the format (str, array_like).


### PR DESCRIPTION
This PR addresses documentation inconsistencies and typos identified during pulse-level simulation testing.
instruction.py: Updated duration type hint from list to float to match the implementation logic (self.duration = self.tlist[-1]). Clarified the N+1 rule for tlist in piecewise constant pulses to prevent dimension errors.
gatecompiler.py: Fixed typos ("the the"(Line 122), "ime"(line 147)) while preserving the recently implemented qubit property refactors.
These changes ensure that the pulse-level documentation correctly guides users through the discretization process.

I am Anshuman Sahu, interested in the "Generalized Oracle Construction and Pulse-Level Compilation" project. I've also opened a GitHub Discussion regarding my proposal, though it may currently be in the moderation queue.