### PR TITLE
Classical control flow for Ops

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Python
         uses: actions/setup-python@v6
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Python
         uses: actions/setup-python@v6

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -22,7 +22,7 @@ jobs:
 
       steps:
         - name: Clone the repo
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Set up Python
           uses: actions/setup-python@v6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pulse-paper.yaml
+++ b/.github/workflows/pulse-paper.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Spell Check the repo
         uses: crate-ci/typos@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         with:
           flag-name: run-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.case-name }}
           parallel: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -310,7 +310,15 @@ class QubitCircuit:
         self._instructions = []
 
         for op_instruction in self._ops:
-            if isinstance(op_instruction.op, Gate) or issubclass(
+            if isinstance(op_instruction.op, Label):
+                self._instructions.append()
+
+            elif isinstance(op_instruction.op, Cbz) or isinstance(
+                op_instruction.op, Cbnz
+            ):
+                self._instructions.append()
+
+            elif isinstance(op_instruction.op, Gate) or issubclass(
                 op_instruction.op, Gate
             ):
                 self._instructions.append(

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -10,18 +10,19 @@ from typing import Iterable, Type, Self
 from qutip import qeye, Qobj, basis, tensor
 import numpy as np
 
-from qutip_qip.circuit import (
-    CircuitSimulator,
-    CircuitInstruction,
-    GateInstruction,
-    MeasurementInstruction,
-    OpInstruction,
-)
+from qutip_qip.circuit import CircuitSimulator, OpInstruction
 from qutip_qip.circuit._decompose import (
     _resolve_to_universal,
     _resolve_2q_basis,
 )
-from qutip_qip.circuit.conditional import Cbnz, Cbz, Label
+from qutip_qip.circuit.instruction import (
+    CircuitInstruction,
+    ConditionalBranchInstruction,
+    GateInstruction,
+    LabelInstruction,
+    MeasurementInstruction,
+)
+from qutip_qip.circuit.conditional import Cbnz, Cbz, Conditional, Label
 from qutip_qip.operations import (
     Gate,
     Measurement,
@@ -310,17 +311,16 @@ class QubitCircuit:
         self._instructions = []
 
         for op_instruction in self._ops:
-            if isinstance(op_instruction.op, Label):
-                self._instructions.append()
+            op = op_instruction.op
+            if isinstance(op, Label):
+                self._instructions.append(LabelInstruction(op_instruction.op))
 
-            elif isinstance(op_instruction.op, Cbz) or isinstance(
-                op_instruction.op, Cbnz
-            ):
-                self._instructions.append()
+            elif isinstance(op, Conditional):
+                self._instructions.append(
+                    ConditionalBranchInstruction(operation=op, cbits=op.creg)
+                )
 
-            elif isinstance(op_instruction.op, Gate) or issubclass(
-                op_instruction.op, Gate
-            ):
+            elif isinstance(op, Gate) or issubclass(op, Gate):
                 self._instructions.append(
                     GateInstruction(
                         operation=op_instruction.op,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -53,6 +53,8 @@ class ClassicalControlCheck(StrEnum):
     NEQ = "NEQ"
     GT = "GT"
     LT = "LT"
+    GTE = "GTE"  # This can be subimplemented using GT - 1
+    LTE = "LTE"
 
 
 class QubitCircuit:
@@ -266,28 +268,120 @@ class QubitCircuit:
                 self.output_states[i] = state
 
     @contextmanager
-    def test_if(
+    def if_test(
         self: Self,
         cbits: int | IntSequence,
         value: int,
         check: ClassicalControlCheck = "EQ",
     ):
-        # TODO check the arguments
+        # TODO Validate the arguments
         if type(cbits) is int:
             cbits = [cbits]
 
-        # TODO Implement other checks
+        # GTE, LTE checks can be implemented as GT, LT conditions itself
+        if check == ClassicalControlCheck.GTE:
+            check = ClassicalControlCheck.GT
+            value -= 1
+
+        elif check == ClassicalControlCheck.LTE:
+            check = ClassicalControlCheck.LT
+            value += 1
 
         label = Label(f"label_{self._label_counter}")
         self._label_counter += 1
 
-        for index, cbit in enumerate(cbits):
-            if (value >> index) & 1 == 0:
-                self.add_op(Cbnz(label=label), creg=cbit)
-            else:
-                self.add_op(Cbz(label=label), creg=cbit)
+        if check == ClassicalControlCheck.EQ:
+            for index, cbit in enumerate(cbits):
+                if (value >> index) & 1 == 1:
+                    # If does not match for cbit_value=1, then branch to label (don't execute the condiitonal if)
+                    self.add_op(Cbz(label=label), creg=cbit)
+                else:
+                    # If does not match for cbit_value=0, then branch to label
+                    self.add_op(Cbnz(label=label), creg=cbit)
 
-        # Yields the control back to the code inside the `with` block
+        elif check == ClassicalControlCheck.NEQ:
+            neq_label = Label(f"label_{self._label_counter}")
+            self._label_counter += 1
+
+            for index, cbit in enumerate(cbits):
+                target_bit_value = (value >> index) & 1
+
+                if target_bit_value == 1:
+                    # If a mismatch match for cbit_value=1, then branch to neqlabel
+                    self.add_op(Cbz(label=neq_label), creg=cbit)
+                else:
+                    self.add_op(Cbnz(label=neq_label), creg=cbit)
+
+            # This will only execute if non of the earlier conditional branching executes.
+            # means NEQ is FALSE. We must skip the conditional block.
+
+            # This must be preferably replaced Jump statement (unconditional)
+            self.add_op(Cbz(label=label), creg=0)
+            self.add_op(Cbnz(label=label), creg=0)
+
+            # Successful entry point for the NEQ condition
+            self.add_op(neq_label)
+
+        elif check == ClassicalControlCheck.GT:
+            # Check for redundant conditions
+            if value >= 2 ** len(cbits):  # Never true
+                return
+
+            elif value > 0:  # for value less than 0, condition is always true
+                gt_label = Label(f"label_{self._label_counter}")
+                self._label_counter += 1
+
+                for index, cbit in enumerate(cbits):
+                    target_bit_value = (value >> index) & 1
+
+                    # We break at first point of discontinuity (but to different labels)
+                    if target_bit_value == 1:
+                        self.add_op(Cbz(label=label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=gt_label), creg=cbit)
+
+                # If execution falls through the entire loop without jumping,
+                # it means every single bit matched exactly.
+                # self.add_op(Jump(label=label))
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
+
+                # Entry point for the GT conditional block
+                self.add_op(gt_label)
+
+        elif check == ClassicalControlCheck.LT:
+            # Check for redundant conditions
+            if value <= 0:  # Never true
+                return
+
+            elif value < 2 ** len(
+                cbits
+            ):  # for value larger than 2^m, condition is always true
+                lt_label = Label(f"label_{self._label_counter}")
+                self._label_counter += 1
+
+                for index, cbit in enumerate(cbits):
+                    target_bit_value = (value >> index) & 1
+
+                    # We break at first point of discontinuity (but to different labels)
+                    if target_bit_value == 1:
+                        self.add_op(Cbz(label=lt_label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=label), creg=cbit)
+
+                # If execution falls through the entire loop without jumping,
+                # it means every single bit matched exactly.
+                # self.add_op(Jump(label=label))
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
+
+                # Entry point for the GT conditional block
+                self.add_op(lt_label)
+
+        else:
+            raise ValueError(f"Invalid check {check}")
+
+        # Yields the control back to the code inside the "with" context block
         try:
             yield
         finally:

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -229,7 +229,7 @@ class QubitCircuit:
     def instructions(self) -> list[CircuitInstruction]:
         return self._instructions
 
-    # TODO: Add method to add auxilary qubits
+    # TODO: Add method to add auxiliary qubits
 
     def add_state(
         self,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -4,6 +4,7 @@ Quantum circuit representation and simulation.
 
 import warnings
 import inspect
+from contextlib import contextmanager
 from typing import Iterable, Type, Self
 from qutip import qeye, Qobj, basis, tensor
 import numpy as np
@@ -91,6 +92,7 @@ class QubitCircuit:
         self._ops: list[Op] = []
         self._instructions: list[CircuitInstruction] = []
         self.dims = dims if dims is not None else [2] * self.num_qubits
+        self._active_condition = None  # To track if we are inside an if_eq block
 
         if input_states:
             self.input_states = input_states
@@ -252,6 +254,17 @@ class QubitCircuit:
             for i in targets:
                 self.output_states[i] = state
 
+    @contextmanager
+    def if_eq(self: Self, cbits: int | IntSequence, value: int):
+        previous_condition = self._active_condition
+        self._active_condition = {"type": "if_eq", "bits": cbits, "value": value}
+
+        try:
+            # Yields the control back to the code inside the `with` block
+            yield
+        finally:
+            self._active_condition = previous_condition
+
     def add_op(
         self: Self,
         op: Op,
@@ -263,6 +276,10 @@ class QubitCircuit:
 
         if type(creg) is int:
             creg = [creg]
+
+        if self._active_condition:
+            # Add the conditional branch and label logic
+            pass
 
         # TODO validate the inputs
         self._ops.append(OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg)))

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -100,8 +100,8 @@ class QubitCircuit:
         self._global_phase: float = 0.0
         self._ops: list[Op] = []
         self._instructions: list[CircuitInstruction] = []
+        self._label_counter = 0
         self.dims = dims if dims is not None else [2] * self.num_qubits
-        self._active_condition = None  # To track if we are inside an if_eq block
 
         if input_states:
             self.input_states = input_states
@@ -273,21 +273,23 @@ class QubitCircuit:
         check: ClassicalControlCheck = "EQ",
     ):
         # TODO check the arguments
+        if type(cbits) is int:
+            cbits = [cbits]
 
-        label_name = f"label_{self._label_counter}"
+        label = Label(f"label_{self._label_counter}")
         self._label_counter += 1
 
         for index, cbit in enumerate(cbits):
             if (value >> index) & 1 == 0:
-                self.add_op(Cbnz(label=label_name), creg=cbit)
+                self.add_op(Cbnz(label=label), creg=cbit)
             else:
-                self.add_op(Cbz(label=label_name), creg=cbit)
+                self.add_op(Cbz(label=label), creg=cbit)
 
         # Yields the control back to the code inside the `with` block
         try:
             yield
         finally:
-            self.add_op(Label(label_name))
+            self.add_op(label)
 
     def add_op(
         self: Self,
@@ -313,26 +315,28 @@ class QubitCircuit:
         for op_instruction in self._ops:
             op = op_instruction.op
             if isinstance(op, Label):
-                self._instructions.append(LabelInstruction(op_instruction.op))
+                self._instructions.append(LabelInstruction(operation=op))
 
             elif isinstance(op, Conditional):
                 self._instructions.append(
-                    ConditionalBranchInstruction(operation=op, cbits=op.creg)
-                )
-
-            elif isinstance(op, Gate) or issubclass(op, Gate):
-                self._instructions.append(
-                    GateInstruction(
-                        operation=op_instruction.op,
-                        qubits=op_instruction.qreg,
-                        cbits=op_instruction.creg,
+                    ConditionalBranchInstruction(
+                        operation=op, cbits=op_instruction.creg
                     )
                 )
 
             elif isinstance(op, Measurement) or issubclass(op, Measurement):
                 self._instructions.append(
                     MeasurementInstruction(
-                        operation=op_instruction.op,
+                        operation=op,
+                        qubits=op_instruction.qreg,
+                        cbits=op_instruction.creg,
+                    )
+                )
+
+            elif isinstance(op, Gate) or issubclass(op, Gate):
+                self._instructions.append(
+                    GateInstruction(
+                        operation=op,
                         qubits=op_instruction.qreg,
                         cbits=op_instruction.creg,
                     )

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -329,7 +329,15 @@ class QubitCircuit:
                     )
                 )
 
-            # TODO handle measurement op
+            elif isinstance(op, Measurement) or issubclass(op, Measurement):
+                self._instructions.append(
+                    MeasurementInstruction(
+                        operation=op_instruction.op,
+                        qubits=op_instruction.qreg,
+                        cbits=op_instruction.creg,
+                    )
+                )
+
             # TODO handle non-gate/non-measurement op
 
         self._instructions = tuple(self._instructions)

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -293,7 +293,7 @@ class QubitCircuit:
         if check == ClassicalControlCheck.EQ:
             for index, cbit in enumerate(cbits):
                 if (value >> index) & 1 == 1:
-                    # If does not match for cbit_value=1, then branch to label (don't execute the condiitonal if)
+                    # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
                     self.add_op(Cbz(label=label), creg=cbit)
                 else:
                     # If does not match for cbit_value=0, then branch to label

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -276,6 +276,8 @@ class QubitCircuit:
         if type(cbits) is int:
             cbits = [cbits]
 
+        # TODO Implement other checks
+
         label = Label(f"label_{self._label_counter}")
         self._label_counter += 1
 
@@ -324,7 +326,9 @@ class QubitCircuit:
                     )
                 )
 
-            elif isinstance(op, Measurement) or issubclass(op, Measurement):
+            elif isinstance(op, Measurement) or (
+                isinstance(op, type) and issubclass(op, Measurement)
+            ):
                 self._instructions.append(
                     MeasurementInstruction(
                         operation=op,
@@ -333,7 +337,9 @@ class QubitCircuit:
                     )
                 )
 
-            elif isinstance(op, Gate) or issubclass(op, Gate):
+            elif isinstance(op, Gate) or (
+                isinstance(op, type) and issubclass(op, Gate)
+            ):
                 self._instructions.append(
                     GateInstruction(
                         operation=op,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -21,8 +21,8 @@ from qutip_qip.circuit._decompose import (
     _resolve_to_universal,
     _resolve_2q_basis,
 )
+from qutip_qip.circuit.conditional import Cbnz, Cbz, Label
 from qutip_qip.operations import (
-    Bloq,
     Gate,
     Measurement,
     Op,
@@ -228,6 +228,8 @@ class QubitCircuit:
     def instructions(self) -> list[CircuitInstruction]:
         return self._instructions
 
+    # TODO: Add method to add auxilary qubits
+
     def add_state(
         self,
         state: str,
@@ -263,7 +265,7 @@ class QubitCircuit:
                 self.output_states[i] = state
 
     @contextmanager
-    def if_eq(
+    def test_if(
         self: Self,
         cbits: int | IntSequence,
         value: int,
@@ -271,17 +273,20 @@ class QubitCircuit:
     ):
         # TODO check the arguments
 
-        previous_condition = self._active_condition
-        self._active_condition = {"bits": cbits, "value": value, "check": check}
+        label_name = f"label_{self._label_counter}"
+        self._label_counter += 1
 
-        # TODO Add the conditional branch and label logic
-        self.add_op()
+        for index, cbit in enumerate(cbits):
+            if (value >> index) & 1 == 0:
+                self.add_op(Cbnz(label=label_name), creg=cbit)
+            else:
+                self.add_op(Cbz(label=label_name), creg=cbit)
 
         # Yields the control back to the code inside the `with` block
-        yield
-
-        self.add_op()
-        self._active_condition = previous_condition
+        try:
+            yield
+        finally:
+            self.add_op(Label(label_name))
 
     def add_op(
         self: Self,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -5,6 +5,7 @@ Quantum circuit representation and simulation.
 import warnings
 import inspect
 from contextlib import contextmanager
+from enum import StrEnum
 from typing import Iterable, Type, Self
 from qutip import qeye, Qobj, basis, tensor
 import numpy as np
@@ -44,6 +45,13 @@ except ImportError:
 
     def DisplaySVG(data, *args, **kwargs):
         return data
+
+
+class ClassicalControlCheck(StrEnum):
+    EQ = "EQ"
+    NEQ = "NEQ"
+    GT = "GT"
+    LT = "LT"
 
 
 class QubitCircuit:
@@ -255,15 +263,25 @@ class QubitCircuit:
                 self.output_states[i] = state
 
     @contextmanager
-    def if_eq(self: Self, cbits: int | IntSequence, value: int):
-        previous_condition = self._active_condition
-        self._active_condition = {"type": "if_eq", "bits": cbits, "value": value}
+    def if_eq(
+        self: Self,
+        cbits: int | IntSequence,
+        value: int,
+        check: ClassicalControlCheck = "EQ",
+    ):
+        # TODO check the arguments
 
-        try:
-            # Yields the control back to the code inside the `with` block
-            yield
-        finally:
-            self._active_condition = previous_condition
+        previous_condition = self._active_condition
+        self._active_condition = {"bits": cbits, "value": value, "check": check}
+
+        # TODO Add the conditional branch and label logic
+        self.add_op()
+
+        # Yields the control back to the code inside the `with` block
+        yield
+
+        self.add_op()
+        self._active_condition = previous_condition
 
     def add_op(
         self: Self,
@@ -276,10 +294,6 @@ class QubitCircuit:
 
         if type(creg) is int:
             creg = [creg]
-
-        if self._active_condition:
-            # Add the conditional branch and label logic
-            pass
 
         # TODO validate the inputs
         self._ops.append(OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg)))

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -316,16 +316,17 @@ class QubitCircuit:
 
         for op_instruction in self._ops:
             op = op_instruction.op
-            if isinstance(op, Label):
-                self._instructions.append(LabelInstruction(operation=op))
 
-            elif isinstance(op, Conditional):
+            if isinstance(op, Gate) or (isinstance(op, type) and issubclass(op, Gate)):
                 self._instructions.append(
-                    ConditionalBranchInstruction(
-                        operation=op, cbits=op_instruction.creg
+                    GateInstruction(
+                        operation=op,
+                        qubits=op_instruction.qreg,
+                        cbits=op_instruction.creg,
                     )
                 )
 
+            # TODO In future Measurement should always just be a class
             elif isinstance(op, Measurement) or (
                 isinstance(op, type) and issubclass(op, Measurement)
             ):
@@ -337,16 +338,15 @@ class QubitCircuit:
                     )
                 )
 
-            elif isinstance(op, Gate) or (
-                isinstance(op, type) and issubclass(op, Gate)
-            ):
+            elif isinstance(op, Conditional):
                 self._instructions.append(
-                    GateInstruction(
-                        operation=op,
-                        qubits=op_instruction.qreg,
-                        cbits=op_instruction.creg,
+                    ConditionalBranchInstruction(
+                        operation=op, cbits=op_instruction.creg
                     )
                 )
+
+            elif isinstance(op, Label):
+                self._instructions.append(LabelInstruction(operation=op))
 
             # TODO handle non-gate/non-measurement op
 

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -291,33 +291,43 @@ class QubitCircuit:
         self._label_counter += 1
 
         if check == ClassicalControlCheck.EQ:
-            for index, cbit in enumerate(cbits):
-                if (value >> index) & 1 == 1:
-                    # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
-                    self.add_op(Cbz(label=label), creg=cbit)
-                else:
-                    # If does not match for cbit_value=0, then branch to label
-                    self.add_op(Cbnz(label=label), creg=cbit)
+            if (value < 0) or (value >= 2 ** len(cbits)):
+                return  # Useless if_test condition
+
+            else:
+                for index, cbit in enumerate(cbits):
+                    if (value >> index) & 1 == 1:
+                        # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
+                        self.add_op(Cbz(label=label), creg=cbit)
+                    else:
+                        # If does not match for cbit_value=0, then branch to label
+                        self.add_op(Cbnz(label=label), creg=cbit)
 
         elif check == ClassicalControlCheck.NEQ:
             neq_label = Label(f"label_{self._label_counter}")
             self._label_counter += 1
 
-            for index, cbit in enumerate(cbits):
-                target_bit_value = (value >> index) & 1
+            if (value < 0) or (value >= 2 ** len(cbits)):
+                # This is an unconditional jump essentially
+                self.add_op(Cbz(label=neq_label), creg=0)
+                self.add_op(Cbnz(label=neq_label), creg=0)
 
-                if target_bit_value == 1:
-                    # If a mismatch match for cbit_value=1, then branch to neqlabel
-                    self.add_op(Cbz(label=neq_label), creg=cbit)
-                else:
-                    self.add_op(Cbnz(label=neq_label), creg=cbit)
+            else:
+                for index, cbit in enumerate(cbits):
+                    target_bit_value = (value >> index) & 1
 
-            # This will only execute if non of the earlier conditional branching executes.
-            # means NEQ is FALSE. We must skip the conditional block.
+                    if target_bit_value == 1:
+                        # If a mismatch match for cbit_value=1, then branch to neqlabel
+                        self.add_op(Cbz(label=neq_label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=neq_label), creg=cbit)
 
-            # This must be preferably replaced Jump statement (unconditional)
-            self.add_op(Cbz(label=label), creg=0)
-            self.add_op(Cbnz(label=label), creg=0)
+                # This will only execute if non of the earlier conditional branching executes.
+                # means NEQ is FALSE. We must skip the conditional block.
+
+                # This must be preferably replaced Jump statement (unconditional)
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
 
             # Successful entry point for the NEQ condition
             self.add_op(neq_label)
@@ -327,7 +337,7 @@ class QubitCircuit:
             if value >= 2 ** len(cbits):  # Never true
                 return
 
-            elif value > 0:  # for value less than 0, condition is always true
+            elif value >= 0:  # for value less than 0, condition is always true
                 gt_label = Label(f"label_{self._label_counter}")
                 self._label_counter += 1
 

--- a/src/qutip_qip/circuit/conditional.py
+++ b/src/qutip_qip/circuit/conditional.py
@@ -8,15 +8,16 @@ class Label(Op):
         self.name = name
 
 
-class Cbz(Op):
-    "Conditional branch on zero"
+class Conditional(Op):
+    """Classical conditional control flow statements"""
 
     def __init__(self, label):
         self.label = label
+
+
+class Cbz(Op):
+    "Conditional branch on zero"
 
 
 class Cbnz(Op):
     "Conditional branch on non-zero i.e. 1."
-
-    def __init__(self, label):
-        self.label = label

--- a/src/qutip_qip/circuit/conditional.py
+++ b/src/qutip_qip/circuit/conditional.py
@@ -1,0 +1,22 @@
+from qutip_qip.operations import Op
+
+
+class Label(Op):
+    """A static marker in the instruction list."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class Cbz(Op):
+    "Conditional branch on zero"
+
+    def __init__(self, label):
+        self.label = label
+
+
+class Cbnz(Op):
+    "Conditional branch on non-zero i.e. 1."
+
+    def __init__(self, label):
+        self.label = label

--- a/src/qutip_qip/circuit/conditional.py
+++ b/src/qutip_qip/circuit/conditional.py
@@ -15,9 +15,9 @@ class Conditional(Op):
         self.label = label
 
 
-class Cbz(Op):
+class Cbz(Conditional):
     "Conditional branch on zero"
 
 
-class Cbnz(Op):
+class Cbnz(Conditional):
     "Conditional branch on non-zero i.e. 1."

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Type
 from dataclasses import dataclass, field
 import warnings
+from qutip_qip.circuit.conditional import Conditional, Label, Cbnz, Cbz
 from qutip_qip.operations import Gate, Measurement, Op
 
 
@@ -18,8 +19,18 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
 
 @dataclass(frozen=True, slots=True)
+class OpInstruction:
+    op: Op
+    qreg: tuple[int, ...] = tuple()
+    creg: tuple[int, ...] = tuple()
+
+    def __post_init__(self):
+        pass
+
+
+@dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
-    operation: Gate | Type[Gate] | Measurement
+    operation: Gate | Type[Gate] | Measurement | Conditional | Label
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
     style: dict = field(default_factory=dict)
@@ -48,7 +59,14 @@ class CircuitInstruction(ABC):
     def is_measurement_instruction() -> bool:
         return False
 
-    @abstractmethod
+    @staticmethod
+    def is_conditional_instruction() -> bool:
+        return False
+
+    @staticmethod
+    def is_label_instrcution() -> bool:
+        return False
+
     def to_qasm(self, qasm_out) -> None:
         raise NotImplementedError
 
@@ -58,16 +76,6 @@ class CircuitInstruction(ABC):
 
     def __repr__(self) -> str:
         return str(self)
-
-
-@dataclass(frozen=True, slots=True)
-class OpInstruction:
-    op: Op
-    qreg: tuple[int, ...] = tuple()
-    creg: tuple[int, ...] = tuple()
-
-    def __post_init__(self):
-        pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,3 +202,40 @@ class MeasurementInstruction(CircuitInstruction):
 
     def __str__(self) -> str:
         return f"Measure(q{self.qubits} -> c{self.cbits})"
+
+
+class ConditionalBranchInstruction(CircuitInstruction):
+    operation: Conditional
+
+    def __post_init__(self) -> None:
+        super(ConditionalBranchInstruction, self).__post_init__()
+        if not isinstance(self.operation, Cbz) or not isinstance(self.operation, Cbnz):
+            raise TypeError(
+                f"Operation must be conditional branch, got {type(self.operation)}"
+            )
+
+        if (type(self.cbits) is not int) or (self.cbits < 0):
+            raise ValueError("Cbit must be a non-negative integer.")
+
+    @staticmethod
+    def is_conditional_instruction() -> bool:
+        return True
+
+    def __str__(self) -> str:
+        return f"{self.operation}(cbit={self.cbits})"
+
+
+class LabelInstruction(CircuitInstruction):
+    operation: Label
+
+    def __post_init__(self) -> None:
+        super(LabelInstruction, self).__post_init__()
+        if not isinstance(self.operation, Label):
+            raise TypeError(f"Operation must be label, got {type(self.operation)}")
+
+    @staticmethod
+    def is_label_instruction() -> bool:
+        return True
+
+    def __str__(self) -> str:
+        return str(self.operation)

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -215,9 +215,7 @@ class ConditionalBranchInstruction(CircuitInstruction):
             )
 
         if len(self.cbits) != 1:
-            raise ValueError(
-                "Conditional Branch instruction must be on a single qubit."
-            )
+            raise ValueError("Conditional Branch instruction must be on a single cbit.")
 
     @staticmethod
     def is_conditional_instruction() -> bool:

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -61,7 +61,7 @@ class CircuitInstruction(ABC):
         return False
 
     @staticmethod
-    def is_label_instrcution() -> bool:
+    def is_label_instruction() -> bool:
         return False
 
     def to_qasm(self, qasm_out) -> None:
@@ -209,7 +209,7 @@ class ConditionalBranchInstruction(CircuitInstruction):
 
     def __post_init__(self) -> None:
         super(ConditionalBranchInstruction, self).__post_init__()
-        if not isinstance(self.operation, Cbz) or not isinstance(self.operation, Cbnz):
+        if not (isinstance(self.operation, Cbz) or isinstance(self.operation, Cbnz)):
             raise TypeError(
                 f"Operation must be conditional branch, got {type(self.operation)}"
             )

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -204,6 +204,7 @@ class MeasurementInstruction(CircuitInstruction):
         return f"Measure(q{self.qubits} -> c{self.cbits})"
 
 
+@dataclass(frozen=True, slots=True)
 class ConditionalBranchInstruction(CircuitInstruction):
     operation: Conditional
 
@@ -225,6 +226,7 @@ class ConditionalBranchInstruction(CircuitInstruction):
         return f"{self.operation}(cbit={self.cbits})"
 
 
+@dataclass(frozen=True, slots=True)
 class LabelInstruction(CircuitInstruction):
     operation: Label
 

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -23,6 +23,8 @@ class OpInstruction:
     op: Op
     qreg: tuple[int, ...] = tuple()
     creg: tuple[int, ...] = tuple()
+    # TODO add a style here instead of circuit instruction
+    # TODO move the circuit draw functionality based on Op then CircuitInstructions
 
     def __post_init__(self):
         pass
@@ -37,11 +39,6 @@ class CircuitInstruction(ABC):
 
     def __post_init__(self):
         """Basic validation for all instructions."""
-        if not len(self.qubits) and not len(self.cbits):
-            raise ValueError(
-                "Circuit Instruction must operate on at least one qubit or cbit."
-            )
-
         _validate_non_negative_int_tuple(self.qubits, "qubit")
         _validate_non_negative_int_tuple(self.cbits, "cbit")
 
@@ -189,6 +186,9 @@ class MeasurementInstruction(CircuitInstruction):
         if not isinstance(self.operation, Measurement):
             raise TypeError(f"Operation must be a measurement, got {self.operation}")
 
+        if (not len(self.qubits)) or (not len(self.cbits)):
+            raise ValueError("qubits or cbits arguments can't be empty")
+
         if len(self.qubits) != len(self.cbits):
             raise ValueError("Measurement requires equal number of qubits and cbits.")
 
@@ -214,8 +214,10 @@ class ConditionalBranchInstruction(CircuitInstruction):
                 f"Operation must be conditional branch, got {type(self.operation)}"
             )
 
-        if (type(self.cbits) is not int) or (self.cbits < 0):
-            raise ValueError("Cbit must be a non-negative integer.")
+        if len(self.cbits) != 1:
+            raise ValueError(
+                "Conditional Branch instruction must be on a single qubit."
+            )
 
     @staticmethod
     def is_conditional_instruction() -> bool:

--- a/src/qutip_qip/circuit/label.py
+++ b/src/qutip_qip/circuit/label.py
@@ -1,8 +1,0 @@
-from qutip_qip.operations import Op
-
-
-class Label(Op):
-    """A static marker in the instruction list."""
-
-    def __init__(self, name):
-        self.name = name

--- a/src/qutip_qip/circuit/label.py
+++ b/src/qutip_qip/circuit/label.py
@@ -1,0 +1,8 @@
+from qutip_qip.operations import Op
+
+
+class Label(Op):
+    """A static marker in the instruction list."""
+
+    def __init__(self, name):
+        self.name = name

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -224,28 +224,8 @@ class CircuitSimulator:
         """
 
         current_instruction = self.qc.instructions[self._op_index]
-        if current_instruction.is_label_instruction():
-            pass
 
-        elif current_instruction.is_conditional_instruction():
-            op = current_instruction.operation
-            label_name = op.label.name
-
-            if (
-                isinstance(op, Cbz) and self.cbits[current_instruction.cbits[0]] == 0
-            ) or (
-                isinstance(op, Cbnz) and self.cbits[current_instruction.cbits[0]] == 1
-            ):
-                self._op_index = self._label_map[label_name]
-
-        elif current_instruction.is_measurement_instruction():
-            targets = current_instruction.qubits
-            classical_store = current_instruction.cbits
-            self._state = self._apply_measurement(
-                current_instruction.operation, targets, classical_store
-            )
-
-        elif current_instruction.is_gate_instruction():
+        if current_instruction.is_gate_instruction():
             gate = current_instruction.operation
             qubits = current_instruction.qubits
             classical_controls = current_instruction.cbits
@@ -265,6 +245,27 @@ class CircuitSimulator:
                 self._state = self._evolve_state_einsum(gate, qubits, self._state)
             else:
                 self._state = self._evolve_state(gate, qubits, self._state)
+
+        elif current_instruction.is_measurement_instruction():
+            targets = current_instruction.qubits
+            classical_store = current_instruction.cbits
+            self._state = self._apply_measurement(
+                current_instruction.operation, targets, classical_store
+            )
+
+        elif current_instruction.is_conditional_instruction():
+            op = current_instruction.operation
+            label_name = op.label.name
+
+            if (
+                isinstance(op, Cbz) and self.cbits[current_instruction.cbits[0]] == 0
+            ) or (
+                isinstance(op, Cbnz) and self.cbits[current_instruction.cbits[0]] == 1
+            ):
+                self._op_index = self._label_map[label_name]
+
+        elif current_instruction.is_label_instruction():
+            pass
 
         else:
             raise ValueError(f"Invalid operation {current_instruction}")

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -5,7 +5,7 @@ from typing import Self
 import numpy as np
 
 from qutip import ket2dm, Qobj
-from qutip_qip.circuit.conditional import Cbz, Cbnz, Label
+from qutip_qip.circuit.conditional import Cbz, Cbnz
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -1,9 +1,11 @@
+from functools import reduce
 from itertools import product
 from operator import mul
-from functools import reduce
+from typing import Self
 import numpy as np
 
 from qutip import ket2dm, Qobj
+from qutip_qip.circuit.conditional import Cbz, Cbnz, Label
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator
 
@@ -58,6 +60,11 @@ class CircuitSimulator:
         self._qc = qc
         self.dims = qc.dims
         self.mode = mode
+        self._label_map = {
+            op.name: index
+            for index, op in enumerate(qc.instructions)
+            if isinstance(op, Label)
+        }
 
     @property
     def qc(self):
@@ -209,32 +216,39 @@ class CircuitSimulator:
 
         return CircuitResult(states, probabilities, cbits_results)
 
-    def step(self):
+    def step(self: Self) -> None:
         """
         Return state after one step of circuit evolution
         (gate or measurement).
-
-        Returns
-        -------
-        state : ket or oper
-            state after one evolution step.
         """
 
-        circ_instruction = self.qc.instructions[self._op_index]
-        current_state = self._state
+        current_instruction = self.qc.instructions[self._op_index]
+        if current_instruction.is_label_instruction():
+            pass
 
-        if self.qc.instructions[self._op_index].is_measurement_instruction():
-            targets = circ_instruction.qubits
-            classical_store = circ_instruction.cbits
-            state = self._apply_measurement(
-                circ_instruction.operation, targets, classical_store
+        elif current_instruction.is_conditional_instruction():
+            op = current_instruction.operation
+            label_name = op.label.name
+
+            if (
+                isinstance(op, Cbz) and self.cbits[current_instruction.cbits[0]] == 0
+            ) or (
+                isinstance(op, Cbnz) and self.cbits[current_instruction.cbits[0]] == 1
+            ):
+                self._op_index = self._label_map[label_name]
+
+        elif current_instruction.is_measurement_instruction():
+            targets = current_instruction.qubits
+            classical_store = current_instruction.cbits
+            self._state = self._apply_measurement(
+                current_instruction.operation, targets, classical_store
             )
 
-        elif self.qc.instructions[self._op_index].is_gate_instruction():
-            gate = circ_instruction.operation
-            qubits = circ_instruction.qubits
-            classical_controls = circ_instruction.cbits
-            classical_control_value = circ_instruction.cbits_ctrl_value
+        elif current_instruction.is_gate_instruction():
+            gate = current_instruction.operation
+            qubits = current_instruction.qubits
+            classical_controls = current_instruction.cbits
+            classical_control_value = current_instruction.cbits_ctrl_value
 
             if len(classical_controls) > 0:
                 apply_gate = _check_classical_control_value(
@@ -247,16 +261,13 @@ class CircuitSimulator:
                 self._op_index += 1
                 return
             if self.mode == "state_vector_simulator":
-                state = self._evolve_state_einsum(gate, qubits, current_state)
+                self._state = self._evolve_state_einsum(gate, qubits, self._state)
             else:
-                state = self._evolve_state(gate, qubits, current_state)
+                self._state = self._evolve_state(gate, qubits, self._state)
 
         else:
-            raise ValueError(
-                f"Invalid operation {self.qc.instructions[self._op_index]}"
-            )
+            raise ValueError(f"Invalid operation {current_instruction}")
 
-        self._state = state
         self._op_index += 1
 
     def _evolve_state(self, operation, targets_indices, state):

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -61,9 +61,9 @@ class CircuitSimulator:
         self.dims = qc.dims
         self.mode = mode
         self._label_map = {
-            circ_instrcution.operation.name: index
-            for index, circ_instrcution in enumerate(qc.instructions)
-            if circ_instrcution.is_label_instruction()
+            circ_instruction.operation.name: index
+            for index, circ_instruction in enumerate(qc.instructions)
+            if circ_instruction.is_label_instruction()
         }
 
     @property

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -61,9 +61,9 @@ class CircuitSimulator:
         self.dims = qc.dims
         self.mode = mode
         self._label_map = {
-            op.name: index
-            for index, op in enumerate(qc.instructions)
-            if isinstance(op, Label)
+            circ_instrcution.operation.name: index
+            for index, circ_instrcution in enumerate(qc.instructions)
+            if circ_instrcution.is_label_instruction()
         }
 
     @property
@@ -166,7 +166,8 @@ class CircuitSimulator:
         """
         self.initialize(state, cbits, measure_results)
 
-        for _ in range(len(self._qc.instructions)):
+        num_instructions = len(self.qc.instructions)
+        while self._op_index < num_instructions:
             self.step()
             if self._state is None:
                 # TODO This only happens if there is predefined post-selection on the measurement results and the measurement results is exactly 0. This needs to be improved.

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -375,6 +375,24 @@ class TestQubitCircuit:
         assert qc.instructions[3].controls == (1,)
         assert qc.instructions[1].controls == (0,)
 
+    def test_classical_control_flow(self):
+        qc = QubitCircuit(num_qubits=2, num_cbits=1)
+
+        qc.add_op(gates.H, qreg=0)
+        qc.add_op(gates.CX, qreg=(0, 1))
+        qc.add_op(Mz, qreg=0, creg=0)
+
+        cbit = 0
+        with qc.test_if(cbit, 1):
+            qc.add_op(gates.X, qreg=0)
+            qc.add_op(gates.X, qreg=1)
+
+        qc.build()
+
+        result = qc.run()
+        fid = qutip.fidelity(result, basis(4, 0))
+        assert pytest.approx(fid, 1.0e-6) == 1
+
     def test_reverse(self):
         """
         Reverse a quantum circuit
@@ -897,10 +915,6 @@ class TestInstructionErrors:
 
             def __str__(self):
                 return ""
-
-        with pytest.raises(ValueError):
-            # Circuit Instruction must operate on at least one qubit or cbit
-            MockInstruction("gate", qubits=(), cbits=())
 
         with pytest.raises(TypeError):
             MockInstruction(

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -375,7 +375,7 @@ class TestQubitCircuit:
         assert qc.instructions[3].controls == (1,)
         assert qc.instructions[1].controls == (0,)
 
-    def test_classical_control_flow(self):
+    def test_classical_control_flow_eq(self):
         qc = QubitCircuit(num_qubits=2, num_cbits=1)
 
         qc.add_op(gates.H, qreg=0)
@@ -383,7 +383,43 @@ class TestQubitCircuit:
         qc.add_op(Mz, qreg=0, creg=0)
 
         cbit = 0
-        with qc.test_if(cbit, 1):
+        with qc.if_test(cbit, 1):
+            qc.add_op(gates.X, qreg=0)
+            qc.add_op(gates.X, qreg=1)
+
+        qc.build()
+
+        result = qc.run()
+        fid = qutip.fidelity(result, basis(4, 0))
+        assert pytest.approx(fid, 1.0e-6) == 1
+
+    def test_classical_control_flow_neq(self):
+        qc = QubitCircuit(num_qubits=2, num_cbits=1)
+
+        qc.add_op(gates.H, qreg=0)
+        qc.add_op(gates.CX, qreg=(0, 1))
+        qc.add_op(Mz, qreg=0, creg=0)
+
+        cbit = 0
+        with qc.if_test(cbit, 0, "NEQ"):
+            qc.add_op(gates.X, qreg=0)
+            qc.add_op(gates.X, qreg=1)
+
+        qc.build()
+
+        result = qc.run()
+        fid = qutip.fidelity(result, basis(4, 0))
+        assert pytest.approx(fid, 1.0e-6) == 1
+
+    def test_classical_control_flow_gt(self):
+        qc = QubitCircuit(num_qubits=2, num_cbits=1)
+
+        qc.add_op(gates.H, qreg=0)
+        qc.add_op(gates.CX, qreg=(0, 1))
+        qc.add_op(Mz, qreg=0, creg=0)
+
+        cbit = 0
+        with qc.if_test(cbit, 0, "GT"):
             qc.add_op(gates.X, qreg=0)
             qc.add_op(gates.X, qreg=1)
 


### PR DESCRIPTION
**Description**
This PR adds Classical control statements based of conditional branching and labels as done in assembly. Instead of adding a `ClassicallyControlledOp` or an argument to the `add_op` method, with context manager is used and is allowed to be nested. Example:

```
with qc.test_if((bit_1, bit_3), 0b11):
    qc.add_op(H, qreg=1)
```

This should also allow one to have multiple add_op statements within the same classical control condition without duplication that would have occurred in case of argument or ClassicallyControlledOp

Label, Conditional Branching are added to the fundamental `CircuitInstruction` and will in future serve as the fundamental instruction for any Quantum Program (basically QuantumAssembly Instruction) and hence won't be exposed to the user, only the general `OpInstruction` will be exposed to user.

@BoxiLi In the next PR I was planning on moving circuit draw from Gates, Measurements to Ops. This should free up the `style` attribute we current have in our `CircuitInstruction` class.

**Related issues or PRs**
None

**AI Tools Usage Disclosure**
None