### PR TITLE
Fix failing CI job on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         with:
           flag-name: run-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.case-name }}
           parallel: true


### PR DESCRIPTION
**Description**
homebrew 6 was released last month rwhich equires explicitly trusting third-party repositories (taps) before installing packages from them (coveralls is considered third party). Github runner for macOS also [moved]((https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md?utm_cta=website-prefooter-start-for-free)) recently to brew 6 which is why the CI job was failing. 

Added an environment variable to disable requirement of tap trust (we have repo ready-only permissions set for all CI jobs already, so this is not a security concern for us).

**Related issues or PRs**
None

**AI Tools Usage Disclosure**
Gemini 3.1 Pro: for recommended ways to resolve the error