### PR TITLE
Add type hints to family.version  and qasm helper functions 

### DIFF
--- a/src/qutip_qip/family.py
+++ b/src/qutip_qip/family.py
@@ -3,6 +3,6 @@
 from . import __version__
 
 
-def version():
+def version() -> tuple[str, str]:
     """Return information to include in qutip.about()."""
     return "qutip-qip", __version__

--- a/src/qutip_qip/qasm.py
+++ b/src/qutip_qip/qasm.py
@@ -26,7 +26,9 @@ class QasmGate:
     Class which stores the gate definitions as specified in the QASM file.
     """
 
-    def __init__(self, name, gate_args, gate_regs):
+    def __init__(
+        self, name: str, gate_args: list[str], gate_regs: list[str]
+    ) -> None:
         self.name = name
         self.gate_args = gate_args
         self.gate_regs = gate_regs
@@ -62,7 +64,7 @@ def _get_qiskit_gates():
     return {"ch": ch, "tdg": tdg, "id": id, "u2": u2, "sdg": sdg, "cu3": cu3}
 
 
-def _tokenize_line(command):
+def _tokenize_line(command: str) -> list[str]:
     """
     Tokenize (break into several parts a string of) a single line of QASM code.
 
@@ -115,7 +117,7 @@ def _tokenize_line(command):
     return tokens
 
 
-def _tokenize(token_cmds):
+def _tokenize(token_cmds: list[str]) -> list[list[str]]:
     """
     Tokenize QASM code for processing, i.e. break it into several parts.
 
@@ -148,7 +150,7 @@ def _tokenize(token_cmds):
     return list(filter(lambda x: x != [], processed_commands))
 
 
-def _gate_processor(command):
+def _gate_processor(command: list[str]) -> tuple[list[str], list[str]]:
     """
     Process tokens for a gate call statement separating them into args and regs.
     Processes tokens from a "gate call" (e.g. rx(pi) q[0]) and returns the


### PR DESCRIPTION
## Summary
This PR adds a small, module-scoped set of type hints:
- `family.version` return type annotation
- `QasmGate.__init__` annotations
- `_tokenize_line`, `_tokenize`, and `_gate_processor` annotations in `qasm.py`

Related to #262 (module-by-module type hint improvements).

## Notes
- No behavioral changes intended.
- This PR is intentionally small and focused for easier review.

## Validation
- Verified diff is limited to the two files above.
- Verified syntax via local Python compile check.