### PR TITLE
fix: added threshold and top_m filtering for histogram generation

### DIFF
--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -150,10 +150,7 @@ class CircuitResult:
         for cbits, prob in zip(self.cbits, self.probabilities):
             if prob > threshold:
                 binary = "".join(str(b) for b in cbits)
-                if binary not in plot_dict:
-                    plot_dict[binary] = prob
-                else:
-                    plot_dict[binary] += prob
+                plot_dict[binary] = prob
 
         plot_dict = dict(
             sorted(plot_dict.items(), key=lambda item: item[1], reverse=True)

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -103,7 +103,7 @@ class CircuitResult:
         fig: "matplotlib.figure.Figure | None" = None,
         ax: "matplotlib.axes.Axes | None" = None,
         color: str = "#1f77b4",
-        top_m: int = None,
+        top_m: int | None = None,
         threshold: float = 0.0,
     ) -> "tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]":
         """

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -124,7 +124,7 @@ class CircuitResult:
             The number of top m highest probability measurements to be plotted in the histogram. If not specified, defaults to all the measurements above the mentioned tolerance.
 
         threshold : float, optional
-            the percentage above which the measurements are desired to be seen in the histogram. excludive, default being 0.
+            The probability e.g. 1e-7 above which the measurements are plotted in the histogram. If not specified, defaults to 1e-10.
 
         Returns
         -------

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -104,7 +104,7 @@ class CircuitResult:
         ax: "matplotlib.axes.Axes | None" = None,
         color: str = "#1f77b4",
         top_m: int | None = None,
-        threshold: float = 0.0,
+        threshold: float = 1e-10,
     ) -> "tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]":
         """
         Plot a histogram of the measurement outcomes and their probabilities.

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -121,7 +121,7 @@ class CircuitResult:
             Bar color for the histogram. Default is '#1f77b4'.
 
         top_m : int, optional
-            the number of top greatest measurements to be plotted in the histogram. In case ignored, all the measurements having measurements more than the mentioned tolerance will be plotted.
+            The number of top m highest probability measurements to be plotted in the histogram. If not specified, defaults to all the measurements above the mentioned tolerance.
 
         threshold : float, optional
             the percentage above which the measurements are desired to be seen in the histogram. excludive, default being 0.

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -1,4 +1,5 @@
 from qutip import Qobj
+import warnings
 
 
 class CircuitResult:
@@ -102,6 +103,8 @@ class CircuitResult:
         fig: "matplotlib.figure.Figure | None" = None,
         ax: "matplotlib.axes.Axes | None" = None,
         color: str = "#1f77b4",
+        top_m: int = None,
+        threshold: float = 0.0,
     ) -> "tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]":
         """
         Plot a histogram of the measurement outcomes and their probabilities.
@@ -116,6 +119,12 @@ class CircuitResult:
 
         color : str, optional
             Bar color for the histogram. Default is '#1f77b4'.
+
+        top_m : int, optional
+            the number of top greatest measurements to be plotted in the histogram. In case ignored, all the measurements having measurements more than the mentioned tolerance will be plotted.
+
+        threshold : float, optional
+            the percentage above which the measurements are desired to be seen in the histogram. excludive, default being 0.
 
         Returns
         -------
@@ -135,11 +144,31 @@ class CircuitResult:
             )
 
         num_cbits = len(self.cbits[0])
-        plot_dict = {f"{i:0{num_cbits}b}": 0.0 for i in range(1 << num_cbits)}
+
+        plot_dict = {}
 
         for cbits, prob in zip(self.cbits, self.probabilities):
-            binary = "".join(str(b) for b in cbits)
-            plot_dict[binary] += prob
+            if prob > threshold:
+                binary = "".join(str(b) for b in cbits)
+                if binary not in plot_dict:
+                    plot_dict[binary] = prob
+                else:
+                    plot_dict[binary] += prob
+
+        entries = len(plot_dict)
+
+        ## No Measured values
+        if entries == 0:
+            warnings.warn(
+                "No entries qualified to be plotted! Plotting empty Histogram..."
+            )
+
+        plot_dict = dict(
+            sorted(plot_dict.items(), key=lambda item: item[1], reverse=True)
+        )
+
+        if top_m != None and top_m < entries:
+            plot_dict = dict(list(plot_dict.items())[:top_m])
 
         if fig is None or ax is None:
             fig, ax = plt.subplots()

--- a/src/qutip_qip/circuit/simulator/result.py
+++ b/src/qutip_qip/circuit/simulator/result.py
@@ -155,20 +155,18 @@ class CircuitResult:
                 else:
                     plot_dict[binary] += prob
 
-        entries = len(plot_dict)
-
-        ## No Measured values
-        if entries == 0:
-            warnings.warn(
-                "No entries qualified to be plotted! Plotting empty Histogram..."
-            )
-
         plot_dict = dict(
             sorted(plot_dict.items(), key=lambda item: item[1], reverse=True)
         )
 
-        if top_m != None and top_m < entries:
+        if top_m != None and top_m < len(plot_dict):
             plot_dict = dict(list(plot_dict.items())[:top_m])
+
+        ## No Measured values
+        if len(plot_dict) == 0:
+            warnings.warn(
+                "No entries qualified to be plotted! Plotting empty Histogram..."
+            )
 
         if fig is None or ax is None:
             fig, ax = plt.subplots()


### PR DESCRIPTION
**Description**
This PR adds a threshold filtering feature to the histogram generation logic in circuit\simulator\result.py . The user needs to pass a floating point argument called threshold in the plot_histogram() function, the default value of which is 0.0. The plot_dict automatically filters all the measurements strictly above the threshold and renders the values on the histogram.

Since the values having zero measurement are automatically filtered by the default value of threshold, no stray values are seen with empty measurements in the histogram.

Here is the before and after state of the histogram of a circuit having just 5 qubits and an X gate applied to qubit[0].

<img width="1536" height="754" alt="before" src="https://github.com/user-attachments/assets/93770d7d-b283-43dd-8fda-808f40bb25ab" />
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/b0bd2969-78fb-487d-9247-21628bc448c5" />

This PR also adds a top_m argument to the plot_histogram() function, the default value of which is none. Passing the top_m=m as an argument filters only the greatest m measurements, which in turn are plotted on the histogram.

I did not get an appropriate name for the above argument, any suggestions for the same are welcome.

If any of the above renders the histogram to be empty, a warning is also issued regarding the same and the blank histogram is plotted.

Another testcase for rendering the histogram of a 3-qubit circuit having hadamard gates on qubits [0] and [1] are as follows:
The screenshots attached are respectively for the following cases:
--> Older version(unchanged)
--> This version with no arguments
--> this version having threshold=0.3
--> warning message of the above with the same threshold when no histograms are rendered
--> histogram with top_m=2.

<img width="640" height="480" alt="hadamard_unchanged" src="https://github.com/user-attachments/assets/66dabc73-19cf-4693-8d46-a798e18ee033" />
<img width="640" height="480" alt="hadamard_zero_arguments" src="https://github.com/user-attachments/assets/eada2f0e-5a0b-4ee8-8681-57616fe9318f" />
<img width="640" height="480" alt="empty_histogram_threshold_0 3" src="https://github.com/user-attachments/assets/4f0a4eac-f285-466e-8221-c50da048a415" />
<img width="1466" height="67" alt="warning_on_threshold_0 3" src="https://github.com/user-attachments/assets/5626b24f-7c01-44b0-9ece-ff8b56307451" />
<img width="640" height="480" alt="top_2_measurements" src="https://github.com/user-attachments/assets/56a5d2c8-1343-4d22-82d7-8edee99adc9d" />


**Related issues or PRs**
fixes #388 

**AI Tools Usage Disclosure**
Google AI Studio: for referencing python documentation and syntax.
