### PR TITLE
Update Contributor guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Thank you for contributing to QuTiP-qip! Please make sure you have finished the following tasks before opening the PR.
 
 - [ ] Please read [Contributing to QuTiP-qip Development](https://qutip-qip.readthedocs.io/en/latest/contribution-code.html)
-- [ ] Contributions to qutip should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/).
+- [ ] Contributions to QuTiP-qip should follow the [PEP 8 style](https://www.python.org/dev/peps/pep-0008/).
 You can use [pycodestyle](http://pycodestyle.pycqa.org/en/latest/index.html) to check your code automatically
 - [ ] Please add tests to cover your changes if applicable.
 - [ ] If the behavior of the code has changed or new feature has been added, please also update the documentation in the `doc` folder, and the [notebook](https://github.com/qutip/qutip-tutorials). Feel free to ask if you are not sure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,29 +2,29 @@
 
 First off, thanks for taking the time to contribute! ❤️
 
-All types of contributions are encouraged and valued. Please make sure to [read the relevant section](#table-of-contents) before making your contribution. It will smooth out the experience for all involved. The community looks forward to your contributions.
+All types of contributions are encouraged and valued. Please make sure to [read the relevant section](#table-of-contents) before making your contribution.
 
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
 - [I Have a Question](#i-have-a-question)
-- [Reporting Bugs](#reporting-bugs/issues)
-- [Contribution to Code](#contributing-to-code)
+- [Reporting Bugs](#reporting-bugsissues)
+- [Contributing to Code](#contributing-to-code)
 - [Improving the Documentation](#improving-the-documentation)
 
 
 ## Code of Conduct
-This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+This project and everyone participating in it are governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
 
 ## I Have a Question
-You can ask questions or answer other user's question on our [Discussion](https://github.com/qutip/qutip-qip/discussions) forum on GitHub or in the [QuTiP Google discussion group](https://groups.google.com/forum/#!forum/qutip). You may also suggest new features or improvements you would like to see in the project. We encourage you to engage with the community and share your ideas and knowledge.
+You can ask questions or answer other users' questions on our [Discussion](https://github.com/qutip/qutip-qip/discussions) forum on GitHub or in the [QuTiP Google discussion group](https://groups.google.com/forum/#!forum/qutip). You may also suggest new features or improvements you would like to see in the project. We encourage you to engage with the community and share your ideas and knowledge.
 
 
 ## Reporting Bugs/Issues
-If you find a bug or issue, it is best to first search in the existing [Issues](https://github.com/qutip/qutip-qip/issues) list. If you didn't find a related issue, please ask report the bug/issue by opening a new issue.:
+If you find a bug or issue, it is best to first search in the existing [Issues](https://github.com/qutip/qutip-qip/issues) list. If you didn't find a related issue, please report the bug by opening a new issue:
 
-- Open an [Issue](https://github.com/qutip/qutip-qip/issues/new).
+- Create a new [Issue](https://github.com/qutip/qutip-qip/issues/new) on GitHub.
 - Provide as much context as you can about what you're running into.
 - Provide the python and package versions by running `qutip.about()` command.
 
@@ -35,18 +35,18 @@ We will then take care of the issue as soon as possible.
 If you want to contribute, please read the [Contributing to QuTiP-qip development](https://qutip-qip.readthedocs.io/en/latest/contribution-code.html) section of the documentation to set up the Python environment for development.
 
 ### Choose an issue to work on
-Qutip-qip uses the following labels to help non-maintainers find issues best suited to their interests and experience level:
+QuTiP-qip uses the following labels to help non-maintainers find issues best suited to their interests and experience level:
 
 - [good first issue](https://github.com/qutip/qutip-qip/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - these issues are typically the simplest available to work on, ideal for newcomers. They should already be fully scoped, with a clear approach outlined in the descriptions.
 - [help wanted](https://github.com/qutip/qutip-qip/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - these issues are generally more complex than good first issues. They typically cover work that core maintainers don't currently have capacity to implement and may require more investigation/discussion. These are a great option for experienced contributors looking for something a bit more challenging.
 
-#### Assigning Issues
+### Assigning Issues
 In our workflow, we generally avoid formally assigning issues to contributors. This approach is intentional — it keeps the project open and flexible, allowing anyone from the community to explore and work on problems that interest them, without waiting for explicit assignment or approval.
 
 The only exception to this is a small subset of “core” issues. These are typically more complex, sensitive, or tightly coupled to ongoing development efforts, and are therefore handled directly by maintainers.
 
 
-#### AI Tool Usage Policy
+### AI Tool Usage Policy
 We have no objections to the use of AI tools to improve efficiency and enhance quality of work. We ask only that contributors are honest about any such usage and that all outputs can be considered their own work, in that they fully understand, endorse and can explain anything that is submitted.
 
 AI use is strongly discouraged where it leads to overly verbose content. In communications, whether via e-mail, GitHub or other channels, we expect to communicate directly with other humans and not with automated systems. Use of translation tools is completely welcome.

--- a/doc/source/contribution-code.rst
+++ b/doc/source/contribution-code.rst
@@ -13,7 +13,7 @@ stop by to talk to us either in the `QuTiP Google group`_ or in the issues page
 on the `qutip-qip repository`_ if you have suggestions for new features, so we
 can discuss the design and suitability with you.
 
-To contribute to QuTiP development, you will need to have a working knowledge of
+To contribute to QuTiP-qip development, you will need to have a working knowledge of
 ``git``.  If you're not familiar with it, you can read `GitHub's simple introduction`_
 or look at the official `Git book <https://git-scm.com/book/en>`_ which also has the basics,
 but then goes into much more detail if you're interested.
@@ -60,7 +60,7 @@ To create a fork, go to the relevant repository's page on GitHub (for example,
 the `qutip-qip repository`_), and click the fork
 button in the top right.  This will create a linked version of the repository in
 your own GitHub account. For additional details you may refer to GitHub's documentation
-on `forking <https://guides.github.com/activies/forking>`_.
+on `forking <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_.
 
 You can now "clone" your fork onto your local computer.  The command will look
 something like
@@ -97,13 +97,13 @@ by running the command:
 
 .. code-block::
 
-    pip install --upgrade pip
+   pip install --upgrade pip
    pip install --group dev
 
 .. note::
    You do not need to re-run above commands even when you make changes
-   to the Project's Python files. `-e` flag automatically ensure you are
-   using latest local changes when you do ``import qutip_qip``
+   to the project's Python files. The ``-e`` flag automatically ensures that you are
+   using the latest local changes when you do ``import qutip_qip``
 
 You should now be able to run the tests.  From the root of the repository, or in
 ``qutip-qip/tests`` folder, you can simply run ``pytest`` to run
@@ -124,7 +124,7 @@ steps:
 #. Create a new branch for your changes
 #. Add commits with your changes to your new branch
 #. Push your branch to your fork on GitHub
-#. Make a pull request (PR) to the QuTiP repository
+#. Make a pull request (PR) to the qutip/qutip-qip repository
 
 You can read more documentation about this pattern in the
 `GitHub guide to Flow`_, and see
@@ -192,7 +192,7 @@ Pull Requests
 =============
 
 Please give the pull request a short, clear title that gives us an idea of what
-your proposed change does.  It's good if this not more ten words, and starts
+your proposed change does.  It's good if this is not more than ten words, and starts
 with an imperative verb.  Good examples of titles are:
 
 - `Add QROT and MS gate <https://github.com/qutip/qutip-qip/pull/193>`_


### PR DESCRIPTION
**Changes:**

- Rewrite the section on Contributing to Code in the documentation. Most of the content for it is based of @jakelishman [developer guide for qutip](https://github.com/qutip/qutip/issues/1359), I found it very well written. I did't know the official way of attribution so I have cherrypicked the latest commit from his fork and used that as the base of this PR.
- Add Pull Request Template based of the main qutip repo's
- Add `CONTRIBUTING.md` file