### PR TITLE
Add sphinx-copybutton extension

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,7 +59,15 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
     "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
 ]
+
+# Strips out the below prompts
+# Standard Python REPL prompts (>>>  and ... )
+# Standard bash/terminal prompts ($ )
+# IPython/Jupyter Notebook prompts (e.g., In [1]: )
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,11 @@ test = [
 ]
 doc = [
     "docutils==0.21.1",
+    "numpydoc==1.10.0",
     "sphinx==8.1.3",
     "sphinx-rtd-theme==3.1.0",
     "sphinxcontrib-bibtex==2.6.5",
-    "numpydoc==1.10.0",
+    "sphinx-copybutton==0.5.2",
 ]
 dev = [ {include-group = "test"}, {include-group = "lint"}]
 


### PR DESCRIPTION
**Description**
Adds the sphinx-copybutton extensions. This shows a copy button towards the right corner for codeblocks in the documentation.

**Related issues or PRs**
None

**AI Usage Disclosure**
None