### PR TITLE
Fix malformed QASM register index handling

### DIFF
--- a/src/qutip_qip/qasm.py
+++ b/src/qutip_qip/qasm.py
@@ -428,11 +428,17 @@ class QasmProcessor:
             prev_token = ""
             new_regs = []
             open_bracket_mode = False
+            reg_num = None
             for token in regs:
                 if token == "[":
                     open_bracket_mode = True
+                    reg_num = None
                 elif open_bracket_mode:
                     if token == "]":
+                        if reg_num is None:
+                            raise SyntaxError(
+                                "QASM: incorrect bracket formatting"
+                            )
                         open_bracket_mode = False
                         reg_name = new_regs.pop()
                         new_regs.append(reg_name + "[" + reg_num + "]")

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -136,14 +136,24 @@ def test_qasm_str():
 
 
 def test_measurement_register_with_missing_index_raises_syntax_error():
-    qasm_input_string = (
+    qasm_input_string1 = (
         "OPENQASM 2.0;\n"
         "qreg q[1];\n"
         "creg c[1];\n"
         "measure q[] -> c[0];\n"
     )
     with pytest.raises(SyntaxError, match="QASM: incorrect bracket formatting"):
-        read_qasm(qasm_input_string, strmode=True)
+        read_qasm(qasm_input_string1, strmode=True)
+
+    # Second case: missing index in classical register
+    qasm_input_string2 = (
+        "OPENQASM 2.0;\n"
+        "qreg q[1];\n"
+        "creg c[1];\n"
+        "measure q[0] -> c[];\n"
+    )
+    with pytest.raises(SyntaxError, match="QASM: incorrect bracket formatting"):
+        read_qasm(qasm_input_string2, strmode=True)
 
 
 def test_export_import():

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -136,24 +136,14 @@ def test_qasm_str():
 
 
 def test_measurement_register_with_missing_index_raises_syntax_error():
-    qasm_input_string1 = (
+    qasm_input_string = (
         "OPENQASM 2.0;\n"
         "qreg q[1];\n"
         "creg c[1];\n"
         "measure q[] -> c[0];\n"
     )
     with pytest.raises(SyntaxError, match="QASM: incorrect bracket formatting"):
-        read_qasm(qasm_input_string1, strmode=True)
-
-    # Second case: missing index in classical register
-    qasm_input_string2 = (
-        "OPENQASM 2.0;\n"
-        "qreg q[1];\n"
-        "creg c[1];\n"
-        "measure q[0] -> c[];\n"
-    )
-    with pytest.raises(SyntaxError, match="QASM: incorrect bracket formatting"):
-        read_qasm(qasm_input_string2, strmode=True)
+        read_qasm(qasm_input_string, strmode=True)
 
 
 def test_export_import():

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -135,6 +135,17 @@ def test_qasm_str():
     assert circuit_to_qasm_str(simple_qc) == expected_qasm_str
 
 
+def test_measurement_register_with_missing_index_raises_syntax_error():
+    qasm_input_string = (
+        "OPENQASM 2.0;\n"
+        "qreg q[1];\n"
+        "creg c[1];\n"
+        "measure q[] -> c[0];\n"
+    )
+    with pytest.raises(SyntaxError, match="QASM: incorrect bracket formatting"):
+        read_qasm(qasm_input_string, strmode=True)
+
+
 def test_export_import():
     qc = QubitCircuit(3)
     qc.add_gate(gates.CRY(np.pi), targets=1, controls=0)


### PR DESCRIPTION
## Summary
Fix malformed indexed register handling in QASM parsing to avoid internal `UnboundLocalError` and return a user-facing syntax error.

## Changes
- In `_regs_processor`, validate bracket content before using `reg_num`.
- Raise `SyntaxError("QASM: incorrect bracket formatting")` for malformed indexed registers like `q[]`.
- Add regression test for malformed measurement register index:
  - `measure q[] -> c[0];`

## Validation
- Ran focused QASM tests related to parser errors and the new regression case.
- All targeted tests passed locally.

## Notes
- Small scoped fix, no API changes.
- Based on `gate_refactor`.

addresses #288