### PR TITLE
 feature: Added Oracle Gate implementation

### DIFF
--- a/src/qutip_qip/operations/__init__.py
+++ b/src/qutip_qip/operations/__init__.py
@@ -13,6 +13,7 @@ from .gateclass import Gate, get_unitary_gate
 from .parametric import ParametricGate, AngleParametricGate
 from .controlled import ControlledGate, get_controlled_gate
 from .measurement import Measurement
+from .gates import get_oracle_gate
 from .old_gates import (
     rx,
     ry,
@@ -55,6 +56,7 @@ __all__ = [
     "ControlledGate",
     "get_unitary_gate",
     "get_controlled_gate",
+    "get_oracle_gate",
     "AngleParametricGate",
     "Measurement",
     "rx",

--- a/src/qutip_qip/operations/gates/__init__.py
+++ b/src/qutip_qip/operations/gates/__init__.py
@@ -53,6 +53,7 @@ from .other_gates import (
     GLOBALPHASE,
     TOFFOLI,
     FREDKIN,
+    OracleGate,
 )
 
 GATE_CLASS_MAP = {
@@ -105,6 +106,7 @@ GATE_CLASS_MAP = {
     "CPHASE": CPHASE,
     "RZX": RZX,
     "CQASMU": CQASMU,
+    "ORACLE": OracleGate,
 }
 
 CONTROLLED_GATE_MAP = {

--- a/src/qutip_qip/operations/gates/__init__.py
+++ b/src/qutip_qip/operations/gates/__init__.py
@@ -53,7 +53,7 @@ from .other_gates import (
     GLOBALPHASE,
     TOFFOLI,
     FREDKIN,
-    OracleGate,
+    get_oracle_gate,
 )
 
 GATE_CLASS_MAP = {
@@ -106,7 +106,7 @@ GATE_CLASS_MAP = {
     "CPHASE": CPHASE,
     "RZX": RZX,
     "CQASMU": CQASMU,
-    "ORACLE": OracleGate,
+    "ORACLE": get_oracle_gate,
 }
 
 CONTROLLED_GATE_MAP = {

--- a/src/qutip_qip/operations/gates/other_gates.py
+++ b/src/qutip_qip/operations/gates/other_gates.py
@@ -203,25 +203,23 @@ class FREDKIN(ControlledGate):
 
 def get_oracle_gate(num_qubits, logic_func, num_target_qubits=1, name="ORACLE"):
     """
-    Function that returns a gate object that performs the operation
-    |x>|y>-->|x>|y⊕logic_func(x)>.
+    Function that returns a gate class that performs the operation
+    ``|x>|y> --> |x>|y ⊕ logic_func(x)>``.
 
-    Attributes
+    Parameters
     ----------
-
     num_qubits : int
-        The total number of qubits the Oracle Gate Acts upon.
-
+        The total number of qubits the Oracle Gate acts upon.
     logic_func : function
         The logic function involved in mapping of the control to target qubits.
-
-    num_target_qubits : int
-        The number of qubits the y value of the function is stored in. The value is defaulted to 1, the most common usecase.
+    num_target_qubits : int, optional
+        The number of qubits the y value of the function is stored in.
+        The value is defaulted to 1, the most common use case.
 
     Returns
     -------
-
-    A gate Class Representing the Oracle.
+    type
+        A gate class representing the Oracle.
     """
 
     try:

--- a/src/qutip_qip/operations/gates/other_gates.py
+++ b/src/qutip_qip/operations/gates/other_gates.py
@@ -4,6 +4,7 @@ from typing import Final, Type
 import scipy.sparse as sp
 import numpy as np
 from qutip import Qobj
+import inspect
 
 from qutip_qip.operations import Gate, ControlledGate, AngleParametricGate
 from qutip_qip.operations.gates import X, SWAP
@@ -198,3 +199,71 @@ class FREDKIN(ControlledGate):
             dims=[[2, 2, 2], [2, 2, 2]],
             dtype=dtype,
         )
+
+
+def OracleGate(num_qubits, logic_func, num_target_qubits=1, name="ORACLE"):
+    """
+    Function that returns a gate object that performs the operation
+    |x>|y>-->|x>|y⊕logic_func(x)>.
+
+    Attributes
+    ----------
+
+    num_qubits : int
+        The total number of qubits the Oracle Gate Acts upon.
+
+    logic_func : function
+        The logic function involved in mapping of the control to target qubits.
+
+    num_target_qubits : int
+        The number of qubits the y value of the function is stored in. The value is defaulted to 1, the most common usecase.
+    """
+
+    try:
+        source_code = inspect.getsource(logic_func)
+    except (TypeError, OSError):
+        source_code = "Custom logic function"
+
+    @staticmethod
+    def _get_qobj(dtype="dense"):
+        N = num_qubits
+        m = num_target_qubits
+        dim = 2**N
+
+        mask = (1 << m) - 1
+
+        rows = []
+        cols = []
+
+        for i in range(dim):
+            x = i >> m
+            y = i & mask
+            f_val = logic_func(x)
+            y_new = y ^ f_val
+            j = (x << m) | y_new
+            cols.append(i)
+            rows.append(j)
+
+        data = np.ones(dim, dtype=complex)
+
+        matrix = sp.csr_matrix((data, (rows, cols)), shape=(dim, dim))
+
+        return Qobj(matrix, dims=[[2] * N, [2] * N], dtype=dtype)
+
+    return type(
+        "OracleGate",
+        (Gate,),
+        {
+            "num_qubits": num_qubits,
+            "name": name,
+            "logic_func": logic_func,
+            "num_target_qubits": num_target_qubits,
+            "_source": source_code,
+            "self_inverse": True,
+            "is_clifford": False,
+            "is_parametric": False,
+            "is_controlled": False,
+            "latex_str": r"{\rm ORACLE}",
+            "get_qobj": _get_qobj,  ## Temporary helper function for the oracle
+        },
+    )

--- a/src/qutip_qip/operations/gates/other_gates.py
+++ b/src/qutip_qip/operations/gates/other_gates.py
@@ -201,7 +201,7 @@ class FREDKIN(ControlledGate):
         )
 
 
-def OracleGate(num_qubits, logic_func, num_target_qubits=1, name="ORACLE"):
+def get_oracle_gate(num_qubits, logic_func, num_target_qubits=1, name="ORACLE"):
     """
     Function that returns a gate object that performs the operation
     |x>|y>-->|x>|y⊕logic_func(x)>.
@@ -217,6 +217,11 @@ def OracleGate(num_qubits, logic_func, num_target_qubits=1, name="ORACLE"):
 
     num_target_qubits : int
         The number of qubits the y value of the function is stored in. The value is defaulted to 1, the most common usecase.
+
+    Returns
+    -------
+
+    A gate Class Representing the Oracle.
     """
 
     try:

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,13 +1,15 @@
 import numpy as np
 from qutip import basis, qeye
-from qutip_qip.operations.gates import OracleGate, CNOT
+from qutip_qip.operations.gates import get_oracle_gate, CNOT
 from qutip_qip.circuit import QubitCircuit
 
 
 def test_oracle_identity():
     qc = QubitCircuit(num_qubits=3)
     logic_func = lambda x: 0
-    my_oracle = OracleGate(num_qubits=3, logic_func=logic_func, num_target_qubits=1)
+    my_oracle = get_oracle_gate(
+        num_qubits=3, logic_func=logic_func, num_target_qubits=1
+    )
     qc.add_gate(my_oracle, targets=[0, 1, 2])
     U = qc.compute_unitary()
 
@@ -20,7 +22,9 @@ def test_oracle_identity():
 def test_oracle_not():
     qc = QubitCircuit(num_qubits=2)
     logic_func = lambda x: x
-    my_oracle = OracleGate(num_qubits=2, logic_func=logic_func, num_target_qubits=1)
+    my_oracle = get_oracle_gate(
+        num_qubits=2, logic_func=logic_func, num_target_qubits=1
+    )
     qc.add_gate(my_oracle, targets=[0, 1])
     U = qc.compute_unitary()
 
@@ -33,7 +37,9 @@ def test_oracle_not():
 def test_oracle_multi_target():
     qc = QubitCircuit(num_qubits=3)
     logic_func = lambda x: 3
-    my_oracle = OracleGate(num_qubits=3, logic_func=logic_func, num_target_qubits=2)
+    my_oracle = get_oracle_gate(
+        num_qubits=3, logic_func=logic_func, num_target_qubits=2
+    )
     qc.add_gate(my_oracle, targets=[0, 1, 2])
     U = qc.compute_unitary()
     print(U.full())
@@ -42,7 +48,7 @@ def test_oracle_multi_target():
 def test_unitarity():
     qc = QubitCircuit(5)
     func = lambda x: (x * 3 + 1) % 2  # random
-    oracle_class = OracleGate(num_qubits=5, logic_func=func, num_target_qubits=1)
+    oracle_class = get_oracle_gate(num_qubits=5, logic_func=func, num_target_qubits=1)
     qc.add_gate(oracle_class, targets=range(5))
     U = qc.compute_unitary()
 
@@ -60,7 +66,7 @@ def my_logic(x):
 
 
 def test_named_function():
-    oracle_class = OracleGate(num_qubits=2, logic_func=my_logic)
+    oracle_class = get_oracle_gate(num_qubits=2, logic_func=my_logic)
     # Check serialization
     print(f"Captured Source:\n{oracle_class._source}")
     assert "def my_logic" in oracle_class._source
@@ -68,7 +74,7 @@ def test_named_function():
 
 
 def test_serialization():
-    gate_class = OracleGate(num_qubits=2, logic_func=lambda x: x)
+    gate_class = get_oracle_gate(num_qubits=2, logic_func=lambda x: x)
     assert gate_class._source is not None
     print("Serialization Metadata: PASSED")
 
@@ -78,7 +84,7 @@ def test_grover_oracle():
         return 1 if x == 3 else 0
 
     qc = QubitCircuit(num_qubits=3)
-    my_oracle = OracleGate(num_qubits=3, logic_func=mark_3, num_target_qubits=1)
+    my_oracle = get_oracle_gate(num_qubits=3, logic_func=mark_3, num_target_qubits=1)
     qc.add_gate(my_oracle, targets=[0, 1, 2])
     U = qc.compute_unitary()
 

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,99 @@
+import numpy as np
+from qutip import basis, qeye
+from qutip_qip.operations.gates import OracleGate, CNOT
+from qutip_qip.circuit import QubitCircuit
+
+
+def test_oracle_identity():
+    qc = QubitCircuit(num_qubits=3)
+    logic_func = lambda x: 0
+    my_oracle = OracleGate(num_qubits=3, logic_func=logic_func, num_target_qubits=1)
+    qc.add_gate(my_oracle, targets=[0, 1, 2])
+    U = qc.compute_unitary()
+
+    expected = qeye([2, 2, 2]).full()
+    # Check if your oracle is equal to a standard CNOT
+    assert np.allclose(U.full(), expected), "Test IDENTITY: Failed!"
+    print("Test IDENTITY: PASSED")
+
+
+def test_oracle_not():
+    qc = QubitCircuit(num_qubits=2)
+    logic_func = lambda x: x
+    my_oracle = OracleGate(num_qubits=2, logic_func=logic_func, num_target_qubits=1)
+    qc.add_gate(my_oracle, targets=[0, 1])
+    U = qc.compute_unitary()
+
+    expected = CNOT.get_qobj().full()
+    # Check if your oracle is equal to a standard CNOT
+    assert np.allclose(U.full(), expected), "Test NOT: Failed!"
+    print("Test NOT: PASSED")
+
+
+def test_oracle_multi_target():
+    qc = QubitCircuit(num_qubits=3)
+    logic_func = lambda x: 3
+    my_oracle = OracleGate(num_qubits=3, logic_func=logic_func, num_target_qubits=2)
+    qc.add_gate(my_oracle, targets=[0, 1, 2])
+    U = qc.compute_unitary()
+    print(U.full())
+
+
+def test_unitarity():
+    qc = QubitCircuit(5)
+    func = lambda x: (x * 3 + 1) % 2  # random
+    oracle_class = OracleGate(num_qubits=5, logic_func=func, num_target_qubits=1)
+    qc.add_gate(oracle_class, targets=range(5))
+    U = qc.compute_unitary()
+
+    # U_dagger * U should be Identity
+    identity_check = U.dag() * U
+    expected_id = qeye([2] * 5)
+    assert (identity_check - expected_id).norm() < 1e-12
+    print("Unitarity Stress Test: PASSED")
+
+
+def my_logic(x):
+    if x % 2 == 0:
+        return 1
+    return 0
+
+
+def test_named_function():
+    oracle_class = OracleGate(num_qubits=2, logic_func=my_logic)
+    # Check serialization
+    print(f"Captured Source:\n{oracle_class._source}")
+    assert "def my_logic" in oracle_class._source
+    print("Named Function Serialization: PASSED")
+
+
+def test_serialization():
+    gate_class = OracleGate(num_qubits=2, logic_func=lambda x: x)
+    assert gate_class._source is not None
+    print("Serialization Metadata: PASSED")
+
+
+def test_grover_oracle():
+    def mark_3(x):
+        return 1 if x == 3 else 0
+
+    qc = QubitCircuit(num_qubits=3)
+    my_oracle = OracleGate(num_qubits=3, logic_func=mark_3, num_target_qubits=1)
+    qc.add_gate(my_oracle, targets=[0, 1, 2])
+    U = qc.compute_unitary()
+
+    k6 = basis(8, 6)
+    k6.dims = [[2, 2, 2], [1, 1, 1]]
+
+    k7 = basis(8, 7)
+    k7.dims = [[2, 2, 2], [1, 1, 1]]
+
+    k4 = basis(8, 4)
+    k4.dims = [[2, 2, 2], [1, 1, 1]]
+
+    product = U * k6
+    assert np.allclose(product.full(), k7.full()), "Test 1 Grover: Failed!"
+    print("Test 1 Grover: Passed!")
+    product = U * k4
+    assert np.allclose(product.full(), k4.full()), "Test 2 Grover: Failed!"
+    print("Test 2 Grover: Passed!")


### PR DESCRIPTION
**Description**
This Pull Request adds a new "OracleGate" Feature to the qutip-qip Library. This gate takes a function logic_func as an input, and applies the transformation:

|x>|y> --> |x>|y ⊕ logic_func(x)>

hence, turning an arbitrary python function into a unitary Oracle Matrix.

The input register |x> is always preserved in the method |x,y⊕f(x)>. The |x> acts as a memory that makes the entire matrix unitary regardless of whether the function is reversible. Even if f(x) is a many-to-one(irreversible) function, the matrix just remains a permutation of the basis states(discussion #323). The XOR is bitwise for the multi-target case.

I have implemented the OracleGate as a function rather than a separate class, the reason being the num_qubits parameter needed strictly to be an int for this gate. Since the size of the matrix is variable, It failed the class-level validation and had to be made as a function that returns the Gate class type upon execution.

This feature also utilises the inspect module to take the python function and extract its source code as a string. Since standard python functions are hard to save or print, by storing the source code in _source, the gate is serialisable.

This PR also includes a separate test_oracle.py file in tests that covers its identity, CNOT, multi-qubit tests, Unitarity test, a separate named function test, serialisation and a Grover's Oracle test.

Any suggestions on the changing of naming conventions and other edits are welcome.

**AI Tools Usage Disclosure**
Google AI Studio and Claude: For referring Python documentation and generating Testcases.