### PR TITLE
Add AI Tools Usage Policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,6 @@ Describe here the proposed change.
 **Related issues or PRs**
 Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id, e.g. fix #249
 
-**AI Usage Disclosure**
-If AI tools were used, please describe how they were used.
+**AI Tools Usage Disclosure**
+If AI tools were used, please mention
+`Model/Tool Name: Describe how they were used`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,6 +33,7 @@ Examples of unacceptable behavior include:
 * Public or private harassment
 * Publishing others' private information, such as a physical or email
   address, without their explicit permission
+* Spamming, including the submission of unsupervised AI-generated pull requests and issues.
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ All types of contributions are encouraged and valued. Please make sure to [read 
 - [Reporting Bugs](#reporting-bugsissues)
 - [Contributing to Code](#contributing-to-code)
 - [Improving the Documentation](#improving-the-documentation)
+- [AI Tools Usage Policy](#ai-tools-usage-policy)
 
 
 ## Code of Conduct
@@ -46,15 +47,47 @@ In our workflow, we generally avoid formally assigning issues to contributors. T
 The only exception to this is a small subset of “core” issues. These are typically more complex, sensitive, or tightly coupled to ongoing development efforts, and are therefore handled directly by maintainers.
 
 
-### AI Tool Usage Policy
-We have no objections to the use of AI tools to improve efficiency and enhance quality of work. We ask only that contributors are honest about any such usage and that all outputs can be considered their own work, in that they fully understand, endorse and can explain anything that is submitted.
-
-AI use is strongly discouraged where it leads to overly verbose content. In communications, whether via e-mail, GitHub or other channels, we expect to communicate directly with other humans and not with automated systems. Use of translation tools is completely welcome.
-
-
 ## Improving The Documentation
 Documentation is a crucial part of any project, and we welcome contributions to improve it. If you find any errors, inconsistencies, or areas that could be clarified, please feel free to submit a pull request with your suggested changes. You can also open an issue to discuss potential improvements before making changes.
 
 Please read the [Contributing to the documentation](https://qutip-qip.readthedocs.io/en/latest/contribution-docs.html) for more details on how to contribute to the documentation.
 
 Also you can add new tutorials in the [Tutorials](http://github.com/qutip/qutip-tutorials/) repository. If you have an idea for a tutorial example that you think would be helpful to others, please feel free to submit a pull request with your suggested tutorial.
+
+
+## AI Tools Usage Policy
+We acknowledge the use of AI tools to improve efficiency and enhance quality of work. We only require that the contributors follow the below guidelines:
+
+### 1. Accountability
+
+The human contributor is solely responsible for their contribution i.e. all the AI-generated outputs can be considered their own work. If you're submitting a Pull Request that includes AI-generated code, documentation:
+
+- You are responsible for ensuring that code you submit meets the qutip-qip project's standards.
+- You must fully understand every line of code in the submission.
+- You must be able to explain the "why" behind the implementation during the review process.
+
+### 2. Transparency
+
+All Pull Requests must fill the "AI Tools Usage Disclosure" section in the Pull Request template. This disclosure is mandatory and must reflect the actual use of AI tools.
+
+### 3. Copyright & Legal
+
+By submitting a contribution to qutip-qip, you agree to
+
+1. Submit your contribution under the project's license.
+
+2. The contribution does not violate any third-party rights or the terms of service of the AI provider. And does not include "regurgitated" code from libraries with incompatible licenses (e.g., GPL-licensed code) being suggested into our BSD-3-licensed project.
+
+3. AI agents must not sign commits or be added to commit message trailer `Co-authored-by:` since copyright is fundamentally tied to the concept of human authorship as per the Copyright law. You can instead use `Assisted-by: AI Model/Tool` as commit message trailer e.g. `Assisted-by: Cursor with Opus 4.6`.
+
+### 4. Prohibited Use
+
+The following use cases are strictly prohibited:
+
+- **Ban on Bots/Agents:** Fully autonomous or unsupervised AI agents (e.g. OpenClaw, SWE-agent) are not allowed to submit Pull Requests.
+- **Communication:** In project communications (GitHub Issues, Discussion, PR descriptions and review comments), we expect to communicate directly with other humans not with automated systems. Use of translation tools is completely welcome.
+- **Good First Issues Misuse:** The main purpose of a “good first issue” is not getting the low-priority bug fixed, it is to allow human contributors to get familiar with `qutip-qip`, with the GitHub workflow and to engage with the community. AI can be used as a learning aid to understand the codebase, but the final implementation must be your own.
+
+### 5. Enforcement
+
+Maintainers reserve the right to close any Pull Request that violates this Policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,19 +56,19 @@ Also you can add new tutorials in the [Tutorials](http://github.com/qutip/qutip-
 
 
 ## AI Tools Usage Policy
-We acknowledge the use of AI tools to improve efficiency and enhance quality of work. We only require that the contributors follow the below guidelines:
+We acknowledge the use of AI tools to improve efficiency and enhance quality of work. Contributors may use such tools, provided they adhere to the following guidelines:
 
 ### 1. Accountability
 
-The human contributor is solely responsible for their contribution i.e. all the AI-generated outputs can be considered their own work. If you're submitting a Pull Request that includes AI-generated code, documentation:
+The human contributor is solely responsible for their contribution i.e. all the AI-generated outputs can be considered their own work. If you're submitting a Pull Request that includes AI-generated code or documentation:
 
-- You are responsible for ensuring that code you submit meets the qutip-qip project's standards.
+- You are responsible for ensuring that code you submit meets the [project's standards](https://qutip-qip.readthedocs.io/en/latest/contribution-code.html#code-style).
 - You must fully understand every line of code in the submission.
 - You must be able to explain the "why" behind the implementation during the review process.
 
 ### 2. Transparency
 
-All Pull Requests must fill the "AI Tools Usage Disclosure" section in the Pull Request template. This disclosure is mandatory and must reflect the actual use of AI tools.
+All Pull Requests must fill the **AI Tools Usage Disclosure** in the PR template. This disclosure is mandatory and must accurately reflect how AI Tools were used.
 
 ### 3. Copyright & Legal
 
@@ -76,18 +76,28 @@ By submitting a contribution to qutip-qip, you agree to
 
 1. Submit your contribution under the project's license.
 
-2. The contribution does not violate any third-party rights or the terms of service of the AI provider. And does not include "regurgitated" code from libraries with incompatible licenses (e.g., GPL-licensed code) being suggested into our BSD-3-licensed project.
+2. The contribution does not violate any third-party rights or the terms of service of the AI provider. And does not include "regurgitated" code from libraries with incompatible licenses (e.g., GPL-licensed code) being suggested into our BSD-3-clause licensed project.
 
-3. AI agents must not sign commits or be added to commit message trailer `Co-authored-by:` since copyright is fundamentally tied to the concept of human authorship as per the Copyright law. You can instead use `Assisted-by: AI Model/Tool` as commit message trailer e.g. `Assisted-by: Cursor with Opus 4.6`.
+3. AI agents must not sign commits or be added to commit message trailer `Co-authored-by:` since copyright is fundamentally tied to the concept of human authorship as per the US Copyright law. You can instead use `Assisted-by: AI Model/Tool` as commit message trailer e.g. `Assisted-by: Cursor with Opus 4.6`.
 
-### 4. Prohibited Use
+### 4. Good Use Cases
 
-The following use cases are strictly prohibited:
+- **Understand the codebase:** AI can be used to explore unfamiliar parts of the repository, summarize modules, and clarify how components interact. It helps build the mental model of the project faster. 
+
+- **Brainstorming and Design:**  AI may assist in generating ideas, evaluating different approaches, and structuring designs. However, all final decisions regarding design and architecture should be independently validated and be made by the contributor.
+
+- **Reviewing your implementation:**  AI can be used to spot potential bugs, suggest improvements, and help clarify unexpected behavior in code. Contributors should verify the correctness and relevance of AI-generated feedback before applying it.
+
+### 5. Prohibited Use
+
+The following use cases are prohibited:
+
+- **Communication:** In project communications (GitHub Issues, Discussion, PR descriptions and review comments), we personally expect to communicate directly with other humans not with automated systems. Use of translation tools is completely welcome.
 
 - **Ban on Bots/Agents:** Fully autonomous or unsupervised AI agents (e.g. OpenClaw, SWE-agent) are not allowed to submit Pull Requests.
-- **Communication:** In project communications (GitHub Issues, Discussion, PR descriptions and review comments), we expect to communicate directly with other humans not with automated systems. Use of translation tools is completely welcome.
-- **Good First Issues Misuse:** The main purpose of a “good first issue” is not getting the low-priority bug fixed, it is to allow human contributors to get familiar with `qutip-qip`, with the GitHub workflow and to engage with the community. AI can be used as a learning aid to understand the codebase, but the final implementation must be your own.
 
-### 5. Enforcement
+- **Stance on Good First Issues:** The main purpose of a “good first issue” is to allow new human contributors to get familiar with `qutip-qip`, with the GitHub workflow and to engage with the community. Submitting a fully AI-generated PR defeats that purpose. AI can be used as a learning aid to understand the codebase, but the final implementation must be your own.
 
-Maintainers reserve the right to close any Pull Request that violates this Policy.
+### 6. Enforcement
+
+Maintainers reserve the right to close any Pull Request that violates this Policy. Maintainers may restrict participation or report users to GitHub for repeated violations of this policy.


### PR DESCRIPTION
**Description**
Adding a proper AI Tools Usage Policy in `CONTRIBUTING.md` based on discussion with @BoxiLi on Discord.

**Related issues or PRs**
None

**AI Usage Disclosure**
None

**Acknowledgement:** The policy is mainly inspired from [Mastodon's AI Policy](https://github.com/mastodon/.github/blob/main/AI_POLICY.md) and some parts of it from this [repo](https://github.com/melissawm/open-source-ai-contribution-policies) collection of AI Usage Policy followed by major open-source orgs. Stance on "good-first-issues" is taken from this [comment](https://github.com/qutip/qutip/issues/2880#issuecomment-4257481718) by @pmenczel which I completely agree with. Good use cases section is inspired from [matplotlib's policy](https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai).