### PR TITLE
fix: render hollow circle for control_value=0 in circuit draw

### DIFF
--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -220,7 +220,9 @@ class MatRenderer(BaseRenderer):
             )
             self._ax.add_artist(wire_label)
 
-    def _draw_control_node(self, pos: int, xskip: float, color: str, control_value: int = 1) -> None:
+    def _draw_control_node(
+    self, pos: int, xskip: float, color: str, control_value: int = 1
+) -> None:
         """
         Draw the control node for the multi-qubit gate.
 
@@ -661,7 +663,9 @@ class MatRenderer(BaseRenderer):
             # add qbridge if control qubits are present
             for i, control in enumerate(controls):
                 ctrl_val = (gate.ctrl_value >> i) & 1
-                self._draw_control_node(control, xskip + text_width / 2, self.color, ctrl_val)
+                self._draw_control_node(
+                    control, xskip + text_width / 2, self.color, ctrl_val
+                )
                 self._draw_qbridge(
                     control,
                     targets[0],

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -220,7 +220,7 @@ class MatRenderer(BaseRenderer):
             )
             self._ax.add_artist(wire_label)
 
-    def _draw_control_node(self, pos: int, xskip: float, color: str) -> None:
+    def _draw_control_node(self, pos: int, xskip: float, color: str, control_value: int = 1) -> None:
         """
         Draw the control node for the multi-qubit gate.
 
@@ -234,19 +234,36 @@ class MatRenderer(BaseRenderer):
 
         color : str
             The color of the control node. HEX code or color name supported by matplotlib are valid.
+
+        control_value : int, optional
+            The value of the control qubit. 1 draws a filled circle (default),
+            0 draws a hollow circle, following the Qiskit convention.
         """
 
         pos = pos + self._cwires
 
-        control_node = Circle(
-            (
-                xskip + self.style.gate_margin + self.style.gate_pad,
-                pos * self.style.wire_sep,
-            ),
-            self._control_node_r,
-            color=color,
-            zorder=self._zorder["node"],
-        )
+        if control_value == 1:
+            control_node = Circle(
+                (
+                    xskip + self.style.gate_margin + self.style.gate_pad,
+                    pos * self.style.wire_sep,
+                ),
+                self._control_node_r,
+                color=color,
+                zorder=self._zorder["node"],
+            )
+        else:
+            control_node = Circle(
+                (
+                    xskip + self.style.gate_margin + self.style.gate_pad,
+                    pos * self.style.wire_sep,
+                ),
+                self._control_node_r,
+                facecolor="none",
+                edgecolor=color,
+                linewidth=1.5,
+                zorder=self._zorder["node"],
+            )
         self._ax.add_artist(control_node)
 
     def _draw_target_node(self, pos: int, xskip: float, color: str) -> None:
@@ -642,8 +659,9 @@ class MatRenderer(BaseRenderer):
                     self._ax.add_artist(connector_r)
 
             # add qbridge if control qubits are present
-            for control in controls:
-                self._draw_control_node(control, xskip + text_width / 2, self.color)
+            for i, control in enumerate(controls):
+                ctrl_val = (gate.ctrl_value >> i) & 1
+                self._draw_control_node(control, xskip + text_width / 2, self.color, ctrl_val)
                 self._draw_qbridge(
                     control,
                     targets[0],

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -221,8 +221,8 @@ class MatRenderer(BaseRenderer):
             self._ax.add_artist(wire_label)
 
     def _draw_control_node(
-    self, pos: int, xskip: float, color: str, control_value: int = 1
-) -> None:
+        self, pos: int, xskip: float, color: str, control_value: int = 1
+    ) -> None:
         """
         Draw the control node for the multi-qubit gate.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import functools
 import os
 import tempfile
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
 
 
 def _add_repeats_if_marked(metafunc):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import numpy as np
 import matplotlib
+
 matplotlib.use("Agg")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,6 @@ import functools
 import os
 import tempfile
 import numpy as np
-import matplotlib
-
-matplotlib.use("Agg")
 
 
 def _add_repeats_if_marked(metafunc):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -308,8 +308,6 @@ def test_control_value_rendering():
         # Test control_value=0 — circle must be hollow
         renderer_anti = MatRenderer(qc_anti)
         renderer_anti.canvas_plot()
-        circles = [
-            a for a in renderer_anti._ax.get_children() if isinstance(a, Circle)
-        ]
+        circles = [a for a in renderer_anti._ax.get_children() if isinstance(a, Circle)]
         hollow = [c for c in circles if c.get_facecolor()[3] == 0]
         assert len(hollow) > 0, "control_value=0 should render a hollow circle"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -270,3 +270,47 @@ def test_circuit_saving(request, qc_fixture, tmpdir):
     # test TextRenderer
     qc.draw("text", save=True, file_path=str(tmpdir.join("test")))
     assert tmpdir.join("test.txt").check(), "TextRenderer saved TXT file not found."
+
+def test_control_value_rendering():
+    """
+    Test that control nodes render as filled circles for control_value=1
+    and hollow circles for control_value=0.
+    Regression test for issue #367.
+    """
+    pytest.importorskip("matplotlib")
+    from matplotlib.patches import Circle
+    from unittest.mock import patch
+    from qutip_qip.operations import get_controlled_gate
+
+    # control_value=1 — standard controlled gate, filled circle
+    cx_standard = get_controlled_gate(X, n_ctrl_qubits=1, control_value=1)
+    qc_standard = QubitCircuit(2)
+    qc_standard.add_gate(cx_standard, controls=[0], targets=[1])
+
+    # control_value=0 — anti-controlled gate, hollow circle
+    cx_anti = get_controlled_gate(X, n_ctrl_qubits=1, control_value=0)
+    qc_anti = QubitCircuit(2)
+    qc_anti.add_gate(cx_anti, controls=[0], targets=[1])
+
+    with patch("matplotlib.pyplot.show"):
+        from qutip_qip.circuit.draw.mat_renderer import MatRenderer
+
+        # Test control_value=1 — circle must be filled
+        renderer_standard = MatRenderer(qc_standard)
+        renderer_standard.canvas_plot()
+        circles = [
+            a for a in renderer_standard._ax.get_children()
+            if isinstance(a, Circle)
+        ]
+        filled = [c for c in circles if c.get_facecolor()[3] > 0]
+        assert len(filled) > 0, "control_value=1 should render a filled circle"
+
+        # Test control_value=0 — circle must be hollow
+        renderer_anti = MatRenderer(qc_anti)
+        renderer_anti.canvas_plot()
+        circles = [
+            a for a in renderer_anti._ax.get_children()
+            if isinstance(a, Circle)
+        ]
+        hollow = [c for c in circles if c.get_facecolor()[3] == 0]
+        assert len(hollow) > 0, "control_value=0 should render a hollow circle"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -280,13 +280,10 @@ def test_control_value_rendering():
     """
     pytest.importorskip("matplotlib")
     from matplotlib.patches import Circle
-    from unittest.mock import patch
-    from qutip_qip.operations import get_controlled_gate
 
-    # control_value=1 — standard controlled gate, filled circle
-    cx_standard = get_controlled_gate(X, n_ctrl_qubits=1, control_value=1)
+    # control_value=1 — standard CX gate, filled circle
     qc_standard = QubitCircuit(2)
-    qc_standard.add_gate(cx_standard, controls=[0], targets=[1])
+    qc_standard.add_gate(CX, controls=[0], targets=[1])
 
     # control_value=0 — anti-controlled gate, hollow circle
     cx_anti = get_controlled_gate(X, n_ctrl_qubits=1, control_value=0)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -271,6 +271,7 @@ def test_circuit_saving(request, qc_fixture, tmpdir):
     qc.draw("text", save=True, file_path=str(tmpdir.join("test")))
     assert tmpdir.join("test.txt").check(), "TextRenderer saved TXT file not found."
 
+
 def test_control_value_rendering():
     """
     Test that control nodes render as filled circles for control_value=1
@@ -299,8 +300,7 @@ def test_control_value_rendering():
         renderer_standard = MatRenderer(qc_standard)
         renderer_standard.canvas_plot()
         circles = [
-            a for a in renderer_standard._ax.get_children()
-            if isinstance(a, Circle)
+            a for a in renderer_standard._ax.get_children() if isinstance(a, Circle)
         ]
         filled = [c for c in circles if c.get_facecolor()[3] > 0]
         assert len(filled) > 0, "control_value=1 should render a filled circle"
@@ -309,8 +309,7 @@ def test_control_value_rendering():
         renderer_anti = MatRenderer(qc_anti)
         renderer_anti.canvas_plot()
         circles = [
-            a for a in renderer_anti._ax.get_children()
-            if isinstance(a, Circle)
+            a for a in renderer_anti._ax.get_children() if isinstance(a, Circle)
         ]
         hollow = [c for c in circles if c.get_facecolor()[3] == 0]
         assert len(hollow) > 0, "control_value=0 should render a hollow circle"


### PR DESCRIPTION
Fixes #367

## Problem
Control nodes in circuit diagrams always rendered as filled circles regardless of `control_value`. A gate with `control_value=0` (anti-controlled) was visually identical to `control_value=1`.

## Fix
- Added `control_value` parameter to `_draw_control_node()`
- `control_value=1` → filled circle ● (existing behavior)
- `control_value=0` → hollow circle ○ (new behavior)
- Bitmask extraction `(ctrl_value >> i) & 1` handles multi-control gates correctly

## Convention
Follows the Qiskit/standard quantum circuit drawing convention as suggested in the issue comments.

## Testing
Added `test_control_value_rendering` regression test verifying:
- Filled circle rendered for control_value=1
- Hollow circle rendered for control_value=0

## AI Assistance
This PR was developed with assistance from Claude (Anthropic) as a learning and reference tool for understanding the codebase. The fix, tests, and all code have been reviewed and understood by the author.

Assisted-by: Claude (Anthropic)

All 491 tests passing.

