### PR TITLE
Add QuTiP 5-compatible solver options handling

### DIFF
--- a/src/qutip_qip/compat.py
+++ b/src/qutip_qip/compat.py
@@ -2,11 +2,11 @@
 For the compatibility between qutip-v5 and v4.
 """
 
-from itertools import chain
-from functools import reduce
 from packaging.version import parse as parse_version
-import numpy as np
 import qutip
+
+
+is_qutip5 = parse_version(qutip.__version__) >= parse_version("5.dev")
 
 
 def to_scalar(qobj_or_scalar):
@@ -14,3 +14,9 @@ def to_scalar(qobj_or_scalar):
         if qobj_or_scalar.dims == [[1], [1]]:
             return qobj_or_scalar[0, 0]
     return qobj_or_scalar
+
+
+def solver_options(**kwargs):
+    if is_qutip5:
+        return kwargs
+    return qutip.Options(**kwargs)

--- a/src/qutip_qip/compat.py
+++ b/src/qutip_qip/compat.py
@@ -16,7 +16,7 @@ def to_scalar(qobj_or_scalar):
     return qobj_or_scalar
 
 
-def solver_options(**kwargs):
+def back_compatible_solver_options(**kwargs):
     if is_qutip5:
         return kwargs
     return qutip.Options(**kwargs)

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -13,7 +13,6 @@ from qutip import (
     Qobj,
     QobjEvo,
 )
-from ..compat import solver_options
 from ..circuit import QubitCircuit
 from ..operations import Gate
 from .processor import Processor, Model

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -13,6 +13,7 @@ from qutip import (
     Qobj,
     QobjEvo,
 )
+from ..compat import solver_options
 from ..circuit import QubitCircuit
 from ..operations import Gate
 from .processor import Processor, Model
@@ -70,7 +71,7 @@ class DispersiveCavityQED(ModelProcessor):
         processor.load_circuit(qc)
         result = processor.run_state(
             qutip.basis([10, 2, 2], [0, 0, 0]),
-            options=qutip.Options(nsteps=5000))
+            options=solver_options(nsteps=5000))
         final_qubit_state = result.states[-1].ptrace([1, 2])
         print(round(qutip.fidelity(
             final_qubit_state,

--- a/src/qutip_qip/device/cavityqed.py
+++ b/src/qutip_qip/device/cavityqed.py
@@ -71,7 +71,8 @@ class DispersiveCavityQED(ModelProcessor):
         processor.load_circuit(qc)
         result = processor.run_state(
             qutip.basis([10, 2, 2], [0, 0, 0]),
-            options=solver_options(nsteps=5000))
+            options={"nsteps": 5000}
+        )
         final_qubit_state = result.states[-1].ptrace([1, 2])
         print(round(qutip.fidelity(
             final_qubit_state,

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1005,7 +1005,7 @@ class Processor(object):
             final_qu.args.update(args)
 
         # bring all c_ops to the same tlist, won't need it in QuTiP 5
-        if not parse_version(qutip.__version__) >= parse_version("5.dev"):
+        if not is_qutip5:
             temp = []
             for c_op in c_ops:
                 temp.append(_merge_qobjevo([c_op], final_qu.tlist))
@@ -1202,7 +1202,7 @@ class Processor(object):
         # is however, much harder to implement at this stage, see also
         # https://github.com/qutip/qutip-qip/issues/184.
         if is_qutip5:
-            options = kwargs.get("options", qutip.Options())
+            options = kwargs.get("options", {})
             if options.get("max_step", 0.0) == 0.0:
                 options["max_step"] = self._get_max_step()
             options["progress_bar"] = False

--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -1202,7 +1202,9 @@ class Processor(object):
         # is however, much harder to implement at this stage, see also
         # https://github.com/qutip/qutip-qip/issues/184.
         if is_qutip5:
-            options = kwargs.get("options", {})
+            options = kwargs.get("options")
+            if options is None:
+                options = {}
             if options.get("max_step", 0.0) == 0.0:
                 options["max_step"] = self._get_max_step()
             options["progress_bar"] = False

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,6 +10,8 @@ filterwarnings =
     ; DeprecationWarning: Please use `upcast` from the `scipy.sparse` namespace
     ignore::DeprecationWarning:qutip.fastsparse*:
     ignore:matplotlib not found:UserWarning
+    ignore::pyparsing.warnings.PyparsingDeprecationWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
     ignore::DeprecationWarning:qiskit.utils.algorithm_globals:
-
+    ignore:.*`disp` and `iprint` options.*L-BFGS-B.*deprecated.*:DeprecationWarning
+    ignore:.*'mode' parameter is deprecated and will be removed in Pillow 13.*:DeprecationWarning

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -11,6 +11,5 @@ filterwarnings =
     ignore::DeprecationWarning:qutip.fastsparse*:
     ignore:matplotlib not found:UserWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-    ignore:Dedicated options class are no longer needed, options should be passed as dict to solvers.:FutureWarning
     ignore::DeprecationWarning:qiskit.utils.algorithm_globals:
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,17 +8,12 @@ import pytest
 
 import qutip
 from qutip_qip.circuit import QubitCircuit
+from qutip_qip.compat import back_compatible_solver_options
 from qutip_qip.operations import Gate, gate_sequence_product, RZX
 from qutip_qip.device import (DispersiveCavityQED, LinearSpinChain,
                                 CircularSpinChain, SCQubits)
 
 from packaging.version import parse as parse_version
-
-if parse_version(qutip.__version__) < parse_version("5.dev"):
-    from qutip import Options as SolverOptions
-else:
-    def SolverOptions(**kwargs):
-        return kwargs
 
 _tol = 3.e-2
 
@@ -141,7 +136,9 @@ def _test_numerical_evolution_helper(num_qubits, gates, device_class, kwargs):
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = SolverOptions(store_final_state=True, nsteps=50_000)
+    options = back_compatible_solver_options(
+        store_final_state=True, nsteps=50_000
+    )
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)
@@ -198,7 +195,9 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = SolverOptions(store_final_state=True, nsteps=50_000)
+    options = back_compatible_solver_options(
+        store_final_state=True, nsteps=50_000
+    )
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,7 +13,12 @@ from qutip_qip.device import (DispersiveCavityQED, LinearSpinChain,
                                 CircularSpinChain, SCQubits)
 
 from packaging.version import parse as parse_version
-from qutip import Options
+
+if parse_version(qutip.__version__) < parse_version("5.dev"):
+    from qutip import Options as SolverOptions
+else:
+    def SolverOptions(**kwargs):
+        return kwargs
 
 _tol = 3.e-2
 
@@ -136,7 +141,7 @@ def _test_numerical_evolution_helper(num_qubits, gates, device_class, kwargs):
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = Options(store_final_state=True, nsteps=50_000)
+    options = SolverOptions(store_final_state=True, nsteps=50_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)
@@ -193,7 +198,7 @@ def test_numerical_circuit(circuit, device_class, kwargs, schedule_mode):
         init_state = _ket_expaned_dims(state, device.dims)
     else:
         init_state = state
-    options = Options(store_final_state=True, nsteps=50_000)
+    options = SolverOptions(store_final_state=True, nsteps=50_000)
     result = device.run_state(init_state=init_state,
                               analytical=False,
                               options=options)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -157,7 +157,7 @@ class TestCliffordGroup:
                 fid = qutip.average_gate_fidelity(gate, other)
                 assert not np.allclose(fid, 1., atol=1e-3)
 
-    @pytest.mark.parametrize("gate", gates.qubit_clifford_group())
+    @pytest.mark.parametrize("gate", tuple(gates.qubit_clifford_group()))
     def test_gate_normalises_pauli_group(self, gate):
         """
         Test the fundamental definition of the Clifford group, i.e. that it

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -6,6 +6,7 @@ import pytest
 from packaging.version import parse as parse_version
 
 pytest.importorskip("qutip_qtrl")
+from qutip_qip.compat import back_compatible_solver_options
 from qutip_qip.device import OptPulseProcessor, SpinChainModel
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.qubits import qubit_states
@@ -23,14 +24,7 @@ from qutip_qip.operations import (
     cnot,
 )
 
-if parse_version(qutip.__version__) < parse_version("5.dev"):
-    from qutip import Options as SolverOptions
-    is_qutip5 = False
-else:
-    is_qutip5 = True
-
-    def SolverOptions(**kwargs):
-        return kwargs
+is_qutip5 = parse_version(qutip.__version__) >= parse_version("5.dev")
 
 
 class TestOptPulseProcessor:
@@ -87,7 +81,9 @@ class TestOptPulseProcessor:
         )
         rho0 = qubit_states(3, [1, 1, 1])
         rho1 = qubit_states(3, [1, 1, 0])
-        result = test.run_state(rho0, options=SolverOptions(store_states=True))
+        result = test.run_state(
+            rho0, options=back_compatible_solver_options(store_states=True)
+        )
         assert_(fidelity(result.states[-1], rho1) > 1 - 1.0e-6)
 
     def test_multi_gates(self):

--- a/tests/test_optpulseprocessor.py
+++ b/tests/test_optpulseprocessor.py
@@ -3,6 +3,7 @@ import os
 from numpy.testing import assert_, assert_allclose, assert_equal
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 pytest.importorskip("qutip_qtrl")
 from qutip_qip.device import OptPulseProcessor, SpinChainModel
@@ -21,13 +22,15 @@ from qutip import (
 from qutip_qip.operations import (
     cnot,
 )
-import qutip
-from packaging.version import parse as parse_version
 
 if parse_version(qutip.__version__) < parse_version("5.dev"):
     from qutip import Options as SolverOptions
+    is_qutip5 = False
 else:
-    from qutip import SolverOptions
+    is_qutip5 = True
+
+    def SolverOptions(**kwargs):
+        return kwargs
 
 
 class TestOptPulseProcessor:
@@ -127,10 +130,10 @@ class TestOptPulseProcessor:
             qc, merge_gates=True, num_tslots=10, evo_time=2.0
         )
 
-        if parse_version(qutip.__version__) < parse_version("5.dev"):
-            init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
-        else:
+        if is_qutip5:
             init_state = qutip.rand_ket([2, 2, 2])
+        else:
+            init_state = qutip.rand_ket(8, dims=[[2, 2, 2], [1, 1, 1]])
 
         num_result = processor.run_state(init_state=init_state).states[-1]
         ideal_result = qc.run(init_state)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -17,7 +17,13 @@ from qutip_qip.noise import (
 from qutip_qip.qubits import qubit_states
 from qutip_qip.pulse import Pulse
 from qutip_qip.circuit import QubitCircuit
-from qutip import Options
+
+
+if parse_version(qutip.__version__) < parse_version("5.dev"):
+    from qutip import Options as SolverOptions
+else:
+    def SolverOptions(**kwargs):
+        return kwargs
 
 
 class TestCircuitProcessor:
@@ -89,7 +95,7 @@ class TestCircuitProcessor:
         tlist = [0., 1., 2.]
         proc.add_pulse(Pulse(identity(2), 0, tlist, False))
         result = proc.run_state(
-            init_state, options=Options(store_final_state=True))
+            init_state, options=SolverOptions(store_final_state=True))
         global_phase = init_state[0, 0]/result.final_state[0, 0]
         assert_allclose(
             global_phase*result.final_state.full(), init_state.full())
@@ -398,7 +404,7 @@ class TestCircuitProcessor:
         # No max_step
         final_state = processor.run_state(
             init_state,
-            options=Options(max_step=10000)  # too large max_step
+            options=SolverOptions(max_step=10000)  # too large max_step
         ).states[-1]
         expected_state = tensor([basis(2, 0), basis(2, 1)])
         assert pytest.approx(fidelity(final_state, expected_state), 0.001) == 0

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import qutip
+from qutip_qip.compat import back_compatible_solver_options
 from qutip_qip.device import Processor, LinearSpinChain
 from qutip import (
     basis, sigmaz, sigmax, sigmay, identity, destroy, tensor,
@@ -17,13 +18,6 @@ from qutip_qip.noise import (
 from qutip_qip.qubits import qubit_states
 from qutip_qip.pulse import Pulse
 from qutip_qip.circuit import QubitCircuit
-
-
-if parse_version(qutip.__version__) < parse_version("5.dev"):
-    from qutip import Options as SolverOptions
-else:
-    def SolverOptions(**kwargs):
-        return kwargs
 
 
 class TestCircuitProcessor:
@@ -95,7 +89,9 @@ class TestCircuitProcessor:
         tlist = [0., 1., 2.]
         proc.add_pulse(Pulse(identity(2), 0, tlist, False))
         result = proc.run_state(
-            init_state, options=SolverOptions(store_final_state=True))
+            init_state, options=back_compatible_solver_options(
+                store_final_state=True
+            ))
         global_phase = init_state[0, 0]/result.final_state[0, 0]
         assert_allclose(
             global_phase*result.final_state.full(), init_state.full())
@@ -404,7 +400,9 @@ class TestCircuitProcessor:
         # No max_step
         final_state = processor.run_state(
             init_state,
-            options=SolverOptions(max_step=10000)  # too large max_step
+            options=back_compatible_solver_options(
+                max_step=10000
+            )  # too large max_step
         ).states[-1]
         expected_state = tensor([basis(2, 0), basis(2, 1)])
         assert pytest.approx(fidelity(final_state, expected_state), 0.001) == 0


### PR DESCRIPTION
qutip dropped the old interface `qutip.Options`. qutip-qip also dropped the support of old qutipv4, but it is not yet released. This patch is to fix qutip-v0.4

Ignore some deprecation warnings caused by matplotlib due to Python 3.9 env.

The failing VQA tests are fixed in #280, and will be included in the release. (Test will pass, verified here https://github.com/qutip/qutip-qip/actions/runs/27660840477)

GPT-5.4 is used to fix the pytest and matplotlib warning issue.
