### PR TITLE
FIX: Add validation for empty register indices in QASM parser

### DIFF
--- a/src/qutip_qip/qasm.py
+++ b/src/qutip_qip/qasm.py
@@ -17,7 +17,6 @@ from .operations import (
     snot,
 )
 
-
 __all__ = ["read_qasm", "save_qasm", "print_qasm", "circuit_to_qasm_str"]
 
 
@@ -317,9 +316,7 @@ class QasmProcessor:
                             "QASM: opaque gate {} are  \
                                                    not allowed, please define \
                                                    or omit \
-                                                   them".format(
-                                curr_gate.name
-                            )
+                                                   them".format(curr_gate.name)
                         )
                     open_bracket_mode = False
                     self.gate_names.add(curr_gate.name)
@@ -452,14 +449,20 @@ class QasmProcessor:
             prev_token = ""
             new_regs = []
             open_bracket_mode = False
+            reg_num = None
             for token in regs:
                 if token == "[":
                     open_bracket_mode = True
                 elif open_bracket_mode:
                     if token == "]":
                         open_bracket_mode = False
+                        if reg_num is None:
+                            raise SyntaxError(
+                                "QASM: incorrect bracket formatting"
+                            )
                         reg_name = new_regs.pop()
                         new_regs.append(reg_name + "[" + reg_num + "]")
+                        reg_num = None
                     elif token.isdigit():
                         reg_num = token
                     else:
@@ -498,10 +501,8 @@ class QasmProcessor:
                 if len(qubits) == len(cbits):
                     return zip(qubits, cbits)
                 else:
-                    raise ValueError(
-                        "QASM: qubit and cbit \
-                                     register sizes are different"
-                    )
+                    raise ValueError("QASM: qubit and cbit \
+                                     register sizes are different")
         else:
             # processes gate tokens to create sets of registers to
             # which the gates are applied.
@@ -918,10 +919,8 @@ def read_qasm(qasm_input, mode="default", version="2.0", strmode=False):
         qasm_lines[i] = qasm_line
 
     if version != "2.0":
-        raise NotImplementedError(
-            "QASM: Only OpenQASM 2.0 \
-                                  is currently supported."
-        )
+        raise NotImplementedError("QASM: Only OpenQASM 2.0 \
+                                  is currently supported.")
 
     if qasm_lines.pop(0) != "OPENQASM 2.0;":
         raise SyntaxError("QASM: File does not contain QASM 2.0 header")
@@ -1168,10 +1167,8 @@ class QasmOutput:
         if self.version == "2.0":
             self.output("OPENQASM 2.0;")
         else:
-            raise NotImplementedError(
-                "QASM: Only OpenQASM 2.0 \
-                                      is currently supported."
-            )
+            raise NotImplementedError("QASM: Only OpenQASM 2.0 \
+                                      is currently supported.")
 
         self.output('include "qelib1.inc";', 1)
 


### PR DESCRIPTION
- Initialize reg_num to None before processing register tokens
- Add check for malformed brackets (e.g., q[]) to raise SyntaxError
- Reset reg_num after use to prevent stale values
- Apply Black formatting to fix lint issues