### PR TITLE
Fix: render arg_label properly in Parametric gates and show gate name

### DIFF
--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -625,20 +625,7 @@ class MatRenderer(BaseRenderer):
                 horizontalalignment="center",
                 zorder=self._zorder["gate_label"],
             )
-            # gate_text = plt.Text(
-            #     xskip + self.style.gate_margin + gate_width / 2,
-            #     (adj_targets[0] + adj_targets[-1]) / 2 * self.style.wire_sep,
-            #     self.text,
-            #     color=self.fontcolor,
-            #     fontsize=self.fontsize,
-            #     fontweight=self.fontweight,
-            #     fontfamily=self.fontfamily,
-            #     fontstyle=self.fontstyle,
-            #     verticalalignment="center",
-            #     horizontalalignment="center",
-            #     zorder=self._zorder["gate_label"],
-            # )
-
+           
             gate_patch = FancyBboxPatch(
                 (
                     xskip + self.style.gate_margin,


### PR DESCRIPTION
Currently, in MatRenderer the arg_label of Parametric gates (e.g., RZ(arg_value=np.pi, arg_label='π')) is not displayed, and if arg_label is provided, the gate name sometimes disappears.

This PR fixes the issue by:

Ensuring the gate name is always rendered

Displaying arg_label if provided, falling back to arg_value otherwise

Wrapping symbolic labels (like π, π/2) in LaTeX formatting for proper rendering

Supporting both single-qubit and multi-qubit gates