### PR TITLE
Measurement: Add measurement subclasses

### DIFF
--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -53,7 +53,7 @@ A circuit with the various gates and registers available is demonstrated below:
   :options: +NORMALIZE_WHITESPACE
 
     [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,), style={}),
+      MeasurementInstruction(operation=<class 'qutip_qip.operations.measurement.Mz'>, qubits=(1,), cbits=(0,), style={}),
       GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
       GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), style=None, cbits_ctrl_value=1),
       GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None)]

--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -53,7 +53,7 @@ A circuit with the various gates and registers available is demonstrated below:
   :options: +NORMALIZE_WHITESPACE
 
     [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      MeasurementInstruction(operation=<class 'qutip_qip.operations.measurement.Mz'>, qubits=(1,), cbits=(0,), style={}),
+      MeasurementInstruction(operation=Measurement(Mz), qubits=(1,), cbits=(0,), style={}),
       GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
       GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), style=None, cbits_ctrl_value=1),
       GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None)]

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -19,7 +19,7 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
-    operation: Gate | Type[Gate] | Measurement | Type[Measurement]
+    operation: Gate | Type[Gate] | Type[Measurement]
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
     style: dict = field(default_factory=dict)

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -19,7 +19,7 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
-    operation: Gate | Type[Gate] | Measurement
+    operation: Gate | Type[Gate] | Measurement | Type[Measurement]
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
     style: dict = field(default_factory=dict)
@@ -168,7 +168,13 @@ class MeasurementInstruction(CircuitInstruction):
 
     def __post_init__(self) -> None:
         super(MeasurementInstruction, self).__post_init__()
-        if not isinstance(self.operation, Measurement):
+        if not (
+            isinstance(self.operation, Measurement)
+            or (
+                isinstance(self.operation, type)
+                and issubclass(self.operation, Measurement)
+            )
+        ):
             raise TypeError(f"Operation must be a measurement, got {self.operation}")
 
         if len(self.qubits) != len(self.cbits):

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -3,6 +3,7 @@ from typing import Type
 from dataclasses import dataclass, field
 import warnings
 from qutip_qip.operations import Gate, Measurement
+from qutip_qip.operations.measurement import Mz
 
 
 def _validate_non_negative_int_tuple(T: any, txt: str = ""):
@@ -185,6 +186,10 @@ class MeasurementInstruction(CircuitInstruction):
         return True
 
     def to_qasm(self, qasm_out) -> None:
+        if self.operation is not Mz:
+            raise NotImplementedError(
+                f"Exporting non-Z basis measurement ({self.operation}) to QASM is not supported."
+            )
         for qubit, cbit in zip(self.qubits, self.cbits):
             qasm_out.output(f"measure q[{qubit}] -> c[{cbit}];")
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -316,7 +316,7 @@ class CircuitSimulator:
 
     def _apply_measurement(
         self,
-        operation: Measurement | Type[Measurement],
+        operation: Type[Measurement],
         qubits: tuple[int, ...],
         cbits: tuple[int, ...],
     ) -> Qobj:
@@ -339,8 +339,8 @@ class CircuitSimulator:
             The collapsed state after the measurement.
         """
         current_state = self.state
-        n = int(np.log2(current_state.shape[0]))
-        if isinstance(operation, type) and issubclass(operation, Measurement):
+        n = self.qc.num_qubits
+        if issubclass(operation, Measurement):
             operation = operation()
         raw_ops = operation.get_measurement_ops()
         measurement_ops = [

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -1,11 +1,13 @@
 from itertools import product
 from operator import mul
 from functools import reduce
+from typing import Type
 import numpy as np
 
 from qutip import ket2dm, Qobj
+from qutip.measurement import measurement_statistics
 from qutip_qip.circuit.simulator import CircuitResult
-from qutip_qip.operations import expand_operator
+from qutip_qip.operations import expand_operator, Measurement
 
 
 def _decimal_to_binary(decimal, length):
@@ -312,14 +314,19 @@ class CircuitSimulator:
         )
         return state
 
-    def _apply_measurement(self, operation, qubits, cbits):
+    def _apply_measurement(
+        self,
+        operation: Measurement | Type[Measurement],
+        qubits: tuple[int, ...],
+        cbits: tuple[int, ...],
+    ) -> Qobj:
         """
         Applies measurement gate specified by operation to current state.
 
         Parameters
         ----------
-        operation: :class:`.Measurement`
-            Measurement gate in a circuit object.
+        operation: :class:`.Measurement` or Type[:class:`.Measurement`]
+            Measurement gate in a circuit object or its class.
         qubits : tuple of int
             The indices of the qubits to be measured.
         cbits : tuple of int
@@ -331,7 +338,16 @@ class CircuitSimulator:
         state : qutip.Qobj
             The collapsed state after the measurement.
         """
-        states, probabilities = operation.measurement_comp_basis(self.state, qubits)
+        current_state = self.state
+        n = int(np.log2(current_state.shape[0]))
+        if isinstance(operation, type) and issubclass(operation, Measurement):
+            operation = operation()
+        raw_ops = operation.get_measurement_ops()
+        measurement_ops = [
+            expand_operator(oper=op, dims=[2] * n, targets=qubits) for op in raw_ops
+        ]
+
+        states, probabilities = measurement_statistics(current_state, measurement_ops)
 
         if self.mode == "state_vector_simulator":
             if self._measure_results:
@@ -339,7 +355,8 @@ class CircuitSimulator:
                 self._measure_ind += 1
             else:
                 probabilities = [p / sum(probabilities) for p in probabilities]
-                i = np.random.choice([0, 1], p=probabilities)
+                outcome_indices = np.arange(len(probabilities))
+                i = np.random.choice(outcome_indices, p=probabilities)
             self._probability *= probabilities[i]
             state = states[i]
             if cbits:

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -340,7 +340,7 @@ class CircuitSimulator:
         """
         current_state = self.state
         n = self.qc.num_qubits
-        if issubclass(operation, Measurement):
+        if isinstance(operation, type) and issubclass(operation, Measurement):
             operation = operation()
         raw_ops = operation.get_measurement_ops()
         measurement_ops = [

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -63,7 +63,13 @@ class Measurement:
                         the probability of measuring a state in a the state
                         specified by the index.
         """
-
+        warnings.warn(
+            "'measurement_comp_basis' has been deprecated and will be removed "
+            "in future versions. Please use 'get_measurement_ops()' combined "
+            "with simulator logic, or the upcoming 'apply()' method.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         n = int(np.log2(state.shape[0]))
         target = qubits[0]
         if target < n:

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,6 +1,7 @@
 import numpy as np
 import warnings
 import qutip
+from abc import ABC, abstractmethod
 from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
@@ -8,7 +9,7 @@ from qutip_qip.operations import expand_operator
 __all__ = ["Mz", "Mx", "My"]
 
 
-class Measurement:
+class Measurement(ABC):
     """
     Base class for quantum measurements.
     """
@@ -20,20 +21,18 @@ class Measurement:
         if type(self) is Measurement:
             warnings.warn(
                 "Direct instantiation of Measurement() is deprecated and will "
-                "be removed in future verisions. Please use a specific subclass "
+                "be removed in future versions. Please use a specific subclass "
                 "like 'Mz()' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
+    @abstractmethod
     def get_measurement_ops(self) -> list[Qobj]:
         """
         Returns a list of Kraus operators representing the measurement.
-        (Defaults to Z-basis for backward compatibility)
         """
-        op0 = basis(2, 0) * basis(2, 0).dag()
-        op1 = basis(2, 1) * basis(2, 1).dag()
-        return [op0, op1]
+        pass
 
     @classmethod
     def measurement_comp_basis(cls, state, qubits):

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,46 +1,45 @@
 import numpy as np
 import warnings
 import qutip
-from qutip import basis
+from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
 
-__all__ = ["Mz"]
+__all__ = ["Mz", "Mx", "My"]
 
 
 class Measurement:
     """
-    Representation of a quantum measurement, with its required parameters,
-    and target qubits.
+    Base class for quantum measurements.
     """
 
     name = "M"
+    num_qubits = 1
 
-    def __init__(self, name=None, targets=None, index=None, classical_store=None):
-        """
-        Create a measurement with specified parameters.
-        """
-        if name is not None:
+    def __init__(self, *args, **kwargs) -> None:
+        if type(self) is Measurement:
             warnings.warn(
-                "'name' argument in Measurement has been deprecated.",
+                "Direct instantiation of Measurement() is deprecated and will "
+                "be removed in future verisions. Please use a specific subclass "
+                "like 'Mz()' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
-        if index is not None:
-            raise AttributeError("argument index is no longer supported")
-
-        if targets is not None or classical_store is not None:
-            warnings.warn(
-                "'targets' and 'classical_store' arguments in Measurement are deprecated. "
-                "Please pass these directly to QubitCircuit.add_measurement() method.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    def get_measurement_ops(self) -> list[Qobj]:
+        """
+        Returns a list of Kraus operators representing the measurement.
+        (Defaults to Z-basis for backward compatibility)
+        """
+        op0 = basis(2, 0) * basis(2, 0).dag()
+        op1 = basis(2, 1) * basis(2, 1).dag()
+        return [op0, op1]
 
     @classmethod
     def measurement_comp_basis(cls, state, qubits):
         """
+        DEPRECATED: Old method for computational basis meaasurement.
+
         Measures a particular qubit (determined by the target)
         whose ket vector/ density matrix is specified in the
         computational basis and returns collapsed_states and probabilities
@@ -95,4 +94,31 @@ class Measurement:
         return str(self)
 
 
-Mz = Measurement()
+class Mz(Measurement):
+    name = "Mz"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        op0 = basis(2, 0) * basis(2, 0).dag()
+        op1 = basis(2, 1) * basis(2, 1).dag()
+        return [op0, op1]
+
+
+class Mx(Measurement):
+    name = "Mx"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        plus = (basis(2, 0) + basis(2, 1)).unit()
+        minus = (basis(2, 0) - basis(2, 1)).unit()
+        return [plus * plus.dag(), minus * minus.dag()]
+
+
+class My(Measurement):
+    name = "My"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        plus_y = (basis(2, 0) + 1j * basis(2, 1)).unit()
+        minus_y = (basis(2, 0) - 1j * basis(2, 1)).unit()
+        return [plus_y * plus_y.dag(), minus_y * minus_y.dag()]

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,7 +1,7 @@
 import numpy as np
 import warnings
 import qutip
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
@@ -9,7 +9,16 @@ from qutip_qip.operations import expand_operator
 __all__ = ["Mz", "Mx", "My"]
 
 
-class Measurement(ABC):
+class _MeasurementMetaClass(ABCMeta):
+    def __repr__(cls) -> str:
+        name = getattr(cls, "name", cls.__name__)
+        return f"Measurement({name})"
+
+    def __str__(cls) -> str:
+        return repr(cls)
+
+
+class Measurement(ABC, metaclass=_MeasurementMetaClass):
     """
     Base class for quantum measurements.
     """
@@ -22,7 +31,7 @@ class Measurement(ABC):
             warnings.warn(
                 "Direct instantiation of Measurement() is deprecated and will "
                 "be removed in future versions. Please use a specific subclass "
-                "like 'Mz()' instead.",
+                "like 'Mz' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -65,7 +74,7 @@ class Measurement(ABC):
         warnings.warn(
             "'measurement_comp_basis' has been deprecated and will be removed "
             "in future versions. Please use 'get_measurement_ops()' combined "
-            "with simulator logic, or the upcoming 'apply()' method.",
+            "with simulator logic.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -92,7 +101,7 @@ class Measurement(ABC):
 
     def __str__(self):
         if self.name:
-            return f" Measurement({self.name})"
+            return f"Measurement({self.name})"
         return "Measurement"
 
     def __repr__(self):

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -17,6 +17,7 @@ from qutip import (
     ket2dm,
     identity,
 )
+from qutip.measurement import measurement_statistics
 
 from qutip_qip.circuit import (
     QubitCircuit,
@@ -27,7 +28,12 @@ from qutip_qip.circuit import (
 )
 from qutip_qip.circuit.draw import TeXRenderer
 from qutip_qip.decompose.decompose_single_qubit_gate import _ZYZ_rotation
-from qutip_qip.operations import Gate, Measurement, gate_sequence_product
+from qutip_qip.operations import (
+    Gate,
+    Measurement,
+    gate_sequence_product,
+    expand_operator,
+)
 import qutip_qip.operations.gates as gates
 from qutip_qip.operations.measurement import Mz
 from qutip_qip.transpiler import to_chain_structure
@@ -77,6 +83,20 @@ def _measurement_circuit():
     qc.add_measurement(Mz, targets=[1], classical_store=1)
 
     return qc
+
+
+def _get_probs(state, measurement_obj, targets):
+    """Helper to get probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
+
+    _, probabilities = measurement_statistics(state, expanded_ops)
+    return probabilities
 
 
 class TestQubitCircuit:
@@ -318,7 +338,7 @@ class TestQubitCircuit:
         # checking correct addition of measurements
         assert qc.instructions[0].qubits[0] == 0
         assert qc.instructions[0].cbits[0] == 0
-        assert isinstance(qc.instructions[3].operation, Measurement)
+        assert issubclass(qc.instructions[3].operation, Measurement)
         assert qc.instructions[5].cbits[0] == 2
 
         # checking if gates are added correctly with measurements
@@ -393,7 +413,7 @@ class TestQubitCircuit:
         qc_rev = qc.reverse_circuit()
 
         assert qc_rev.instructions[0].operation == gates.H
-        assert isinstance(qc_rev.instructions[1].operation, Measurement)
+        assert issubclass(qc_rev.instructions[1].operation, Measurement)
         assert qc_rev.instructions[2].operation == gates.CX
         assert isinstance(qc_rev.instructions[3].operation, gates.RX)
 
@@ -531,13 +551,13 @@ class TestQubitCircuit:
         teleportation = _teleportation_circuit()
 
         state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-        _, initial_probabilities = Mz.measurement_comp_basis(state, qubits=[0])
+        initial_probabilities = _get_probs(state, Mz, [0])
 
         teleportation_sim = CircuitSimulator(teleportation)
         teleportation_sim_results = teleportation_sim.run(state)
         state_final = teleportation_sim_results.get_final_states(0)
 
-        _, final_probabilities = Mz.measurement_comp_basis(state_final, qubits=[2])
+        final_probabilities = _get_probs(state_final, Mz, [2])
 
         np.testing.assert_allclose(initial_probabilities, final_probabilities)
 
@@ -572,7 +592,7 @@ class TestQubitCircuit:
         teleportation = _teleportation_circuit()
 
         original_state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-        _, initial_probabilities = Mz.measurement_comp_basis(original_state, qubits=[0])
+        initial_probabilities = _get_probs(original_state, Mz, [0])
 
         teleportation_results = teleportation.run_statistics(original_state)
         states = teleportation_results.get_final_states()
@@ -581,7 +601,7 @@ class TestQubitCircuit:
         for i, state in enumerate(states):
             state_final = state
             prob = probabilities[i]
-            _, final_probabilities = Mz.measurement_comp_basis(state_final, qubits=[2])
+            final_probabilities = _get_probs(state_final, Mz, [2])
             np.testing.assert_allclose(initial_probabilities, final_probabilities)
             assert prob == pytest.approx(0.25, abs=1e-7)
 
@@ -591,8 +611,8 @@ class TestQubitCircuit:
         teleportation2 = _teleportation_circuit2()
 
         final_state = teleportation2.run(dm_state)
-        _, probs1 = Mz.measurement_comp_basis(final_state, qubits=[2])
-        _, probs2 = Mz.measurement_comp_basis(mixed_state, qubits=[2])
+        probs1 = _get_probs(final_state, Mz, [2])
+        probs2 = _get_probs(mixed_state, Mz, [2])
 
         np.testing.assert_allclose(probs1, probs2)
 
@@ -677,7 +697,7 @@ class TestQubitCircuit:
         rand_state = rand_ket(2)
         state = tensor(basis(2, 0), basis(2, 0), basis(2, 0), rand_state)
 
-        _, probs_initial = Mz.measurement_comp_basis(state, qubits=[3])
+        probs_initial = _get_probs(state, Mz, [3])
 
         simulator = CircuitSimulator(qc)
 
@@ -686,7 +706,7 @@ class TestQubitCircuit:
         result_cbits = result.get_cbits()
 
         for i, final_state in enumerate(final_states):
-            _, probs_final = Mz.measurement_comp_basis(final_state, qubits=[3])
+            probs_final = _get_probs(final_state, Mz, [3])
             np.testing.assert_allclose(probs_initial, probs_final)
             assert sum(result_cbits[i]) == 1
 

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -1,69 +1,99 @@
 import numpy as np
+import qutip
 import pytest
 from math import sqrt
-from qutip_qip.operations.measurement import Mz
-from qutip import basis, ket2dm, tensor, rand_ket
-import qutip
+from qutip_qip.operations import expand_operator
+from qutip_qip.operations.measurement import Measurement, Mz, Mx, My
+from qutip import basis, tensor
+from qutip.measurement import measurement_statistics
 
 
-@pytest.mark.repeat(10)
-def test_measurement_comp_basis():
-    """
-    Test measurements to test probability calculation in
-    computational basis measurements on a 3 qubit state
-    """
+def _get_measurement_results(state, measurement_obj, targets):
+    """Helper to apply measurement and return states and probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
 
-    qubit_kets = [rand_ket(2), rand_ket(2), rand_ket(2)]
-    qubit_dms = [ket2dm(qubit_kets[i]) for i in range(3)]
+    measurement_tol = qutip.settings.core["atol"] ** 2
+    states, probabilities = measurement_statistics(state, expanded_ops)
+    probabilities = [p if p > measurement_tol else 0.0 for p in probabilities]
+    states = [s if p > measurement_tol else None for s, p in zip(states, probabilities)]
+    return states, probabilities
 
-    state = tensor(qubit_kets)
-    density_mat = tensor(qubit_dms)
 
-    for i in range(3):
-        final_states, probabilities_state = Mz.measurement_comp_basis(state, [i])
-        final_dms, probabilities_dm = Mz.measurement_comp_basis(density_mat, [i])
+def test_measurement_classes():
+    """Test standard measurement class attributes and operators."""
+    for cls, name, num_ops in [(Mz, "Mz", 2), (Mx, "Mx", 2), (My, "My", 2)]:
+        meas = cls()
+        assert meas.name == name
+        assert meas.num_qubits == 1
+        ops = meas.get_measurement_ops()
+        assert len(ops) == num_ops
+        for op in ops:
+            assert isinstance(op, qutip.Qobj)
 
-        amps = qubit_kets[i].full()
-        probabilities_i = [np.abs(amps[0][0]) ** 2, np.abs(amps[1][0]) ** 2]
 
-        np.testing.assert_allclose(probabilities_state, probabilities_dm)
-        np.testing.assert_allclose(probabilities_state, probabilities_i)
-        for j, final_state in enumerate(final_states):
-            np.testing.assert_allclose(final_dms[j].full(), ket2dm(final_state).full())
+def test_custom_measurement_subclass():
+    """Test creating a custom Measurement subclass."""
+
+    class MyCustomMeasurement(Measurement):
+        def get_measurement_ops(self):
+            return [basis(2, 0) * basis(2, 0).dag(), basis(2, 1) * basis(2, 1).dag()]
+
+    meas = MyCustomMeasurement()
+    assert meas.name == "M"
+    assert meas.num_qubits == 1
+    assert len(meas.get_measurement_ops()) == 2
 
 
 @pytest.mark.parametrize("index", [0, 1])
-def test_measurement_collapse(index):
+@pytest.mark.parametrize("measurement_class", [Mz, Mx, My])
+def test_measurement_collapse(index, measurement_class):
     """
     Test if correct state is created after measurement using the example of
-    the Bell state
+    the Bell state in respective bases.
     """
+    if measurement_class == Mz:
+        v0 = basis(2, 0)
+        v1 = basis(2, 1)
+    elif measurement_class == Mx:
+        v0 = (basis(2, 0) + basis(2, 1)).unit()
+        v1 = (basis(2, 0) - basis(2, 1)).unit()
+    elif measurement_class == My:
+        v0 = (basis(2, 0) + 1j * basis(2, 1)).unit()
+        v1 = (basis(2, 0) - 1j * basis(2, 1)).unit()
 
-    state_00 = tensor(basis(2, 0), basis(2, 0))
-    state_11 = tensor(basis(2, 1), basis(2, 1))
+    state_00 = tensor(v0, v0)
+    state_11 = tensor(v1, v1)
 
     bell_state = (state_00 + state_11) / sqrt(2)
 
-    states, probabilities = Mz.measurement_comp_basis(bell_state, qubits=[index])
+    states, probabilities = _get_measurement_results(
+        bell_state, measurement_class, targets=[index]
+    )
     np.testing.assert_allclose(probabilities, [0.5, 0.5])
 
     for i, state in enumerate(states):
         if i == 0:
-            states_00, probability_00 = Mz.measurement_comp_basis(
-                state, qubits=[1 - index]
+            states_00, probability_00 = _get_measurement_results(
+                state, measurement_class, targets=[1 - index]
             )
-            assert probability_00[0] == 1
+            assert probability_00[0] == pytest.approx(1.0)
             assert states_00[1] is None
         else:
-            states_11, probability_11 = Mz.measurement_comp_basis(
-                state, qubits=[1 - index]
+            states_11, probability_11 = _get_measurement_results(
+                state, measurement_class, targets=[1 - index]
             )
-            assert probability_11[1] == 1
+            assert probability_11[1] == pytest.approx(1.0)
             assert states_11[0] is None
 
 
 def test_against_numerical_error():
     state = qutip.Qobj([[1], [1.0e-12]])
-    states, probabilities = Mz.measurement_comp_basis(state, [0])
+    states, probabilities = _get_measurement_results(state, Mz, [0])
     assert states[1] is None
     assert probabilities[1] == 0.0

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -8,7 +8,23 @@ from qutip_qip.qasm import read_qasm, circuit_to_qasm_str
 from qutip_qip.circuit import QubitCircuit
 from qutip import tensor, rand_ket, basis, identity
 from qutip_qip.operations.measurement import Mz
+from qutip_qip.operations import expand_operator
+from qutip.measurement import measurement_statistics
 import qutip_qip.operations.gates as gates
+
+
+def _get_probs(state, measurement_obj, targets):
+    """Helper to get probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
+
+    _, probabilities = measurement_statistics(state, expanded_ops)
+    return probabilities
 
 
 @pytest.mark.parametrize(
@@ -76,8 +92,8 @@ def test_qasm_addcircuit():
     check_gate_instruction_defn(qc.instructions[4], "H", (0,))
     check_gate_instruction_defn(qc.instructions[5], "H", (1,))
     check_gate_instruction_defn(qc.instructions[6], "H", (0,), (), (0, 1), 0)
-    check_measurement_defn(qc.instructions[7], "M", (0,), (0,))
-    check_measurement_defn(qc.instructions[8], "M", (1,), (1,))
+    check_measurement_defn(qc.instructions[7], "Mz", (0,), (0,))
+    check_measurement_defn(qc.instructions[8], "Mz", (1,), (1,))
 
 
 def test_custom_gates():
@@ -102,9 +118,7 @@ def test_qasm_teleportation():
     initial_measurement = Mz
 
     state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-    _, initial_probabilities = initial_measurement.measurement_comp_basis(
-        state, qubits=[0]
-    )
+    initial_probabilities = _get_probs(state, initial_measurement, [0])
 
     teleportation_results = teleportation.run_statistics(state)
 
@@ -114,9 +128,7 @@ def test_qasm_teleportation():
     for i, state in enumerate(states):
         final = state
         prob = probabilities[i]
-        _, final_probabilities = final_measurement.measurement_comp_basis(
-            final, qubits=[2]
-        )
+        final_probabilities = _get_probs(final, final_measurement, [2])
         np.testing.assert_allclose(initial_probabilities, final_probabilities)
         assert prob == pytest.approx(0.25, abs=1e-7)
 


### PR DESCRIPTION
**Description**
This PR adds measurement subclasses
Changes:
- Adds Measurement subclasses (Mx, My, Mz)
- Adds `get_measurement_ops()`
- Deprecates `measurement_comp_basis`
- Modifies `_apply_measurement` to call `measurement_statistics()`
- Adds helper to test files and changes test cases   

**Related issues or PRs**
Part of #331 

**AI Tools Usage Disclosure**
- Gemini 3.1 Pro: Implementation discussion
- Gemini 3.5 Flash: Docstring and changing tests 
