### PR TITLE
Refactor einsum execution path

### DIFF
--- a/doc/source/qip-simulator.rst
+++ b/doc/source/qip-simulator.rst
@@ -348,3 +348,82 @@ One can save it in a ``.qasm`` file and import it using the following code:
     from qutip_qip.qasm import read_qasm
 
     qc = read_qasm("source/w-state.qasm")
+
+
+GPU-accelerated and Tensor-based Simulation
+===========================================
+
+What if you want to simulate a huge circuit with 20+ qubits? Traditional matrix
+multiplication can become a memory-guzzling bottleneck because expanding the
+gates to the full Hilbert space creates massive matrices.
+
+To save the day, the :class:`.CircuitSimulator` uses tensor contraction
+(Einstein summation, or ``einsum``) by default for both state vector and
+density matrix simulations. Instead of expanding gates, it contracts the gate
+directly with the target qubits.
+
+Even better, we can pair this with GPU backends to turbocharge the simulation!
+Note that because of GPU data transfer and compilation overheads, you will
+typically see a speedup for large circuits (specifically 20+ qubits) compared
+to standard CPU simulation.
+
+Using JAX (CPU/GPU)
+-------------------
+
+With `qutip-jax <https://github.com/qutip/qutip-jax>`_, we can run simulations
+using JAX's JIT compiler. Simply convert your state to a JAX array:
+
+.. code-block:: python
+
+    import qutip_jax
+    from qutip import tensor, basis
+    from qutip_qip.circuit import QubitCircuit, CircuitSimulator
+    import qutip_qip.operations.gates as gates
+
+    # Create a 20-qubit circuit
+    qc = QubitCircuit(20)
+    qc.add_gate(gates.H, targets=0)
+    for q in range(19):
+        qc.add_gate(gates.CX, controls=q, targets=q+1)
+
+    # Convert initial state to JAX
+    state = tensor([basis(2, 0)] * 20).to("jax")
+
+    sim = CircuitSimulator(qc, mode="state_vector_simulator")
+
+    # First run compiles the circuit (takes a moment)
+    _ = sim.run(state)
+
+    # Second run is lightning fast on your GPU!
+    result = sim.run(state)
+
+Using cuQuantum (GPU)
+---------------------
+
+For NVIDIA GPU enthusiasts, `qutip-cuquantum <https://github.com/qutip/qutip-cuquantum>`_
+links directly with NVIDIA's cuQuantum SDK for state-vector simulations.
+
+.. code-block:: python
+
+    import qutip_cuquantum
+    from cuquantum.densitymat import WorkStream
+    from qutip import tensor, basis
+    from qutip_qip.circuit import QubitCircuit, CircuitSimulator
+    import qutip_qip.operations.gates as gates
+
+    # Set up the cuQuantum default context
+    qutip_cuquantum.set_as_default(WorkStream())
+
+    try:
+        qc = QubitCircuit(20)
+        qc.add_gate(gates.H, targets=0)
+        for q in range(19):
+            qc.add_gate(gates.CX, controls=q, targets=q+1)
+
+        # Convert to CuState for GPU simulation
+        state = tensor([basis(2, 0)] * 20).to("CuState")
+
+        sim = CircuitSimulator(qc, mode="state_vector_simulator")
+        result = sim.run(state)
+    finally:
+        qutip_cuquantum.set_as_default(reverse=True)

--- a/doc/source/qip-simulator.rst
+++ b/doc/source/qip-simulator.rst
@@ -30,7 +30,7 @@ It corresponds to the following circuit:
 .. plot::
     :include-source: False
     :context: reset
-    
+
 
     from qutip_qip.circuit import QubitCircuit
     from qutip_qip.operations.gates import X, CX, CH, QASMU, TOFFOLI
@@ -47,7 +47,7 @@ It corresponds to the following circuit:
     qc.draw()
 
 
-    
+
 
 We will add the measurement gates later. This circuit prepares the W-state
 :math:`\newcommand{\ket}[1]{\left|{#1}\right\rangle} (\ket{001} + \ket{010} + \ket{100})/\sqrt{3}`.
@@ -283,7 +283,7 @@ followed just by measurement on the first qubit:
 .. testoutput::
     :options: +NORMALIZE_WHITESPACE
 
-    Quantum object: dims=[[2, 2, 2], [2, 2, 2]], shape=(8, 8), type='oper', dtype=Dense, isherm=True
+    Quantum object: dims=[[2, 2, 2], [2, 2, 2]], shape=(8, 8), type='oper', dtype=CSR, isherm=True
     Qobj data =
     [[0.      0.      0.      0.      0.      0.      0.      0.     ]
      [0.      0.33333 0.      0.      0.      0.      0.      0.     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 # When Python version is updated same change needs to be made in classifier tags in pyproject.toml,
-# build.yaml and in contributing to code, Installation guide. 
+# build.yaml and in contributing to code, Installation guide.
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.9.2",
@@ -70,6 +70,8 @@ Donate = "https://github.com/sponsors/qutip"
 graphics = ["matplotlib>=3.6"]
 control = ["qutip-qtrl>=0.1.5"]
 qiskit = ["qiskit>=2.0"]
+jax = ["qutip-jax", "jax", "jaxlib"]
+cuquantum = ["qutip-cuquantum", "cuquantum", "cupy"]
 full = [
     "qutip-qip[graphics,qiskit,control]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ Donate = "https://github.com/sponsors/qutip"
 graphics = ["matplotlib>=3.6"]
 control = ["qutip-qtrl>=0.1.5"]
 qiskit = ["qiskit>=2.0"]
-jax = ["qutip-jax", "jax", "jaxlib"]
-cuquantum = ["qutip-cuquantum", "cuquantum", "cupy"]
+cuquantum = ["qutip-cuquantum>=0.1.0", "cuquantum>=23.3.0", "cupy>=12.2.0"]
 full = [
     "qutip-qip[graphics,qiskit,control]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Donate = "https://github.com/sponsors/qutip"
 graphics = ["matplotlib>=3.6"]
 control = ["qutip-qtrl>=0.1.5"]
 qiskit = ["qiskit>=2.0"]
-cuquantum = ["qutip-cuquantum>=0.1.0", "cuquantum>=23.3.0", "cupy>=12.2.0"]
+cuquantum = ["qutip-cuquantum>=0.1.0"]
 full = [
     "qutip-qip[graphics,qiskit,control]",
 ]

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -309,15 +309,14 @@ class CircuitSimulator:
     def _evolve_state_einsum(self, gate, targets_indices, state):
         gate_qobj = gate.get_qobj()
 
-        orignal_dims = state.dims
-        orignal_shape = state.shape
+        original_dims = state.dims
+        original_shape = state.shape
 
         # Generate equation
         num_dims = len(self._tensor_dims)
         eq = self._generate_einsum_eq(targets_indices, num_dims)
 
         data_type = type(state.data).__name__
-        print(data_type)
 
         if data_type == "JaxArray":
             import jax.numpy as jnp
@@ -333,8 +332,8 @@ class CircuitSimulator:
 
             new_state_tensor = jnp.einsum(eq, gate_tensor, state_tensor)
 
-            reshaped_data = JaxArray(new_state_tensor.reshape(orignal_shape))
-            state = Qobj(reshaped_data, dims=orignal_dims)
+            reshaped_data = JaxArray(new_state_tensor.reshape(original_shape))
+            state = Qobj(reshaped_data, dims=original_dims)
 
         elif data_type == "CuState":
             import cupy as cp
@@ -351,17 +350,17 @@ class CircuitSimulator:
 
             new_state_tensor = contract(eq, gate_tensor, state_tensor)
 
-            reshaped_data = CuState(new_state_tensor.reshape(orignal_shape))
-            state = Qobj(reshaped_data, dims=orignal_dims)
+            reshaped_data = CuState(new_state_tensor.reshape(original_shape))
+            state = Qobj(reshaped_data, dims=original_dims)
 
         else:
             from qutip.core.dimensions import einsum
 
             malformed_state = einsum(eq, gate_qobj, state)
             reshaped_data = _data.reshape(
-                malformed_state.data, orignal_shape[0], orignal_shape[1]
+                malformed_state.data, original_shape[0], original_shape[1]
             )
-            state = Qobj(reshaped_data, dims=orignal_dims)
+            state = Qobj(reshaped_data, dims=original_dims)
 
         return state
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -262,6 +262,9 @@ class CircuitSimulator:
         self._op_index += 1
 
     def _generate_einsum_eq(self, targets, num_qubits):
+        """
+        Generates the einsum string for tensor contraction.
+        """
         l_chars = string.ascii_lowercase
         u_chars = string.ascii_uppercase
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -305,7 +305,10 @@ class CircuitSimulator:
         U: Qobj
             unitary to be applied.
         """
-        U = operation.get_qobj()
+        data_type = type(state.data).__name__
+        gate_dtype = "CuOperator" if data_type == "CuState" else "Dense"
+
+        U = operation.get_qobj().to(gate_dtype)
         U = expand_operator(
             U,
             dims=self.dims,

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -6,6 +6,7 @@ import string
 
 from qutip import ket2dm, Qobj
 from qutip.core import data as _data
+from qutip.core.dimensions import einsum
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator
 
@@ -263,13 +264,25 @@ class CircuitSimulator:
 
     def _generate_einsum_eq(self, targets, num_qubits):
         """
-        Generates the einsum string for tensor contraction.
-        """
-        l_chars = string.ascii_lowercase
-        u_chars = string.ascii_uppercase
+        Generates the einsum string for tensor contraction supporting up to 52 qubits.
+        Uses standard ASCII letters (a-z, A-Z) to map input and output indices.
 
-        state_in = list(l_chars[:num_qubits])
-        gate_out = list(u_chars[: len(targets)])
+        Parameters
+        ----------
+        targets : list of int
+            The target qubits the gate acts on.
+        num_qubits : int
+            The total number of qubits (tensor dimensions) in the state.
+
+        Returns
+        -------
+        eq : str
+            The einsum equation string (e.g., "ab,cde->cde").
+        """
+        chars = string.ascii_letters
+
+        state_in = list(chars[:num_qubits])
+        gate_out = list(chars[num_qubits : num_qubits + len(targets)])
 
         gate_in = [state_in[t] for t in targets]
 
@@ -307,60 +320,40 @@ class CircuitSimulator:
         return state
 
     def _evolve_state_einsum(self, gate, targets_indices, state):
+        """
+        Applies a gate to the state using tensor contraction (einsum).
+        Delegates all data routing to QuTiP's internal dispatcher, allowing
+        seamless integration with numpy, scipy, and qutip-jax backends.
+
+        Parameters
+        ----------
+        gate: :class:`.Gate`
+            The quantum gate to be applied.
+        targets_indices: list of int
+            The indices of the target qubits.
+        state: :class:`qutip.Qobj`
+            The current quantum state vector.
+
+        Returns
+        -------
+        state : :class:`qutip.Qobj`
+            The updated quantum state, maintaining its original data type.
+        """
         gate_qobj = gate.get_qobj()
 
         original_dims = state.dims
         original_shape = state.shape
+        data_type = type(state.data).__name__
 
         # Generate equation
         num_dims = len(self._tensor_dims)
         eq = self._generate_einsum_eq(targets_indices, num_dims)
 
-        data_type = type(state.data).__name__
-
-        if data_type == "JaxArray":
-            import jax.numpy as jnp
-            from qutip_jax.jaxarray import JaxArray
-
-            gate_qobj = gate_qobj.to("jax")
-
-            raw_state = state.data._jxa
-            raw_gate = gate_qobj.data._jxa
-
-            state_tensor = raw_state.reshape(self._tensor_dims)
-            gate_tensor = raw_gate.reshape(gate_qobj.dims[0] + gate_qobj.dims[1])
-
-            new_state_tensor = jnp.einsum(eq, gate_tensor, state_tensor)
-
-            reshaped_data = JaxArray(new_state_tensor.reshape(original_shape))
-            state = Qobj(reshaped_data, dims=original_dims)
-
-        elif data_type == "CuState":
-            import cupy as cp
-            from cuquantum.tensornet import contract
-            from qutip_cuquantum import CuState
-
-            gate_qobj = gate_qobj.to("CuOperator")
-
-            raw_state = state.data.to_cupy()
-            raw_gate = cp.array(gate_qobj.full())
-
-            state_tensor = raw_state.reshape(self._tensor_dims)
-            gate_tensor = raw_gate.reshape(gate_qobj.dims[0] + gate_qobj.dims[1])
-
-            new_state_tensor = contract(eq, gate_tensor, state_tensor)
-
-            reshaped_data = CuState(new_state_tensor.reshape(original_shape))
-            state = Qobj(reshaped_data, dims=original_dims)
-
-        else:
-            from qutip.core.dimensions import einsum
-
-            malformed_state = einsum(eq, gate_qobj, state)
-            reshaped_data = _data.reshape(
-                malformed_state.data, original_shape[0], original_shape[1]
-            )
-            state = Qobj(reshaped_data, dims=original_dims)
+        malformed_state = einsum(eq, gate_qobj, state)
+        reshaped_data = _data.reshape(
+            malformed_state.data, original_shape[0], original_shape[1]
+        )
+        state = Qobj(reshaped_data, dims=original_dims).to(data_type)
 
         return state
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -8,7 +8,8 @@ from qutip import ket2dm, Qobj
 from qutip.core import data as _data
 from qutip.core.dimensions import einsum
 from qutip_qip.circuit.simulator import CircuitResult
-from qutip_qip.operations import expand_operator
+from qutip_qip.operations import expand_operator, Gate
+from qutip_qip.typing import IntSequence
 
 
 def _decimal_to_binary(decimal, length):
@@ -296,17 +297,28 @@ class CircuitSimulator:
 
         return f"{gate_str}, {state_in_str}... -> {state_out_str}..."
 
-    def _evolve_state(self, operation, targets_indices, state):
+    def _evolve_state(
+        self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
+    ) -> Qobj:
         """
-        Applies unitary to state.
+         Applies a unitary gate to the quantum state using operator expansion.
 
-        Parameters
-        ----------
-        U: Qobj
-            unitary to be applied.
+         Parameters
+         ----------
+        operation : :class:`.Gate`
+             The quantum gate to be applied.
+         targets_indices : int or sequence of int
+             The indices of the target qubits.
+         state : :class:`qutip.Qobj`
+             The current quantum state (ket or density matrix).
+
+         Returns
+         -------
+         state : :class:`qutip.Qobj`
+             The updated quantum state.
         """
-        data_type = type(state.data).__name__
-        gate_dtype = "CuOperator" if data_type == "CuState" else "Dense"
+        state_dtype = type(state.data).__name__
+        gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
 
         U = operation.get_qobj().to(gate_dtype)
         U = expand_operator(
@@ -322,27 +334,25 @@ class CircuitSimulator:
             raise NotImplementedError(f"mode {self.mode} is not available.")
         return state
 
-    def _evolve_state_einsum(self, gate, targets_indices, state):
+    def _evolve_state_einsum(self, operation, targets_indices, state):
         """
         Applies a gate to the state using tensor contraction (einsum).
-        Delegates all data routing to QuTiP's internal dispatcher, allowing
-        seamless integration with numpy, scipy, and qutip-jax backends.
 
         Parameters
         ----------
-        gate: :class:`.Gate`
+        operation : :class:`.Gate`
             The quantum gate to be applied.
-        targets_indices: list of int
+        targets_indices : int or sequence of int
             The indices of the target qubits.
-        state: :class:`qutip.Qobj`
+        state : :class:`qutip.Qobj`
             The current quantum state vector.
 
         Returns
         -------
         state : :class:`qutip.Qobj`
-            The updated quantum state, maintaining its original data type.
+            The updated quantum state.
         """
-        gate_qobj = gate.get_qobj()
+        gate_qobj = operation.get_qobj()
 
         original_dims = state.dims
         original_shape = state.shape

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -2,8 +2,10 @@ from itertools import product
 from operator import mul
 from functools import reduce
 import numpy as np
+import string
 
 from qutip import ket2dm, Qobj
+from qutip.core import data as _data
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator
 
@@ -259,6 +261,25 @@ class CircuitSimulator:
         self._state = state
         self._op_index += 1
 
+    def _generate_einsum_eq(self, targets, num_qubits):
+        l_chars = string.ascii_lowercase
+        u_chars = string.ascii_uppercase
+
+        state_in = list(l_chars[:num_qubits])
+        gate_out = list(u_chars[: len(targets)])
+
+        gate_in = [state_in[t] for t in targets]
+
+        state_out = state_in.copy()
+        for i, t in enumerate(targets):
+            state_out[t] = gate_out[i]
+
+        gate_str = "".join(gate_out + gate_in)
+        state_in_str = "".join(state_in)
+        state_out_str = "".join(state_out)
+
+        return f"{gate_str}, {state_in_str}... -> {state_out_str}..."
+
     def _evolve_state(self, operation, targets_indices, state):
         """
         Applies unitary to state.
@@ -283,33 +304,62 @@ class CircuitSimulator:
         return state
 
     def _evolve_state_einsum(self, gate, targets_indices, state):
-        # Prepare the state tensor.
-        if isinstance(state, Qobj):
-            # If it is a Qobj, transform it to the array representation.
-            state = state.full()
-            # Transform the gate and state array to the corresponding
-            # tensor form.
-            state = state.reshape(self._tensor_dims)
+        gate_qobj = gate.get_qobj()
 
-        # Prepare the gate tensor.
-        gate = gate.get_qobj()
-        gate_array = gate.full().reshape(gate.dims[0] + gate.dims[1])
+        orignal_dims = state.dims
+        orignal_shape = state.shape
 
-        # Compute the tensor indices and call einsum.
-        num_site = len(state.shape)
-        ancillary_indices = range(num_site, num_site + len(targets_indices))
-        index_list = range(num_site)
-        new_index_list = list(index_list)
-        for j, k in enumerate(targets_indices):
-            new_index_list[k] = j + num_site
+        # Generate equation
+        num_dims = len(self._tensor_dims)
+        eq = self._generate_einsum_eq(targets_indices, num_dims)
 
-        state = np.einsum(
-            gate_array,
-            list(ancillary_indices) + list(targets_indices),
-            state,
-            index_list,
-            new_index_list,
-        )
+        data_type = type(state.data).__name__
+        print(data_type)
+
+        if data_type == "JaxArray":
+            import jax.numpy as jnp
+            from qutip_jax.jaxarray import JaxArray
+
+            gate_qobj = gate_qobj.to("jax")
+
+            raw_state = state.data._jxa
+            raw_gate = gate_qobj.data._jxa
+
+            state_tensor = raw_state.reshape(self._tensor_dims)
+            gate_tensor = raw_gate.reshape(gate_qobj.dims[0] + gate_qobj.dims[1])
+
+            new_state_tensor = jnp.einsum(eq, gate_tensor, state_tensor)
+
+            reshaped_data = JaxArray(new_state_tensor.reshape(orignal_shape))
+            state = Qobj(reshaped_data, dims=orignal_dims)
+
+        elif data_type == "CuState":
+            import cupy as cp
+            from cuquantum.tensornet import contract
+            from qutip_cuquantum import CuState
+
+            gate_qobj = gate_qobj.to("CuOperator")
+
+            raw_state = state.data.to_cupy()
+            raw_gate = cp.array(gate_qobj.full())
+
+            state_tensor = raw_state.reshape(self._tensor_dims)
+            gate_tensor = raw_gate.reshape(gate_qobj.dims[0] + gate_qobj.dims[1])
+
+            new_state_tensor = contract(eq, gate_tensor, state_tensor)
+
+            reshaped_data = CuState(new_state_tensor.reshape(orignal_shape))
+            state = Qobj(reshaped_data, dims=orignal_dims)
+
+        else:
+            from qutip.core.dimensions import einsum
+
+            malformed_state = einsum(eq, gate_qobj, state)
+            reshaped_data = _data.reshape(
+                malformed_state.data, orignal_shape[0], orignal_shape[1]
+            )
+            state = Qobj(reshaped_data, dims=orignal_dims)
+
         return state
 
     def _apply_measurement(self, operation, qubits, cbits):

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -104,6 +104,7 @@ class CircuitSimulator:
                 state = np.exp(1j * self.qc.global_phase) * state
                 self._state = state
 
+            # Reconstruct CuState with multipartite hilbert_dims for CuOperator mode mapping
             if type(self._state.data).__name__ == "CuState":
                 from qutip_cuquantum.state import CuState as CuStateClass
 
@@ -275,7 +276,9 @@ class CircuitSimulator:
         self._state = state
         self._op_index += 1
 
-    def _generate_einsum_eq(self, targets, num_qubits, is_oper=False):
+    def _generate_einsum_eq(
+        self, targets: int | IntSequence, num_qubits: int, is_oper: bool = False
+    ) -> str:
         """
         Generates the einsum string for tensor contraction supporting up to 52 qubits.
         Uses standard ASCII letters (a-z, A-Z) to map input and output indices.
@@ -321,7 +324,9 @@ class CircuitSimulator:
 
         return f"{sub_gate},{sub_state}->{sub_out}"
 
-    def _generate_dm_einsum_eq(self, targets, num_qubits):
+    def _generate_dm_einsum_eq(
+        self, targets: int | IntSequence, num_qubits: int
+    ) -> str:
         r"""
         Generates the einsum string for density matrix tensor contraction U rho U^\dagger.
 
@@ -389,6 +394,9 @@ class CircuitSimulator:
         state_dtype = type(state.data).__name__
         gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
 
+        # Construct CuOperator with explicit hilbert_dims and target mode mapping
+        # so cuQuantum knows which qubit sites to act on (calling .to('CuOperator')
+        # on raw gate Qobjs loses multipartite mode information).
         if gate_dtype == "CuOperator":
             from qutip_cuquantum.operator import CuOperator as CuOperatorClass
 
@@ -418,7 +426,9 @@ class CircuitSimulator:
             raise NotImplementedError(f"mode {self.mode} is not available.")
         return state
 
-    def _evolve_state_einsum(self, operation, targets_indices, state):
+    def _evolve_state_einsum(
+        self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
+    ) -> Qobj:
         """
         Applies a gate to the state using tensor contraction (einsum).
 
@@ -437,6 +447,8 @@ class CircuitSimulator:
             The updated quantum state.
         """
         state_dtype = type(state.data).__name__
+        # There is no einsum specialisation registered for CuState/CuOperator, so einsum
+        # falls back to CPU NumPy. We route to matrix mul (_evolve_state) to stay on GPU.
         if state_dtype == "CuState":
             return self._evolve_state(operation, targets_indices, state)
 
@@ -459,7 +471,9 @@ class CircuitSimulator:
 
         return state
 
-    def _evolve_state_einsum_dm(self, operation, targets_indices, state):
+    def _evolve_state_einsum_dm(
+        self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
+    ) -> Qobj:
         """
         Applies a gate to the density matrix state using tensor contraction (einsum).
 
@@ -478,6 +492,8 @@ class CircuitSimulator:
             The updated quantum density matrix state.
         """
         state_dtype = type(state.data).__name__
+        # There is no einsum specialisation registered for CuState/CuOperator, so einsum
+        # falls back to CPU NumPy. We route to matrix mul (_evolve_state) to stay on GPU.
         if state_dtype == "CuState":
             return self._evolve_state(operation, targets_indices, state)
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -412,7 +412,10 @@ class CircuitSimulator:
             The updated quantum state.
         """
         state_dtype = type(state.data).__name__
-        gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+        if state_dtype == "CuState":
+            return self._evolve_state(operation, targets_indices, state)
+
+        gate_dtype = state_dtype
 
         gate_qobj = operation.get_qobj().to(gate_dtype)
 
@@ -450,7 +453,10 @@ class CircuitSimulator:
             The updated quantum density matrix state.
         """
         state_dtype = type(state.data).__name__
-        gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+        if state_dtype == "CuState":
+            return self._evolve_state(operation, targets_indices, state)
+
+        gate_dtype = state_dtype
 
         gate_qobj = operation.get_qobj().to(gate_dtype)
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -252,6 +252,8 @@ class CircuitSimulator:
                 return
             if self.mode == "state_vector_simulator":
                 state = self._evolve_state_einsum(gate, qubits, current_state)
+            elif self.mode == "density_matrix_simulator":
+                state = self._evolve_state_einsum_dm(gate, qubits, current_state)
             else:
                 state = self._evolve_state(gate, qubits, current_state)
 
@@ -263,39 +265,96 @@ class CircuitSimulator:
         self._state = state
         self._op_index += 1
 
-    def _generate_einsum_eq(self, targets, num_qubits):
+    def _generate_einsum_eq(self, targets, num_qubits, is_oper=False):
         """
         Generates the einsum string for tensor contraction supporting up to 52 qubits.
         Uses standard ASCII letters (a-z, A-Z) to map input and output indices.
 
         Parameters
         ----------
-        targets : list of int
+        targets : int or list of int
             The target qubits the gate acts on.
         num_qubits : int
             The total number of qubits (tensor dimensions) in the state.
+        is_oper : bool, optional
+            Whether the state is an operator (e.g. unitary matrix) or ket vector.
 
         Returns
         -------
         eq : str
             The einsum equation string (e.g., "ab,cde->cde").
         """
+        if isinstance(targets, int):
+            targets = [targets]
+
         chars = string.ascii_letters
 
-        state_in = list(chars[:num_qubits])
-        gate_out = list(chars[num_qubits : num_qubits + len(targets)])
+        row_in = list(chars[:num_qubits])
+        k = len(targets)
+        gate_out = list(chars[num_qubits : num_qubits + k])
+        gate_in = [row_in[t] for t in targets]
 
-        gate_in = [state_in[t] for t in targets]
-
-        state_out = state_in.copy()
+        row_out = row_in.copy()
         for i, t in enumerate(targets):
-            state_out[t] = gate_out[i]
+            row_out[t] = gate_out[i]
 
-        gate_str = "".join(gate_out + gate_in)
-        state_in_str = "".join(state_in)
-        state_out_str = "".join(state_out)
+        sub_gate = "".join(gate_out + gate_in)
 
-        return f"{gate_str}, {state_in_str}... -> {state_out_str}..."
+        if is_oper:
+            col_in = list(chars[num_qubits + k : 2 * num_qubits + k])
+            sub_state = "".join(row_in + col_in)
+            sub_out = "".join(row_out + col_in)
+        else:
+            col_char = chars[num_qubits + k]
+            sub_state = "".join(row_in) + col_char
+            sub_out = "".join(row_out) + col_char
+
+        return f"{sub_gate},{sub_state}->{sub_out}"
+
+    def _generate_dm_einsum_eq(self, targets, num_qubits):
+        r"""
+        Generates the einsum string for density matrix tensor contraction U rho U^\dagger.
+
+        Parameters
+        ----------
+        targets : int or list of int
+            The target qubits the gate acts on.
+        num_qubits : int
+            The total number of qubits in the state.
+
+        Returns
+        -------
+        eq : str
+            The einsum equation string (e.g., "ghac,abcdef,dfij->gbhiej").
+        """
+        if isinstance(targets, int):
+            targets = [targets]
+
+        chars = string.ascii_letters
+
+        row_in = list(chars[:num_qubits])
+        col_in = list(chars[num_qubits : 2 * num_qubits])
+
+        offset = 2 * num_qubits
+        k = len(targets)
+        gate_out_rows = list(chars[offset : offset + k])
+        gate_out_cols = list(chars[offset + k : offset + 2 * k])
+
+        gate_in_rows = [row_in[t] for t in targets]
+        gate_in_cols = [col_in[t] for t in targets]
+
+        row_out = row_in.copy()
+        col_out = col_in.copy()
+        for i, t in enumerate(targets):
+            row_out[t] = gate_out_rows[i]
+            col_out[t] = gate_out_cols[i]
+
+        sub_U = "".join(gate_out_rows + gate_in_rows)
+        sub_rho = "".join(row_in + col_in)
+        sub_Udag = "".join(gate_in_cols + gate_out_cols)
+        sub_out = "".join(row_out + col_out)
+
+        return f"{sub_U},{sub_rho},{sub_Udag}->{sub_out}"
 
     def _evolve_state(
         self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
@@ -345,28 +404,67 @@ class CircuitSimulator:
         targets_indices : int or sequence of int
             The indices of the target qubits.
         state : :class:`qutip.Qobj`
-            The current quantum state vector.
+            The current quantum state vector or operator.
 
         Returns
         -------
         state : :class:`qutip.Qobj`
             The updated quantum state.
         """
-        gate_qobj = operation.get_qobj()
+        state_dtype = type(state.data).__name__
+        gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+
+        gate_qobj = operation.get_qobj().to(gate_dtype)
 
         original_dims = state.dims
         original_shape = state.shape
-        data_type = type(state.data).__name__
 
-        # Generate equation
-        num_dims = len(self._tensor_dims)
-        eq = self._generate_einsum_eq(targets_indices, num_dims)
+        num_dims = len(self._state_dims[0])
+        is_oper = state.isoper
+        eq = self._generate_einsum_eq(targets_indices, num_dims, is_oper=is_oper)
 
         malformed_state = einsum(eq, gate_qobj, state)
         reshaped_data = _data.reshape(
             malformed_state.data, original_shape[0], original_shape[1]
         )
-        state = Qobj(reshaped_data, dims=original_dims).to(data_type)
+        state = Qobj(reshaped_data, dims=original_dims).to(state_dtype)
+
+        return state
+
+    def _evolve_state_einsum_dm(self, operation, targets_indices, state):
+        """
+        Applies a gate to the density matrix state using tensor contraction (einsum).
+
+        Parameters
+        ----------
+        operation : :class:`.Gate`
+            The quantum gate to be applied.
+        targets_indices : int or sequence of int
+            The indices of the target qubits.
+        state : :class:`qutip.Qobj`
+            The current quantum density matrix state.
+
+        Returns
+        -------
+        state : :class:`qutip.Qobj`
+            The updated quantum density matrix state.
+        """
+        state_dtype = type(state.data).__name__
+        gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+
+        gate_qobj = operation.get_qobj().to(gate_dtype)
+
+        original_dims = state.dims
+        original_shape = state.shape
+
+        num_dims = len(self._state_dims[0])
+        eq = self._generate_dm_einsum_eq(targets_indices, num_dims)
+
+        malformed_state = einsum(eq, gate_qobj, state, gate_qobj.dag())
+        reshaped_data = _data.reshape(
+            malformed_state.data, original_shape[0], original_shape[1]
+        )
+        state = Qobj(reshaped_data, dims=original_dims).to(state_dtype)
 
         return state
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -103,9 +103,19 @@ class CircuitSimulator:
             else:
                 state = np.exp(1j * self.qc.global_phase) * state
                 self._state = state
+
+            if type(self._state.data).__name__ == "CuState":
+                from qutip_cuquantum.state import CuState as CuStateClass
+
+                hilbert_dims = tuple(state.dims[0])
+                self._state = Qobj(
+                    CuStateClass(self._state.data.to_cupy(), hilbert_dims=hilbert_dims),
+                    dims=self._state.dims,
+                )
         else:
             # Just computing the full unitary, no state
             self._state = None
+
         self._state_dims = state.dims.copy()  # Record the dimension of the state.
         self._probability = 1
         self._op_index = 0
@@ -379,11 +389,26 @@ class CircuitSimulator:
         state_dtype = type(state.data).__name__
         gate_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
 
-        U = operation.get_qobj().to(gate_dtype)
+        if gate_dtype == "CuOperator":
+            from qutip_cuquantum.operator import CuOperator as CuOperatorClass
+
+            gate_qobj = operation.get_qobj()
+            U = Qobj(
+                CuOperatorClass(
+                    gate_qobj.data,
+                    hilbert_dims=tuple(gate_qobj.dims[0]),
+                    mode=tuple(range(len(gate_qobj.dims[0]))),
+                ),
+                dims=gate_qobj.dims,
+            )
+        else:
+            U = operation.get_qobj().to(gate_dtype)
+
         U = expand_operator(
             U,
             dims=self.dims,
             targets=targets_indices,
+            dtype=gate_dtype,
         )
         if self.mode == "state_vector_simulator":
             state = U * state

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -857,7 +857,6 @@ class TestEinsumBackend:
             qc = QubitCircuit(1)
             qc.add_gate(gates.X, targets=0)
 
-            # 2. This will now successfully convert because the context exists
             state = basis(2, 0).to(dtype)
 
             sim = CircuitSimulator(qc, mode="state_vector_simulator")
@@ -868,7 +867,6 @@ class TestEinsumBackend:
             assert type(final_state.data) == type(state.data)
 
         finally:
-            # 3. Clean up the context so it doesn't interfere with other tests
             if dtype == "CuState":
                 qutip_cuquantum.set_as_default(reverse=True)
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -33,6 +33,20 @@ from qutip_qip.operations.measurement import Mz
 from qutip_qip.transpiler import to_chain_structure
 from qutip_qip.qasm import read_qasm
 
+try:
+    import qutip_jax
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+try:
+    import qutip_cuquantum
+
+    HAS_CUQANTUM = True
+except ImportError:
+    HAS_CUQANTUM = False
+
 
 def _op_dist(A, B):
     return (A - B).norm()
@@ -811,6 +825,52 @@ class TestQubitCircuit:
 
         assert qc2.reverse_states is True
         assert qc2.input_states == [None] * 3
+
+
+class TestEinsumBackend:
+    """
+    Test suite for the einsum execution path and backend data types.
+    """
+
+    AVAILABLE_DTYPES = ["Dense"]
+    if HAS_JAX:
+        AVAILABLE_DTYPES.append("jax")
+    if HAS_CUQANTUM:
+        AVAILABLE_DTYPES.append("CuState")
+
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
+    def test_dtype_preservation(self, dtype):
+        """
+        Validate that the dtype of the input state is preserved.
+        """
+        if dtype == "CuState":
+            import qutip_cuquantum
+            from cuquantum.densitymat import WorkStream
+
+            # Set the WorkStream as the default context for the backend
+            qutip_cuquantum.set_as_default(WorkStream())
+
+        try:
+            qc = QubitCircuit(1)
+            qc.add_gate(gates.X, targets=0)
+
+            # 2. This will now successfully convert because the context exists
+            state = basis(2, 0).to(dtype)
+
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+
+            assert type(final_state.data) == type(state.data)
+
+        finally:
+            # 3. Clean up the context so it doesn't interfere with other tests
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
 
 
 class TestAddGateError:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -847,22 +847,26 @@ class TestEinsumBackend:
         "ignore:ExternalStream is deprecated:DeprecationWarning"
     )
     @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
-    def test_dtype_preservation(self, dtype):
+    def test_state_vector_einsum_evolution(self, dtype):
         """
-        Validate that the dtype of the input state is preserved.
+        Test state vector einsum evolution with inverted & non-contiguous gate targets.
         """
         if dtype == "CuState":
             import qutip_cuquantum
             from cuquantum.densitymat import WorkStream
 
-            # Set the WorkStream as the default context for the backend
             qutip_cuquantum.set_as_default(WorkStream())
 
         try:
-            qc = QubitCircuit(1)
-            qc.add_gate(gates.X, targets=0)
+            # 3-qubit circuit testing non-contiguous AND inverted target orderings:
+            # CX acting on (2, 0) and TOFFOLI acting on controls=[2, 0] -> target=1
+            qc = QubitCircuit(3)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=2, targets=0)
+            qc.add_gate(gates.TOFFOLI, controls=[2, 0], targets=1)
 
-            state = basis(2, 0).to(dtype)
+            init_state_cpu = tensor(basis(2, 0), basis(2, 0), basis(2, 1))
+            state = init_state_cpu.to(dtype)
 
             sim = CircuitSimulator(qc, mode="state_vector_simulator")
             result = sim.run(state)
@@ -870,6 +874,22 @@ class TestEinsumBackend:
             final_state = result.get_final_states()[0]
 
             assert type(final_state.data) == type(state.data)
+
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
+
+            U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
+            U_CX_exp = expand_operator(
+                gates.CX.get_qobj(), dims=[2, 2, 2], targets=[2, 0]
+            )
+            U_T_exp = expand_operator(
+                gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[2, 0, 1]
+            )
+
+            expected_state = U_T_exp * U_CX_exp * U_H_exp * init_state_cpu
+            np.testing.assert_allclose(
+                final_state.full(), expected_state.full(), atol=1e-12
+            )
 
         finally:
             if dtype == "CuState":
@@ -879,122 +899,105 @@ class TestEinsumBackend:
         "ignore:ExternalStream is deprecated:DeprecationWarning"
     )
     @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
-    def test_density_matrix_dtype_preservation(self, dtype):
+    def test_density_matrix_einsum_evolution(self, dtype):
         """
-        Validate that the dtype of the density matrix state is preserved.
+        Test density matrix einsum evolution with inverted & non-contiguous gate targets.
         """
         if dtype == "CuState":
-            pytest.skip("CuState is for state vectors")
+            import qutip_cuquantum
+            from cuquantum.densitymat import WorkStream
 
-        qc = QubitCircuit(2)
-        qc.add_gate(gates.H, targets=0)
-        qc.add_gate(gates.CX, controls=0, targets=1)
+            qutip_cuquantum.set_as_default(WorkStream())
 
-        state = ket2dm(tensor(basis(2, 0), basis(2, 0))).to(dtype)
-
-        sim = CircuitSimulator(qc, mode="density_matrix_simulator")
-        result = sim.run(state)
-
-        final_state = result.get_final_states()[0]
-
-        assert type(final_state.data) == type(state.data)
-
-    def test_density_matrix_einsum_evolution(self):
-        """
-        Test density matrix einsum evolution accuracy against operator expansion.
-        """
-        qc = QubitCircuit(3)
-        qc.add_gate(gates.H, targets=0)
-        qc.add_gate(gates.CX, controls=0, targets=1)
-        qc.add_gate(gates.TOFFOLI, controls=[0, 1], targets=2)
-
-        dm_init = qutip.rand_dm([2, 2, 2])
-
-        sim_dm = CircuitSimulator(qc, mode="density_matrix_simulator")
-        res_einsum = sim_dm.run(dm_init).get_final_states(0)
-
-        U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
-        U_CX_exp = expand_operator(gates.CX.get_qobj(), dims=[2, 2, 2], targets=[0, 1])
-        U_T_exp = expand_operator(
-            gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[0, 1, 2]
-        )
-
-        expected_dm = (
-            U_T_exp
-            * U_CX_exp
-            * U_H_exp
-            * dm_init
-            * U_H_exp.dag()
-            * U_CX_exp.dag()
-            * U_T_exp.dag()
-        )
-
-        np.testing.assert_allclose(res_einsum.full(), expected_dm.full(), atol=1e-12)
-
-    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
-    @pytest.mark.filterwarnings(
-        "ignore:ExternalStream is deprecated:DeprecationWarning"
-    )
-    def test_cuquantum_state_vector_simulator(self):
-        """Test state_vector_simulator mode with CuState on GPU."""
-        import qutip_cuquantum
-        from cuquantum.densitymat import WorkStream
-
-        ctx = WorkStream()
-        qutip_cuquantum.set_as_default(ctx)
         try:
-            qc = QubitCircuit(2)
+            qc = QubitCircuit(3)
             qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=0, targets=1)
+            qc.add_gate(gates.CX, controls=2, targets=0)
+            qc.add_gate(gates.TOFFOLI, controls=[2, 0], targets=1)
 
-            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
-            sim = CircuitSimulator(qc, mode="state_vector_simulator")
-            result = sim.run(state)
+            dm_init_cpu = ket2dm(tensor(basis(2, 0), basis(2, 0), basis(2, 1)))
+            dm_init = dm_init_cpu.to(dtype)
 
-            final_state = result.get_final_states()[0]
-            assert type(final_state.data).__name__ == "CuState"
+            sim_dm = CircuitSimulator(qc, mode="density_matrix_simulator")
+            res_einsum = sim_dm.run(dm_init).get_final_states(0)
 
-            expected = (
-                tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
-            ).unit()
-            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
-        finally:
-            qutip_cuquantum.set_as_default(reverse=True)
+            assert type(res_einsum.data) == type(dm_init.data)
 
-    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
-    @pytest.mark.filterwarnings(
-        "ignore:ExternalStream is deprecated:DeprecationWarning"
-    )
-    def test_cuquantum_density_matrix_simulator(self):
-        """Test density_matrix_simulator mode with CuState on GPU."""
-        import qutip_cuquantum
-        from cuquantum.densitymat import WorkStream
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
 
-        ctx = WorkStream()
-        qutip_cuquantum.set_as_default(ctx)
-        try:
-            qc = QubitCircuit(2)
-            qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=0, targets=1)
-
-            pure_state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
-            state = ket2dm(pure_state)
-            assert type(state.data).__name__ == "CuState"
-
-            sim = CircuitSimulator(qc, mode="density_matrix_simulator")
-            result = sim.run(state)
-
-            final_state = result.get_final_states()[0]
-            assert type(final_state.data).__name__ == "CuState"
-
-            expected = ket2dm(
-                (
-                    tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
-                ).unit()
+            U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
+            U_CX_exp = expand_operator(
+                gates.CX.get_qobj(), dims=[2, 2, 2], targets=[2, 0]
             )
-            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+            U_T_exp = expand_operator(
+                gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[2, 0, 1]
+            )
+
+            expected_dm = (
+                U_T_exp
+                * U_CX_exp
+                * U_H_exp
+                * dm_init_cpu
+                * U_H_exp.dag()
+                * U_CX_exp.dag()
+                * U_T_exp.dag()
+            )
+
+            np.testing.assert_allclose(
+                res_einsum.full(), expected_dm.full(), atol=1e-12
+            )
         finally:
-            qutip_cuquantum.set_as_default(reverse=True)
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
+
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
+    def test_operator_einsum_evolution(self, dtype):
+        """
+        Test unitary operator matrix propagation (is_oper=True) through einsum with inverted targets.
+        """
+        if dtype == "CuState":
+            pytest.skip(
+                "CuState is for quantum state vectors/DMs, not general full operator matrices"
+            )
+
+        try:
+            qc = QubitCircuit(3)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=2, targets=0)
+            qc.add_gate(gates.TOFFOLI, controls=[2, 0], targets=1)
+
+            init_oper_cpu = identity([2, 2, 2])
+            oper = init_oper_cpu.to(dtype)
+
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            res_einsum = sim.run(oper).get_final_states(0)
+
+            assert res_einsum.isoper
+            assert type(res_einsum.data) == type(oper.data)
+
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
+
+            U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
+            U_CX_exp = expand_operator(
+                gates.CX.get_qobj(), dims=[2, 2, 2], targets=[2, 0]
+            )
+            U_T_exp = expand_operator(
+                gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[2, 0, 1]
+            )
+
+            expected_oper = U_T_exp * U_CX_exp * U_H_exp * init_oper_cpu
+
+            np.testing.assert_allclose(
+                res_einsum.full(), expected_oper.full(), atol=1e-12
+            )
+        finally:
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
 
 
 class TestAddGateError:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -48,9 +48,9 @@ except ImportError:
 try:
     import qutip_cuquantum
 
-    HAS_CUQANTUM = True
+    HAS_CUQUANTUM = True
 except ImportError:
-    HAS_CUQANTUM = False
+    HAS_CUQUANTUM = False
 
 
 def _op_dist(A, B):
@@ -840,7 +840,7 @@ class TestEinsumBackend:
     AVAILABLE_DTYPES = ["Dense"]
     if HAS_JAX:
         AVAILABLE_DTYPES.append("jax")
-    if HAS_CUQANTUM:
+    if HAS_CUQUANTUM:
         AVAILABLE_DTYPES.append("CuState")
 
     @pytest.mark.filterwarnings(
@@ -873,8 +873,11 @@ class TestEinsumBackend:
 
             final_state = result.get_final_states()[0]
 
-            assert type(final_state.data) == type(state.data)
+            assert type(final_state.data) is type(state.data)
 
+            # Switch back to CPU before computing analytical baseline matrices.
+            # Otherwise, expand_operator creates CuOperator instances where .permute()
+            # fails on non-contiguous/inverted targets (e.g. CX on [2, 0]).
             if dtype == "CuState":
                 qutip_cuquantum.set_as_default(reverse=True)
 
@@ -921,8 +924,11 @@ class TestEinsumBackend:
             sim_dm = CircuitSimulator(qc, mode="density_matrix_simulator")
             res_einsum = sim_dm.run(dm_init).get_final_states(0)
 
-            assert type(res_einsum.data) == type(dm_init.data)
+            assert type(res_einsum.data) is type(dm_init.data)
 
+            # Switch back to CPU before computing analytical baseline matrices.
+            # Otherwise, expand_operator creates CuOperator instances where .permute()
+            # fails on non-contiguous/inverted targets (e.g. CX on [2, 0]).
             if dtype == "CuState":
                 qutip_cuquantum.set_as_default(reverse=True)
 
@@ -964,40 +970,29 @@ class TestEinsumBackend:
                 "CuState is for quantum state vectors/DMs, not general full operator matrices"
             )
 
-        try:
-            qc = QubitCircuit(3)
-            qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=2, targets=0)
-            qc.add_gate(gates.TOFFOLI, controls=[2, 0], targets=1)
+        qc = QubitCircuit(3)
+        qc.add_gate(gates.H, targets=0)
+        qc.add_gate(gates.CX, controls=2, targets=0)
+        qc.add_gate(gates.TOFFOLI, controls=[2, 0], targets=1)
 
-            init_oper_cpu = identity([2, 2, 2])
-            oper = init_oper_cpu.to(dtype)
+        init_oper_cpu = identity([2, 2, 2])
+        oper = init_oper_cpu.to(dtype)
 
-            sim = CircuitSimulator(qc, mode="state_vector_simulator")
-            res_einsum = sim.run(oper).get_final_states(0)
+        sim = CircuitSimulator(qc, mode="state_vector_simulator")
+        res_einsum = sim.run(oper).get_final_states(0)
 
-            assert res_einsum.isoper
-            assert type(res_einsum.data) == type(oper.data)
+        assert res_einsum.isoper
+        assert type(res_einsum.data) is type(oper.data)
 
-            if dtype == "CuState":
-                qutip_cuquantum.set_as_default(reverse=True)
+        U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
+        U_CX_exp = expand_operator(gates.CX.get_qobj(), dims=[2, 2, 2], targets=[2, 0])
+        U_T_exp = expand_operator(
+            gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[2, 0, 1]
+        )
 
-            U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
-            U_CX_exp = expand_operator(
-                gates.CX.get_qobj(), dims=[2, 2, 2], targets=[2, 0]
-            )
-            U_T_exp = expand_operator(
-                gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[2, 0, 1]
-            )
+        expected_oper = U_T_exp * U_CX_exp * U_H_exp * init_oper_cpu
 
-            expected_oper = U_T_exp * U_CX_exp * U_H_exp * init_oper_cpu
-
-            np.testing.assert_allclose(
-                res_einsum.full(), expected_oper.full(), atol=1e-12
-            )
-        finally:
-            if dtype == "CuState":
-                qutip_cuquantum.set_as_default(reverse=True)
+        np.testing.assert_allclose(res_einsum.full(), expected_oper.full(), atol=1e-12)
 
 
 class TestAddGateError:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -931,6 +931,71 @@ class TestEinsumBackend:
 
         np.testing.assert_allclose(res_einsum.full(), expected_dm.full(), atol=1e-12)
 
+    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    def test_cuquantum_state_vector_simulator(self):
+        """Test state_vector_simulator mode with CuState on GPU."""
+        import qutip_cuquantum
+        from cuquantum.densitymat import WorkStream
+
+        ctx = WorkStream()
+        qutip_cuquantum.set_as_default(ctx)
+        try:
+            qc = QubitCircuit(2)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+
+            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+            assert type(final_state.data).__name__ == "CuState"
+
+            expected = (
+                tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
+            ).unit()
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            qutip_cuquantum.set_as_default(reverse=True)
+
+    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    def test_cuquantum_density_matrix_simulator(self):
+        """Test density_matrix_simulator mode with CuState on GPU."""
+        import qutip_cuquantum
+        from cuquantum.densitymat import WorkStream
+
+        ctx = WorkStream()
+        qutip_cuquantum.set_as_default(ctx)
+        try:
+            qc = QubitCircuit(2)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+
+            pure_state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
+            state = ket2dm(pure_state)
+            assert type(state.data).__name__ == "CuState"
+
+            sim = CircuitSimulator(qc, mode="density_matrix_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+            assert type(final_state.data).__name__ == "CuState"
+
+            expected = ket2dm(
+                (
+                    tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
+                ).unit()
+            )
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            qutip_cuquantum.set_as_default(reverse=True)
+
 
 class TestAddGateError:
     def test_add_gate_errors(self):

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -27,7 +27,12 @@ from qutip_qip.circuit import (
 )
 from qutip_qip.circuit.draw import TeXRenderer
 from qutip_qip.decompose.decompose_single_qubit_gate import _ZYZ_rotation
-from qutip_qip.operations import Gate, Measurement, gate_sequence_product
+from qutip_qip.operations import (
+    Gate,
+    Measurement,
+    gate_sequence_product,
+    expand_operator,
+)
 import qutip_qip.operations.gates as gates
 from qutip_qip.operations.measurement import Mz
 from qutip_qip.transpiler import to_chain_structure
@@ -869,6 +874,62 @@ class TestEinsumBackend:
         finally:
             if dtype == "CuState":
                 qutip_cuquantum.set_as_default(reverse=True)
+
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
+    def test_density_matrix_dtype_preservation(self, dtype):
+        """
+        Validate that the dtype of the density matrix state is preserved.
+        """
+        if dtype == "CuState":
+            pytest.skip("CuState is for state vectors")
+
+        qc = QubitCircuit(2)
+        qc.add_gate(gates.H, targets=0)
+        qc.add_gate(gates.CX, controls=0, targets=1)
+
+        state = ket2dm(tensor(basis(2, 0), basis(2, 0))).to(dtype)
+
+        sim = CircuitSimulator(qc, mode="density_matrix_simulator")
+        result = sim.run(state)
+
+        final_state = result.get_final_states()[0]
+
+        assert type(final_state.data) == type(state.data)
+
+    def test_density_matrix_einsum_evolution(self):
+        """
+        Test density matrix einsum evolution accuracy against operator expansion.
+        """
+        qc = QubitCircuit(3)
+        qc.add_gate(gates.H, targets=0)
+        qc.add_gate(gates.CX, controls=0, targets=1)
+        qc.add_gate(gates.TOFFOLI, controls=[0, 1], targets=2)
+
+        dm_init = qutip.rand_dm([2, 2, 2])
+
+        sim_dm = CircuitSimulator(qc, mode="density_matrix_simulator")
+        res_einsum = sim_dm.run(dm_init).get_final_states(0)
+
+        U_H_exp = expand_operator(gates.H.get_qobj(), dims=[2, 2, 2], targets=0)
+        U_CX_exp = expand_operator(gates.CX.get_qobj(), dims=[2, 2, 2], targets=[0, 1])
+        U_T_exp = expand_operator(
+            gates.TOFFOLI.get_qobj(), dims=[2, 2, 2], targets=[0, 1, 2]
+        )
+
+        expected_dm = (
+            U_T_exp
+            * U_CX_exp
+            * U_H_exp
+            * dm_init
+            * U_H_exp.dag()
+            * U_CX_exp.dag()
+            * U_T_exp.dag()
+        )
+
+        np.testing.assert_allclose(res_einsum.full(), expected_dm.full(), atol=1e-12)
 
 
 class TestAddGateError:


### PR DESCRIPTION
**Description**
This PR refactors the `_evolve_state_einsum` function to use `qutip.einsum()` and handle other data types.

Changes:
- Adds `_generate_einsum_eq()` to generate string einsum equation.
- Modifies `_evolve_state_einsum()` to handle 3 different dtypes: Dense, jax and CuState.
- Adds test cases for the 3 dtypes
- Modifies `pyproject.toml` to add jax and cuquantum dependencies.

**Related issues or PRs**
Part of GSoC 2026

**AI Tools Usage Disclosure**
Gemini 3.1 Pro: Implementation discussion and debugging.