### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security vulnerability in `qutip-qip` is taken seriously. We appreciate your efforts to responsibly disclose your findings,
+and will make every effort to acknowledge your contributions.
+
+Please **do not** use GitHub issues to report security vulnerabilities. GitHub issues are public, and doing so could allow someone
+to exploit the information before the problem can be addressed. Instead, please use the GitHub
+["Report a Vulnerability"](https://github.com/qutip/qutip-qip/security/advisories/new) interface from the *Security* tab of the qutip-qip repository.
+You can find more details on the security vulnerability feature in the GitHub documentation
+[here](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+
+Please report security issues in third-party modules to the person or team maintaining the module rather than the `qutip-qip` project,
+unless you believe that some action needs to be taken with `qutip-qip` in order to guard against the effects of a security vulnerability in a
+third-party module.
+
+## Additional points of contact
+
+Please contact the QuTiP admin team at via email at qutip-admin@googlegroups.com. if you have questions or other concerns.


### PR DESCRIPTION
**Description**
Currently qutip-qip lacks the mechanism to report vulnerabilities/security issues. Those should never be opened as GitHub Issues which are public. Although security vulnerabilities are rare (and its best to have no security vulnerability reported), but there should be a mechanism to report it. GitHub's [security advisory system](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory) is the default for this.

**Related issues or PRs**
None

**AI Usage Disclosure**
None