### PR TITLE
noise: Add type hints to noise module

### DIFF
--- a/src/qutip_qip/noise/control_amp_noise.py
+++ b/src/qutip_qip/noise/control_amp_noise.py
@@ -1,6 +1,8 @@
 from numpy.typing import ArrayLike
+
 from qutip_qip.noise import Noise
 from qutip_qip.pulse import Pulse
+from qutip_qip.typing import IntSequence, Real, RealSequence
 
 
 class ControlAmpNoise(Noise):
@@ -9,32 +11,32 @@ class ControlAmpNoise(Noise):
 
     Parameters
     ----------
-    coeff: list
+    coeff : Real | RealSequence
         A list of the coefficients for the control Hamiltonians.
         For available choices, see :class:`qutip.QobjEvo`.
-    tlist: array_like, optional
+    tlist : array_like, optional
         A NumPy array specifies the time of each coefficient.
-    indices: list of int, optional
+    indices : IntSequence, optional
         The indices of target pulse in the list of pulses.
 
     Attributes
     ----------
-    coeff: list
+    coeff : Real | RealSequence
         A list of the coefficients for the control Hamiltonians.
         For available choices, see :class:`qutip.QobjEvo`.
-    tlist: array_like
+    tlist : array_like or None
         A NumPy array specifies the time of each coefficient.
-    indices: list of int
+    indices : IntSequence or None
         The indices of target pulse in the list of pulses.
 
     """
 
     def __init__(
         self,
-        coeff: list[complex],
+        coeff: Real | RealSequence,
         tlist: ArrayLike | None = None,
-        indices: list[int] | None = None,
-    ):
+        indices: IntSequence | None = None,
+    ) -> None:
         self.coeff = coeff
         self.tlist = tlist
         self.indices = indices
@@ -45,6 +47,27 @@ class ControlAmpNoise(Noise):
         pulses: list[Pulse] | None = None,
         systematic_noise: Pulse | None = None,
     ) -> tuple[list[Pulse], Pulse]:
+        """
+        Return the input pulses list with noise added and
+        the pulse independent noise in a dummy :class:`.Pulse` object.
+
+        Parameters
+        ----------
+        dims : list of int, optional
+            The dimension of the components system, the default value is
+            [2, 2, ..., 2] for qubits system.
+        pulses : list of :class:`.Pulse`, optional
+            The input pulses. The noise will be added to pulses in this list.
+        systematic_noise : :class:`.Pulse`, optional
+            The dummy pulse with no ideal control element.
+
+        Returns
+        -------
+        noisy_pulses : list of :class:`.Pulse`
+            Noisy pulses.
+        systematic_noise : :class:`.Pulse`
+            The dummy pulse representing pulse-independent noise.
+        """
         if pulses is None:
             pulses = []
 
@@ -65,6 +88,8 @@ class ControlAmpNoise(Noise):
             else:
                 tlist = self.tlist
 
-            pulses[i].add_coherent_noise(pulse.qobj, pulse.targets, tlist, coeff)
+            pulses[i].add_coherent_noise(
+                pulse.qobj, pulse.targets, tlist, coeff
+            )
 
         return pulses, systematic_noise

--- a/src/qutip_qip/noise/control_amp_noise.py
+++ b/src/qutip_qip/noise/control_amp_noise.py
@@ -88,8 +88,6 @@ class ControlAmpNoise(Noise):
             else:
                 tlist = self.tlist
 
-            pulses[i].add_coherent_noise(
-                pulse.qobj, pulse.targets, tlist, coeff
-            )
+            pulses[i].add_coherent_noise(pulse.qobj, pulse.targets, tlist, coeff)
 
         return pulses, systematic_noise

--- a/src/qutip_qip/noise/decoherence.py
+++ b/src/qutip_qip/noise/decoherence.py
@@ -1,4 +1,5 @@
 from numpy.typing import ArrayLike
+from qutip_qip.typing import IntSequence, RealSequence
 from qutip import Qobj
 
 from qutip_qip.noise import Noise
@@ -30,7 +31,7 @@ class DecoherenceNoise(Noise):
         The collapse operators representing the dynamics of the noise.
     targets : int or list of int or None
         The indices of qubits that are acted on.
-    coeff : list of float or bool or None
+    coeff : RealSequence or None
         A list of the coefficients for the control Hamiltonians.
     tlist : array_like or None
         A NumPy array specifies the time of each coefficient.
@@ -41,8 +42,8 @@ class DecoherenceNoise(Noise):
     def __init__(
         self,
         c_ops: Qobj | list[Qobj],
-        targets: int | list[int] | None = None,
-        coeff: list[float] | bool | None = None,
+        targets: int | IntSequence | None = None,
+        coeff: RealSequence | None = None,
         tlist: ArrayLike | None = None,
         all_qubits: bool = False,
     ) -> None:

--- a/src/qutip_qip/noise/decoherence.py
+++ b/src/qutip_qip/noise/decoherence.py
@@ -1,5 +1,6 @@
 from numpy.typing import ArrayLike
 from qutip import Qobj
+
 from qutip_qip.noise import Noise
 from qutip_qip.pulse import Pulse
 
@@ -11,42 +12,40 @@ class DecoherenceNoise(Noise):
 
     Parameters
     ----------
-    c_ops : :class:`qutip.Qobj` or list
-        The Hamiltonian representing the dynamics of the noise.
-    targets: int or list, optional
-        The indices of qubits that are acted on. Default is on all
-        qubits
-    coeff: list, optional
+    c_ops : :class:`qutip.Qobj` or list of :class:`qutip.Qobj`
+        The collapse operators representing the dynamics of the noise.
+    targets : int or list of int, optional
+        The indices of qubits that are acted on. Default is on all qubits.
+    coeff : list of float or bool, optional
         A list of the coefficients for the control Hamiltonians.
-    tlist: array_like, optional
+    tlist : array_like, optional
         A NumPy array specifies the time of each coefficient.
-    all_qubits: bool, optional
+    all_qubits : bool, optional
         If `c_ops` contains only single qubits collapse operator,
         ``all_qubits=True`` will allow it to be applied to all qubits.
 
     Attributes
     ----------
-    c_ops : :class:`qutip.Qobj` or list of :class:`qutip.Qobj`
-        The Hamiltonian representing the dynamics of the noise.
-    targets: int or list
+    c_ops : list of :class:`qutip.Qobj`
+        The collapse operators representing the dynamics of the noise.
+    targets : int or list of int or None
         The indices of qubits that are acted on.
-    coeff: list
+    coeff : list of float or bool or None
         A list of the coefficients for the control Hamiltonians.
-    tlist: array_like
+    tlist : array_like or None
         A NumPy array specifies the time of each coefficient.
-    all_qubits: bool
-        If `c_ops` contains only single qubits collapse operator,
-        ``all_qubits=True`` will allow it to be applied to all qubits.
+    all_qubits : bool
+        Whether the operator is applied to all qubits.
     """
 
     def __init__(
         self,
         c_ops: Qobj | list[Qobj],
         targets: int | list[int] | None = None,
-        coeff: list[complex] = None,
-        tlist: ArrayLike = None,
+        coeff: list[float] | bool | None = None,
+        tlist: ArrayLike | None = None,
         all_qubits: bool = False,
-    ):
+    ) -> None:
         if isinstance(c_ops, Qobj):
             self.c_ops = [c_ops]
         else:
@@ -75,17 +74,17 @@ class DecoherenceNoise(Noise):
 
         Parameters
         ----------
-        dims: list, optional
+        dims : list of int, optional
             The dimension of the components system, the default value is
             [2, 2, ..., 2] for a system of qubits.
-        pulses : list of :class:`.Pulse`
+        pulses : list of :class:`.Pulse`, optional
             The input pulses. The noise will be added to pulses in this list.
-        systematic_noise : :class:`.Pulse`
+        systematic_noise : :class:`.Pulse`, optional
             The dummy pulse with no ideal control element.
 
         Returns
         -------
-        noisy_pulses: list of :class:`.Pulse`
+        noisy_pulses : list of :class:`.Pulse`
             Noisy pulses.
         systematic_noise : :class:`.Pulse`
             The dummy pulse representing pulse-independent noise.

--- a/src/qutip_qip/noise/noise.py
+++ b/src/qutip_qip/noise/noise.py
@@ -1,8 +1,9 @@
 import warnings
+
 from qutip_qip.pulse import Pulse
 
 
-class Noise:
+class Noise(object):
     """
     The base class representing noise in a processor.
     The noise object can be added to :class:`.device.Processor` and
@@ -23,21 +24,18 @@ class Noise:
 
         Parameters
         ----------
-        dims: list, optional
+        dims : list of int, optional
             The dimension of the components system, the default value is
-            [2,2...,2] for qubits system.
-
-        pulses : list of :class:`.Pulse`
+            [2, 2, ..., 2] for qubits system.
+        pulses : list of :class:`.Pulse`, optional
             The input pulses. The noise will be added to pulses in this list.
-
-        systematic_noise : :class:`.Pulse`
+        systematic_noise : :class:`.Pulse`, optional
             The dummy pulse with no ideal control element.
 
         Returns
         -------
-        noisy_pulses: list of :class:`.Pulse`
+        noisy_pulses : list of :class:`.Pulse`
             Noisy pulses.
-
         systematic_noise : :class:`.Pulse`
             The dummy pulse representing pulse-independent noise.
         """
@@ -79,6 +77,8 @@ class Noise:
         elif isinstance(result, list) and len(result) == len(pulses):
             pulses = result
         else:
-            raise TypeError("Returned value of get_noisy_pulses not understood.")
+            raise TypeError(
+                "Returned value of get_noisy_pulses not understood."
+            )
 
         return pulses, systematic_noise

--- a/src/qutip_qip/noise/noise.py
+++ b/src/qutip_qip/noise/noise.py
@@ -3,7 +3,7 @@ import warnings
 from qutip_qip.pulse import Pulse
 
 
-class Noise(object):
+class Noise:
     """
     The base class representing noise in a processor.
     The noise object can be added to :class:`.device.Processor` and

--- a/src/qutip_qip/noise/noise.py
+++ b/src/qutip_qip/noise/noise.py
@@ -77,8 +77,6 @@ class Noise(object):
         elif isinstance(result, list) and len(result) == len(pulses):
             pulses = result
         else:
-            raise TypeError(
-                "Returned value of get_noisy_pulses not understood."
-            )
+            raise TypeError("Returned value of get_noisy_pulses not understood.")
 
         return pulses, systematic_noise

--- a/src/qutip_qip/noise/random_noise.py
+++ b/src/qutip_qip/noise/random_noise.py
@@ -1,4 +1,6 @@
 import numpy as np
+from collections.abc import Callable
+
 from qutip_qip.noise import ControlAmpNoise
 from qutip_qip.pulse import Pulse
 
@@ -10,28 +12,28 @@ class RandomNoise(ControlAmpNoise):
 
     Parameters
     ----------
-    dt: float, optional
+    dt : float
         The time interval between two random amplitude. The coefficients
         of the noise are the same within this time range.
-    rand_gen: numpy.random, optional
-        A random generator in numpy.random, it has to take a ``size``
-        parameter as the size of random numbers in the output array.
-    indices: list of int, optional
+    rand_gen : callable
+        A numpy random generator, reference :mod:`numpy.random`, it has
+        to take a ``size`` parameter as the size of random numbers in
+        the output array.
+    indices : list of int, optional
         The indices of target pulse in the list of pulses.
-    **kwargs:
+    **kwargs
         Key word arguments for the random number generator.
 
     Attributes
     ----------
-    dt: float
+    dt : float
         The time interval between two random amplitude. The coefficients
         of the noise are the same within this time range.
-    rand_gen: numpy.random, optional
-        A random generator in numpy.random, it has to take a ``size``
-        parameter.
-    indices: list of int
+    rand_gen : callable
+        A numpy random generator, reference :mod:`numpy.random`.
+    indices : list of int or None
         The indices of target pulse in the list of pulses.
-    **kwargs:
+    kwargs : dict
         Key word arguments for the random number generator.
 
     Examples
@@ -44,10 +46,10 @@ class RandomNoise(ControlAmpNoise):
     def __init__(
         self,
         dt: float,
-        rand_gen,  # FIXME add the typing for it (Use Generator instead)
+        rand_gen: Callable[..., np.ndarray],
         indices: list[int] | None = None,
-        **kwargs,
-    ):
+        **kwargs: any,
+    ) -> None:
         super().__init__(coeff=None, tlist=None)
         self.rand_gen = rand_gen
         self.kwargs = kwargs
@@ -68,17 +70,17 @@ class RandomNoise(ControlAmpNoise):
 
         Parameters
         ----------
-        dims: list, optional
+        dims : list of int, optional
             The dimension of the components system, the default value is
-            [2,2...,2] for qubits system.
-        pulses : list of :class:`.Pulse`
+            [2, 2, ..., 2] for qubits system.
+        pulses : list of :class:`.Pulse`, optional
             The input pulses. The noise will be added to pulses in this list.
-        systematic_noise : :class:`.Pulse`
+        systematic_noise : :class:`.Pulse`, optional
             The dummy pulse with no ideal control element.
 
         Returns
         -------
-        noisy_pulses: list of :class:`.Pulse`
+        noisy_pulses : list of :class:`.Pulse`
             Noisy pulses.
         systematic_noise : :class:`.Pulse`
             The dummy pulse representing pulse-independent noise.

--- a/src/qutip_qip/noise/random_noise.py
+++ b/src/qutip_qip/noise/random_noise.py
@@ -1,5 +1,5 @@
 import numpy as np
-from collections.abc import Callable
+from numpy.random import Generator
 
 from qutip_qip.noise import ControlAmpNoise
 from qutip_qip.pulse import Pulse
@@ -15,7 +15,7 @@ class RandomNoise(ControlAmpNoise):
     dt : float
         The time interval between two random amplitude. The coefficients
         of the noise are the same within this time range.
-    rand_gen : callable
+    rand_gen : :class:`numpy.random.Generator`
         A numpy random generator, reference :mod:`numpy.random`, it has
         to take a ``size`` parameter as the size of random numbers in
         the output array.
@@ -29,11 +29,11 @@ class RandomNoise(ControlAmpNoise):
     dt : float
         The time interval between two random amplitude. The coefficients
         of the noise are the same within this time range.
-    rand_gen : callable
+    rand_gen : :class:`numpy.random.Generator`
         A numpy random generator, reference :mod:`numpy.random`.
     indices : list of int or None
         The indices of target pulse in the list of pulses.
-    kwargs : dict
+    **kwargs 
         Key word arguments for the random number generator.
 
     Examples
@@ -46,9 +46,9 @@ class RandomNoise(ControlAmpNoise):
     def __init__(
         self,
         dt: float,
-        rand_gen: Callable[..., np.ndarray],
+        rand_gen: Generator,
         indices: list[int] | None = None,
-        **kwargs: any,
+        **kwargs,
     ) -> None:
         super().__init__(coeff=None, tlist=None)
         self.rand_gen = rand_gen

--- a/src/qutip_qip/noise/zzcrosstalk.py
+++ b/src/qutip_qip/noise/zzcrosstalk.py
@@ -1,4 +1,5 @@
 from qutip import basis, destroy, qeye, tensor
+
 from qutip_qip.noise import Noise
 from qutip_qip.pulse import Pulse
 
@@ -13,11 +14,17 @@ class ZZCrossTalk(Noise):
 
     Parameters
     ----------
-    params:
+    params : dict
         Parameters computed from a :class:`.SCQubits`.
+        Expected keys: ``"J"``, ``"wq_dressed_cavity"``, ``"alpha"``.
+
+    Attributes
+    ----------
+    params : dict
+        The device parameters used to compute ZZ coupling coefficients.
     """
 
-    def __init__(self, params):
+    def __init__(self, params: dict[str, any]) -> None:
         self.params = params
 
     def get_noisy_pulses(
@@ -32,22 +39,21 @@ class ZZCrossTalk(Noise):
 
         Parameters
         ----------
-        dims: list, optional
+        dims : list of int, optional
             The dimension of the components system, the default value is
-            [2,2...,2] for qubits system.
-        pulses : list of :class:`.Pulse`
+            [2, 2, ..., 2] for qubits system.
+        pulses : list of :class:`.Pulse`, optional
             The input pulses. The noise will be added to pulses in this list.
-        systematic_noise : :class:`.Pulse`
+        systematic_noise : :class:`.Pulse`, optional
             The dummy pulse with no ideal control element.
 
         Returns
         -------
-        noisy_pulses: list of :class:`.Pulse`
+        noisy_pulses : list of :class:`.Pulse`
             Noisy pulses.
         systematic_noise : :class:`.Pulse`
             The dummy pulse representing pulse-independent noise.
         """
-
         J = self.params["J"]
         wq_dr_cav = self.params["wq_dressed_cavity"]
         alpha = self.params["alpha"]
@@ -59,11 +65,13 @@ class ZZCrossTalk(Noise):
             destroy_op2 = destroy(d2)
 
             projector1 = (
-                basis(d1, 0) * basis(d1, 0).dag() + basis(d1, 1) * basis(d1, 1).dag()
+                basis(d1, 0) * basis(d1, 0).dag()
+                + basis(d1, 1) * basis(d1, 1).dag()
             )
 
             projector2 = (
-                basis(d2, 0) * basis(d2, 0).dag() + basis(d2, 1) * basis(d2, 1).dag()
+                basis(d2, 0) * basis(d2, 0).dag()
+                + basis(d2, 1) * basis(d2, 1).dag()
             )
 
             z1 = (

--- a/src/qutip_qip/noise/zzcrosstalk.py
+++ b/src/qutip_qip/noise/zzcrosstalk.py
@@ -65,13 +65,11 @@ class ZZCrossTalk(Noise):
             destroy_op2 = destroy(d2)
 
             projector1 = (
-                basis(d1, 0) * basis(d1, 0).dag()
-                + basis(d1, 1) * basis(d1, 1).dag()
+                basis(d1, 0) * basis(d1, 0).dag() + basis(d1, 1) * basis(d1, 1).dag()
             )
 
             projector2 = (
-                basis(d2, 0) * basis(d2, 0).dag()
-                + basis(d2, 1) * basis(d2, 1).dag()
+                basis(d2, 0) * basis(d2, 0).dag() + basis(d2, 1) * basis(d2, 1).dag()
             )
 
             z1 = (


### PR DESCRIPTION
## Description
Add type hints to the `noise` module as part of #262.

## Related Issues
Part of #262

## AI Usage Disclosure 
AI tools were used to improve efficiency and enhance quality of work.