### PR TITLE
Fix Matplotlib labels for parametric gate arguments

### DIFF
--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -516,6 +516,25 @@ class MatRenderer(BaseRenderer):
 
         return f"[{round(value, 2)}]"
 
+    def _gate_label(self, gate: Gate | Type[Gate], showarg: bool = False) -> str:
+        """
+        Return the matplotlib label for a gate.
+        """
+        label = gate.name
+
+        if not gate.is_parametric:
+            return label
+
+        if gate.arg_label is not None:
+            return f"{label}({gate.arg_label})"
+
+        if showarg:
+            return label + "".join(
+                self.to_pi_fraction(value) for value in gate.arg_value
+            )
+
+        return label
+
     def _draw_multiq_gate(
         self,
         gate: Gate | Type[Gate],
@@ -770,12 +789,6 @@ class MatRenderer(BaseRenderer):
                 targets = instruction.targets
                 controls = instruction.controls
                 style = style if style is not None else {}
-                self.text = gate.name
-
-                if gate.is_parametric:
-                    self.text = (
-                        gate.arg_label if gate.arg_label is not None else gate.name
-                    )
 
                 self.color = style.get(
                     "color",
@@ -787,6 +800,7 @@ class MatRenderer(BaseRenderer):
                 self.fontstyle = style.get("fontstyle", "normal")
                 self.fontfamily = style.get("fontfamily", "monospace")
                 self.showarg = style.get("showarg", False)
+                self.text = self._gate_label(gate, showarg=self.showarg)
 
                 self.merged_wires = list(targets)
                 self.merged_wires.extend(controls)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -16,6 +16,7 @@ from qutip_qip.operations.gates import (
     TOFFOLI,
     FREDKIN,
     BERKELEY,
+    RZ,
 )
 from qutip_qip.operations.measurement import Mz
 
@@ -252,6 +253,38 @@ def test_matrenderer(request, qc_fixture):
 
     with patch("matplotlib.pyplot.show"):  # to avoid showing the plot
         qc.draw("matplotlib")
+
+
+def test_matrenderer_parametric_gate_showarg():
+    """
+    Check if Matplotlib renderer shows parametric gate arguments.
+    """
+    plt = pytest.importorskip("matplotlib.pyplot")
+    plt.close("all")
+    qc = QubitCircuit(1)
+    qc.add_gate(RZ(np.pi / 2), targets=0, style={"showarg": True})
+
+    with patch("matplotlib.pyplot.show"):  # to avoid showing the plot
+        qc.draw("matplotlib")
+
+    labels = [text.get_text() for text in plt.gca().texts]
+    assert r"RZ[\pi/2]" in labels
+
+
+def test_matrenderer_parametric_gate_arg_label():
+    """
+    Check if Matplotlib renderer keeps gate names with argument labels.
+    """
+    plt = pytest.importorskip("matplotlib.pyplot")
+    plt.close("all")
+    qc = QubitCircuit(1)
+    qc.add_gate(RZ(np.pi, arg_label=r"\pi"), targets=0)
+
+    with patch("matplotlib.pyplot.show"):  # to avoid showing the plot
+        qc.draw("matplotlib")
+
+    labels = [text.get_text() for text in plt.gca().texts]
+    assert r"RZ(\pi)" in labels
 
 
 @pytest.mark.parametrize("qc_fixture", ["qc1", "qc2", "qc3"])


### PR DESCRIPTION
Fixes #340.
Fixes #326.

This updates the Matplotlib circuit renderer so parametric gate labels keep the
gate name while also showing either an explicit argument label or the formatted
argument value when `showarg` is enabled.

Changes:
- render `RZ(\pi)` when a parametric gate has `arg_label=r\pi`
- render `RZ[\pi/2]` when `style={showarg: True}` is used
- add focused Matplotlib renderer regression tests for both cases

Validation:
- `MPLBACKEND=Agg python -m pytest tests/test_renderer.py -q`
- `MPLBACKEND=Agg python -m pytest tests/test_circuit.py tests/test_renderer.py -q`
- `git diff --check`