### PR TITLE
Correct spelling

### DIFF
--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -416,7 +416,7 @@ QuTiP-QIP offers three distinct methods for visualizing quantum circuits. Below 
 - **LaTeX**:
 
     A quantum circuit (described above) can directly be plotted using the QCircuit library (https://github.com/CQuIC/qcircuit).
-    QCiruit is a quantum circuit drawing application and is implemented directly into QuTiP.
+    QCircuit is a quantum circuit drawing application and is implemented directly into QuTiP.
 
     More information related to installing these packages is also available in the
     installation guide (:ref:`circuit_plot_packages`).

--- a/pulse-paper/customize.py
+++ b/pulse-paper/customize.py
@@ -45,8 +45,8 @@ class MyModel(Model):
 
     def get_control(self, label):
         """
-        Get an avaliable control Hamiltonian.
-        For instance, sigmax control on the zeroth qubits is labeld "sx0".
+        Get an available control Hamiltonian.
+        For instance, sigmax control on the zeroth qubits is labeled "sx0".
 
         Args:
             label (str): The label of the Hamiltonian
@@ -226,7 +226,7 @@ def single_crosstalk_simulation(num_gates):
     mycompiler = MyCompiler(num_qubits, {"pulse_amplitude": 0.02, "duration": 25})
     myprocessor.add_noise(ClassicalCrossTalk(1.0))
 
-    # Define a randome circuit.
+    # Define a random circuit.
     gates_set = [
         ROT(arg_value=0),
         ROT(np.pi / 2),

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -168,7 +168,7 @@ class QubitCircuit:
             num_params = len(parameters)
 
             if num_params == 0:
-                # Non parameteric gate
+                # Non parametric gate
                 unitary = user_gate_callable()
                 gate_classes[gate_name] = get_unitary_gate(gate_name, unitary)
                 continue
@@ -403,7 +403,7 @@ class QubitCircuit:
 
             else:
                 raise TypeError(
-                    "gate must be of Gate type or oject or a string ",
+                    "gate must be of Gate type or object or a string ",
                     f"got {type(gate)} instead.",
                 )
 

--- a/src/qutip_qip/circuit/draw/base_renderer.py
+++ b/src/qutip_qip/circuit/draw/base_renderer.py
@@ -61,7 +61,7 @@ class StyleConfig:
 
     color : Optional[str], optional
         Controls color of acsent elements (eg. cross sign in the target node)
-        and set as deafult color of gate-label. Can be overwritten by gate specific color.
+        and set as default color of gate-label. Can be overwritten by gate specific color.
         The default is None.
 
     wire_label : Optional[List], optional

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -56,7 +56,7 @@ class MatRenderer(BaseRenderer):
         self._min_gate_height = 0.2
         self._min_gate_width = 0.2
         self._default_layers = 2
-        self._arrow_lenght = 0.06
+        self._arrow_length = 0.06
         self._connector_r = 0.01
         self._target_node_r = 0.12
         self._control_node_r = 0.05
@@ -378,7 +378,7 @@ class MatRenderer(BaseRenderer):
                 xskip - self._cwire_sep,
             ),
             (
-                c_pos * self.style.wire_sep + self._arrow_lenght,
+                c_pos * self.style.wire_sep + self._arrow_length,
                 q_pos * self.style.wire_sep,
             ),
             color=color,
@@ -390,7 +390,7 @@ class MatRenderer(BaseRenderer):
                 xskip + self._cwire_sep,
             ),
             (
-                c_pos * self.style.wire_sep + self._arrow_lenght,
+                c_pos * self.style.wire_sep + self._arrow_length,
                 q_pos * self.style.wire_sep,
             ),
             color=color,
@@ -402,7 +402,7 @@ class MatRenderer(BaseRenderer):
         if is_arrow:
             end_arrow = FancyArrow(
                 xskip,
-                c_pos * self.style.wire_sep + self._arrow_lenght,
+                c_pos * self.style.wire_sep + self._arrow_length,
                 0,
                 -self._cwire_sep * 3,
                 width=0,

--- a/src/qutip_qip/compiler/circuitqedcompiler.py
+++ b/src/qutip_qip/compiler/circuitqedcompiler.py
@@ -248,7 +248,7 @@ class SCQubitsCompiler(GateCompiler):
 
     def cnot_compiler(self, circuit_instruction, args):
         """
-        Compiler for CNOT gate using the cross resonance iteraction.
+        Compiler for CNOT gate using the cross resonance interaction.
         See
         https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.134507
         for reference.

--- a/src/qutip_qip/compiler/gatecompiler.py
+++ b/src/qutip_qip/compiler/gatecompiler.py
@@ -332,7 +332,7 @@ class GateCompiler:
         # according to different pulse mode
         if np.isscalar(tlist):
             pulse_mode = "discrete"
-            # a single constant rectanglar pulse, where
+            # a single constant rectangular pulse, where
             # tlist and coeff are just float numbers
             step_size = tlist
             coeff = np.array([coeff])
@@ -344,7 +344,7 @@ class GateCompiler:
             coeff = np.asarray(coeff)
             gate_tlist = np.asarray(tlist)[1:]  # first t always 0 by def
         elif len(tlist) == len(coeff):
-            # continuos pulse
+            # continuous pulse
             pulse_mode = "continuous"
             step_size = tlist[1] - tlist[0]
             coeff = np.asarray(coeff)[1:]

--- a/src/qutip_qip/compiler/scheduler.py
+++ b/src/qutip_qip/compiler/scheduler.py
@@ -202,9 +202,9 @@ class InstructionsGraph:
             if priority:
                 available_gates.sort(key=cmp_to_key(self._compare_priority))
             current_cycle = []
-            if apply_constraint is None:  # if no constraits
+            if apply_constraint is None:  # if no constraints
                 current_cycle = deepcopy(available_gates)
-            else:  # check if constraits allow the parallelization
+            else:  # check if constraints allow the parallelization
                 self._add_dependency_among_commuting_gates(
                     current_cycle, available_gates, apply_constraint
                 )
@@ -328,7 +328,7 @@ class Scheduler:
         "ALAP" for as late as possible.
     constraint_functions: list, optional
         A list of hardware constraint functions.
-        Default includes a function `qubit_contraint`,
+        Default includes a function `qubit_constraint`,
         i.e. one qubit cannot be used by two gates at the same time.
     """
 

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -123,9 +123,9 @@ class DispersiveCavityQED(ModelProcessor):
         """
         return self.coeffs[2 * self.num_qubits : 3 * self.num_qubits]
 
-    def eliminate_auxillary_modes(self, U):
+    def eliminate_auxiliary_modes(self, U):
         """
-        Eliminate the auxillary modes like the cavity modes in cqed.
+        Eliminate the auxiliary modes like the cavity modes in cqed.
         """
         psi_proj = tensor(
             [basis(self.num_levels, 0)] + [identity(2) for n in range(self.num_qubits)]

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1006,7 +1006,7 @@ class Processor:
             )
             dt = tlist[n + 1] - tlist[n]
             U = (-1j * H * dt).expm()
-            U = self.eliminate_auxillary_modes(U)
+            U = self.eliminate_auxiliary_modes(U)
             U_list.append(U)
 
         try:  # correct_global_phase are defined for ModelProcessor
@@ -1185,9 +1185,9 @@ class Processor:
         """
         raise NotImplementedError("Use the function in the sub-class")
 
-    def eliminate_auxillary_modes(self, U):
+    def eliminate_auxiliary_modes(self, U):
         """
-        Eliminate the auxillary modes like the cavity modes in cqed.
+        Eliminate the auxiliary modes like the cavity modes in cqed.
         (Defined in subclasses)
         """
         return U

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -752,7 +752,7 @@ class Processor:
             If the axis are shown.
 
         rescale_pulse_coeffs: bool, optional
-            Rescale the hight of each pulses.
+            Rescale the height of each pulses.
 
         num_steps: int, optional
             Number of time steps in the plot.
@@ -967,7 +967,7 @@ class Processor:
         Simulate the state evolution under the given `qutip.QubitCircuit`
         with matrice exponentiation. It will calculate the propagator
         with matrix exponentiation and return a list of :class:`qutip.Qobj`.
-        This method won't include noise or collpase.
+        This method won't include noise or collapse.
 
         Parameters
         ----------
@@ -1022,7 +1022,7 @@ class Processor:
     def run(self, qc=None):
         """
         Calculate the propagator of the evolution by matrix exponentiation.
-        This method won't include noise or collpase.
+        This method won't include noise or collapse.
 
         Parameters
         ----------
@@ -1129,7 +1129,7 @@ class Processor:
         else:
             noisy_qobjevo, sys_c_ops = self.get_qobjevo(noisy=noisy)
 
-        # add collpase operators into kwargs
+        # add collapse operators into kwargs
         if "c_ops" in kwargs:
             if isinstance(kwargs["c_ops"], (Qobj, QobjEvo)):
                 kwargs["c_ops"] += [kwargs["c_ops"]] + sys_c_ops

--- a/src/qutip_qip/operations/controlled.py
+++ b/src/qutip_qip/operations/controlled.py
@@ -82,7 +82,7 @@ class ControlledGate(Gate):
         num_ctrl_qubits = getattr(cls, "num_ctrl_qubits", None)
         if (type(num_ctrl_qubits) is not int) or (num_ctrl_qubits < 1):
             raise TypeError(
-                f"Class '{cls.__name__}' attribute 'num_ctrl_qubits' must be a postive integer, "
+                f"Class '{cls.__name__}' attribute 'num_ctrl_qubits' must be a positive integer, "
                 f"got {type(num_ctrl_qubits)} with value {num_ctrl_qubits}."
             )
 

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -21,7 +21,7 @@ class Measurement:
     targets : list or int
         Gate targets.
     classical_store : int
-        Result of the measurment is stored in this
+        Result of the measurement is stored in this
         classical register of the circuit.
     """
 

--- a/src/qutip_qip/operations/namespace.py
+++ b/src/qutip_qip/operations/namespace.py
@@ -55,7 +55,7 @@ class _GlobalNameSpaceRegistry(metaclass=_SingletonMeta):
 
         # Default behaviour for user defining his own gates is that namespace is None,
         # Thus those gates are considered temporary by default, we use the same logic in
-        # QPE for Controlled Unitary gates, VQA untils Ops are implemented.
+        # QPE for Controlled Unitary gates, VQA until Ops are implemented.
 
 
 _GlobalRegistry = _GlobalNameSpaceRegistry()

--- a/src/qutip_qip/operations/old_gates.py
+++ b/src/qutip_qip/operations/old_gates.py
@@ -287,7 +287,7 @@ def qrot(theta, phi, *args, **kwargs):
     Parameters
     ----------
     phi : float
-        The inital phase of the rabi pulse.
+        The initial phase of the rabi pulse.
     theta : float
         The duration of the rabi pulse.
     N : int
@@ -488,7 +488,7 @@ shape = [4, 4], type='oper', dtype=Dense, isherm=True
          [ 0.+sin(pi/8).j  0.+0.j           0.+0.j           cos(pi/8).+0.j]]
 
     """
-    warnings.warn("berkley has been deprecated and will be removed in future version. \
+    warnings.warn("berkeley has been deprecated and will be removed in future version. \
         Use BERKELEY.get_qobj() instead.", DeprecationWarning, stacklevel=2)
     return Qobj(
         [

--- a/src/qutip_qip/operations/utils.py
+++ b/src/qutip_qip/operations/utils.py
@@ -201,7 +201,7 @@ def expand_operator(
     oper = oper.to(dtype)
 
     if not isinstance(dims, Iterable):
-        raise ValueError(f"dims needs to be an interable {not type(dims)}.")
+        raise ValueError(f"dims needs to be an iterable {not type(dims)}.")
 
     N = len(dims)
     targets = _targets_to_list(targets, oper=oper, N=N)

--- a/src/qutip_qip/qiskit/backend.py
+++ b/src/qutip_qip/qiskit/backend.py
@@ -183,7 +183,7 @@ class QiskitSimulatorBase(BackendV2):
 
         if len(run_input) > self.max_circuits:
             raise ValueError(f"Passed ${len(run_input)} circuits to the backend,\
-                while max_cicruits is defined as ${self.max_circuits}")
+                while max_circuits is defined as ${self.max_circuits}")
 
         # Set the no. of shots
         if "shots" in run_options:

--- a/src/qutip_qip/qiskit/utils/count_prob.py
+++ b/src/qutip_qip/qiskit/utils/count_prob.py
@@ -40,7 +40,7 @@ def sample_shots(count_probs: dict, shots: int) -> Counts:
         to different classical outputs.
 
     shots: int
-        Number of shots for emperical estimation.
+        Number of shots for empirical estimation.
 
     Returns
     -------

--- a/src/qutip_qip/transpiler/chain.py
+++ b/src/qutip_qip/transpiler/chain.py
@@ -24,7 +24,7 @@ def to_chain_structure(qc: QubitCircuit, setup="linear"):
     """
     # FIXME This huge block has been here for a long time.
     # It could be moved to the new compiler section and carefully
-    # splitted into smaller peaces.
+    # split into smaller pieces.
     N = qc.num_qubits
     qc_t = QubitCircuit(N)
     qc_t.add_global_phase(qc.global_phase)

--- a/src/qutip_qip/vqa.py
+++ b/src/qutip_qip/vqa.py
@@ -27,7 +27,7 @@ class VQA:
     num_qubits: int
         number of qubits used by the algorithm
     num_layers: int, optional
-        number of layers used by the algorihtm
+        number of layers used by the algorithm
     cost_method: str
         method used to compute the cost of an instance of the circuit
         constructed by fixing its free parameters. Can be one of `OBSERVABLE` or `STATE`.
@@ -432,7 +432,7 @@ class VQA:
         ----------
         angles: list of float
             Circuit free parameters
-        indicies_to_compute: list of int, optional
+        indices_to_compute: list of int, optional
             Block indices for which to use in computing the jacobian.
             By default, this is every index (every block).
 
@@ -542,7 +542,7 @@ class VQABlock:
         Name of the block. If not provided,
         a name will be generated as "U"+str(len(VQA.blocks)).
     targets: list of int, optional
-        The qubits targetted by the gate. By default, applied
+        The qubits targeted by the gate. By default, applied
         to all qubits.
     initial: bool, optional
         Whether or not to repeat this block in layers. For example,
@@ -600,7 +600,7 @@ class VQABlock:
         angles: list of float, optional
             Block free parameters. Required if the block has free parameters.
         """
-        # Qobj unitary or zero-parmeters function returning Qobj unitary
+        # Qobj unitary or zero-parameters function returning Qobj unitary
         if angles is None:
             if self.is_unitary:
                 return self.operator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def in_temporary_directory():
     with tempfile.TemporaryDirectory() as temporary_dir:
         os.chdir(temporary_dir)
         yield
-        # pytest should catch exceptions occuring in functions using the
+        # pytest should catch exceptions occurring in functions using the
         # fixture, so this should always be called.  We want it here rather
         # than outside to prevent the case of the directory failing to be
         # removed because it is 'busy'.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -140,7 +140,7 @@ class MyCompiler(GateCompiler):  # compiler class
 
 spline_kind = [
     pytest.param("step_func", id="discrete"),
-    pytest.param("cubic", id="continuos"),
+    pytest.param("cubic", id="continuous"),
 ]
 schedule_mode = [
     pytest.param("ASAP", id="ASAP"),
@@ -151,7 +151,7 @@ schedule_mode = [
 
 @pytest.mark.parametrize("spline_kind", spline_kind)
 @pytest.mark.parametrize("schedule_mode", schedule_mode)
-def test_compiler_with_continous_pulse(spline_kind, schedule_mode):
+def test_compiler_with_continuous_pulse(spline_kind, schedule_mode):
     num_qubits = 2
     circuit = QubitCircuit(num_qubits)
     circuit.add_gate(X, targets=0)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -55,7 +55,7 @@ single_gate_tests = [
 # pytest.param(2, CNOT, targets=[0], controls=[1], id="CNOT"),
 
 
-def _ket_expaned_dims(qubit_state, expanded_dims):
+def _ket_expanded_dims(qubit_state, expanded_dims):
     all_qubit_basis = list(product([0, 1], repeat=len(expanded_dims)))
     old_dims = qubit_state.dims[0]
     expanded_qubit_state = np.zeros(reduce(mul, expanded_dims, 1), dtype=np.complex128)
@@ -147,8 +147,8 @@ def _test_numerical_evolution_helper(num_qubits, gates, targets, device_class, k
         init_state = qutip.tensor(extra, state)
 
     elif isinstance(device, SCQubits):
-        # expand to 3-level represetnation
-        init_state = _ket_expaned_dims(state, device.dims)
+        # expand to 3-level representation
+        init_state = _ket_expanded_dims(state, device.dims)
     else:
         init_state = state
 
@@ -159,7 +159,7 @@ def _test_numerical_evolution_helper(num_qubits, gates, targets, device_class, k
     if isinstance(device, DispersiveCavityQED):
         target = qutip.tensor(extra, target)
     elif isinstance(device, SCQubits):
-        target = _ket_expaned_dims(target, device.dims)
+        target = _ket_expanded_dims(target, device.dims)
     assert _tol > abs(1 - qutip.metrics.fidelity(numerical_result, target))
 
 
@@ -210,8 +210,8 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
         init_state = qutip.tensor(extra, state)
 
     elif isinstance(device, SCQubits):
-        # expand to 3-level represetnation
-        init_state = _ket_expaned_dims(state, device.dims)
+        # expand to 3-level representation
+        init_state = _ket_expanded_dims(state, device.dims)
     else:
         init_state = state
 
@@ -221,7 +221,7 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
     if isinstance(device, DispersiveCavityQED):
         target = qutip.tensor(extra, target)
     elif isinstance(device, SCQubits):
-        target = _ket_expaned_dims(target, device.dims)
+        target = _ket_expanded_dims(target, device.dims)
 
     assert _tol > abs(1 - qutip.metrics.fidelity(result.final_state, target))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -64,7 +64,7 @@ def _tensor_with_entanglement(all_qubits, entangled, entangled_locations):
     out = qutip.tensor(*separable, entangled)
     permutation = list(range(n_separable))
     current_locations = range(n_separable, n_separable + n_entangled)
-    # Sort to prevert later insertions changing previous locations.
+    # Sort to prevent later insertions changing previous locations.
     insertions = sorted(zip(entangled_locations, current_locations), key=lambda x: x[0])
     for out_location, current_location in insertions:
         permutation.insert(out_location, current_location)
@@ -668,7 +668,7 @@ class TestGateErrors:
             class BadCtrlGate(ControlledGate):
                 target_gate = gates.RX(
                     0
-                )  # target_gate must be a gate subclass not an instantiated onject
+                )  # target_gate must be a gate subclass not an instantiated object
                 num_ctrl_qubits = 1
                 ctrl_value = 1
                 num_qubits = 2
@@ -738,7 +738,7 @@ class TestGateErrors:
             )  # targets should be an integer or a list of integer
 
         with pytest.raises(ValueError):
-            expand_operator(op, 2, 0)  # dims needs to be an interable
+            expand_operator(op, 2, 0)  # dims needs to be an iterable
 
         with pytest.raises(ValueError):
             gate_sequence_product([], left_to_right=True)  # empty U_list

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -10,7 +10,7 @@ import qutip
 def test_measurement_comp_basis():
     """
     Test measurements to test probability calculation in
-    computational basis measurments on a 3 qubit state
+    computational basis measurements on a 3 qubit state
     """
 
     qubit_kets = [rand_ket(2), rand_ket(2), rand_ket(2)]
@@ -65,6 +65,6 @@ def test_measurement_collapse(index):
 def test_against_numerical_error():
     state = qutip.Qobj([[1], [1.0e-12]])
     measurement = Measurement("M", 0)
-    states, probabilites = measurement.measurement_comp_basis(state)
+    states, probabilities = measurement.measurement_comp_basis(state)
     assert states[1] is None
-    assert probabilites[1] == 0.0
+    assert probabilities[1] == 0.0

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -57,7 +57,7 @@ class TestNoise:
         assert_(tensor([qeye(2), sigmax()]) in c_ops)
         assert_(tensor([sigmax(), qeye(2)]) in c_ops)
 
-        # Time-denpendent and all qubits
+        # Time-dependent and all qubits
         decnoise = DecoherenceNoise(
             sigmax(), all_qubits=True, coeff=coeff * 2, tlist=tlist
         )
@@ -200,7 +200,7 @@ class TestNoise:
 
 
 class DriftNoise1(Noise):
-    """Standard defintion."""
+    """Standard definition."""
 
     def __init__(self, op):
         self.qobj = op

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -63,7 +63,7 @@ class TestOptPulseProcessor:
         test.add_control(sigmax(), cyclic_permutation=True)
         test.add_control(sigmay(), cyclic_permutation=True)
 
-        # test pulse genration for cnot gate, with kwargs
+        # test pulse generation for cnot gate, with kwargs
         qc = [tensor([identity(2), CX.get_qobj()])]
         with pytest.warns(DeprecationWarning):
             test.load_circuit(

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -363,13 +363,13 @@ class TestCircuitProcessor:
         proc.add_control(sigmax(), targets=1, label="sx")
         proc.set_all_coeffs({"sx": np.array([1.0] * len(tlist))})
         proc.set_all_tlist(tlist)
-        observerable = tensor([qutip.qeye(2), qutip.sigmax()])
+        observable = tensor([qutip.qeye(2), qutip.sigmax()])
         result1 = proc.run_state(
-            init_state=init_state, solver="mcsolve", e_ops=observerable
+            init_state=init_state, solver="mcsolve", e_ops=observable
         )
         assert result1.solver == "mcsolve"
 
-    def test_no_saving_intermidiate_state(self):
+    def test_no_saving_intermediate_state(self):
         processor = Processor(1)
         processor.add_pulse(
             pulse=Pulse(

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -43,7 +43,7 @@ class TestPulse:
 
     def test_coherent_noise(self):
         """
-        Test for pulse genration with coherent noise.
+        Test for pulse generation with coherent noise.
         """
         coeff = np.array([0.1, 0.2, 0.3, 0.4])
         tlist = np.array([0.0, 1.0, 2.0, 3.0])


### PR DESCRIPTION
**Description**
- Correct the spelling mistakes pointed out by newly added CI workflow for spellcheck in #372. For all the pointed out typos, check out: https://github.com/qutip/qutip-qip/actions/runs/24556020336/job/71792595502?pr=372

- In `Processor`, `CavityQED`, replaced the method`eliminate_auxillary_modes` with `eliminate_auxiliary_modes` (notice the double `l` in the former). [This needs to go into the changelog for next release]

**Related issues or PRs**
None

**AI Usage Disclosure**
None