### PR TITLE
Circuit op draw

### DIFF
--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -52,11 +52,11 @@ A circuit with the various gates and registers available is demonstrated below:
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
 
-    [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,), style={}),
-      GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), style=None, cbits_ctrl_value=1),
-      GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None)]
+    [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
+      MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,)),
+      GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
+      GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), cbits_ctrl_value=1),
+      GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None)]
 
 Unitaries
 =========

--- a/src/qutip_qip/circuit/_decompose.py
+++ b/src/qutip_qip/circuit/_decompose.py
@@ -31,7 +31,6 @@ def _gate_IGNORED(circ_instruction, temp_resolved):
         controls=controls,
         classical_controls=circ_instruction.cbits,
         classical_control_value=circ_instruction.cbits_ctrl_value,
-        style=circ_instruction.style,
     )
 
 
@@ -335,7 +334,6 @@ def _basis_CZ(qc_temp, temp_resolved):
                 controls=controls,
                 classical_controls=circ_instruction.cbits,
                 classical_control_value=circ_instruction.cbits_ctrl_value,
-                style=circ_instruction.style,
             )
 
 
@@ -400,7 +398,6 @@ def _basis_ISWAP(qc_temp, temp_resolved):
                 controls=controls,
                 classical_controls=circ_instruction.cbits,
                 classical_control_value=circ_instruction.cbits_ctrl_value,
-                style=circ_instruction.style,
             )
 
 
@@ -441,7 +438,6 @@ def _basis_SQRTSWAP(qc_temp, temp_resolved):
                 controls=controls,
                 classical_controls=circ_instruction.cbits,
                 classical_control_value=circ_instruction.cbits_ctrl_value,
-                style=circ_instruction.style,
             )
 
 

--- a/src/qutip_qip/circuit/_decompose.py
+++ b/src/qutip_qip/circuit/_decompose.py
@@ -484,7 +484,6 @@ def _basis_SQRTISWAP(qc_temp, temp_resolved):
                 controls=controls,
                 classical_controls=circ_instruction.cbits,
                 classical_control_value=circ_instruction.cbits_ctrl_value,
-                style=circ_instruction.style,
             )
 
 

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -697,7 +697,6 @@ class QubitCircuit:
                 qubits=tuple(qubits),
                 cbits=tuple(classical_controls),
                 cbits_ctrl_value=classical_control_value,
-                style=style,
             )
         )
 
@@ -735,7 +734,6 @@ class QubitCircuit:
                     controls=[start + c for c in circuit_op.controls],
                     classical_controls=circuit_op.cbits,
                     classical_control_value=circuit_op.cbits_ctrl_value,
-                    style=circuit_op.style,
                 )
 
             elif circuit_op.is_measurement_instruction():
@@ -834,7 +832,6 @@ class QubitCircuit:
                     controls=circ_instruction.controls,
                     classical_controls=circ_instruction.cbits,
                     classical_control_value=circ_instruction.cbits_ctrl_value,
-                    style=circ_instruction.style,
                 )
 
             elif circ_instruction.is_measurement_instruction():
@@ -1009,7 +1006,6 @@ class QubitCircuit:
                             controls=controls,
                             classical_controls=circ_instruction.cbits,
                             classical_control_value=circ_instruction.cbits_ctrl_value,
-                            style=circ_instruction.style,
                         )
                     else:
                         exception = f"Gate {gate.name} cannot be resolved."
@@ -1085,7 +1081,6 @@ class QubitCircuit:
                     controls=controls,
                     classical_controls=circ_instruction.cbits,
                     classical_control_value=circ_instruction.cbits_ctrl_value,
-                    style=circ_instruction.style,
                 )
 
         return qc_temp

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -513,6 +513,14 @@ class QubitCircuit:
             )
         )
 
+        self._ops.append(
+            OpInstruction(
+                op=measurement,
+                qreg=tuple(targets),
+                creg=tuple(classical_store),
+            )
+        )
+
     def add_gate(
         self,
         gate: Gate | Type[Gate] | str,
@@ -692,6 +700,18 @@ class QubitCircuit:
                 style=style,
             )
         )
+
+        instruction = OpInstruction(
+            op=gate,
+            qreg=tuple(qubits),
+            style=style,
+        )
+
+        if len(classical_controls) > 0:
+            with self.if_test(classical_controls, classical_control_value):
+                self._ops.append(instruction)
+        else:
+            self._ops.append(instruction)
 
     def add_circuit(self, qc, start=0):  # TODO Instead of start have a qubit mapping?
         """

--- a/src/qutip_qip/circuit/draw/_control_flow.py
+++ b/src/qutip_qip/circuit/draw/_control_flow.py
@@ -1,0 +1,82 @@
+from qutip_qip.circuit.conditional import Cbnz, Cbz, Conditional, Label
+
+
+def _is_unconditional_pair(instructions, index):
+    """Check for the Cbz/Cbnz pair used to represent an unconditional jump."""
+    if index + 1 >= len(instructions):
+        return False
+
+    first = instructions[index]
+    second = instructions[index + 1]
+    return (
+        {type(first.op), type(second.op)} == {Cbz, Cbnz}
+        and first.op.label is second.op.label
+        and first.creg == second.creg
+    )
+
+
+def infer_classical_controls(instructions):
+    """Infer the classical controls active at each operation.
+
+    Conditional control flow is represented by branches around a sequence of
+    operations instead of metadata on each gate.  This function maps that
+    control flow back to the classical wires that control each operation for
+    use by circuit renderers.
+    """
+    instructions = tuple(instructions)
+    controls = [set() for _ in instructions]
+    label_positions = {
+        id(instruction.op): index
+        for index, instruction in enumerate(instructions)
+        if isinstance(instruction.op, Label)
+    }
+
+    unconditional_pairs = []
+    unconditional_indices = set()
+    for index in range(len(instructions) - 1):
+        if _is_unconditional_pair(instructions, index):
+            target = label_positions.get(id(instructions[index].op.label))
+            if target is not None:
+                unconditional_pairs.append((index, target))
+                unconditional_indices.update((index, index + 1))
+
+    # A regular forward branch controls every operation it can skip.
+    for index, instruction in enumerate(instructions):
+        if not isinstance(instruction.op, Conditional):
+            continue
+        if index in unconditional_indices:
+            continue
+
+        target = label_positions.get(id(instruction.op.label))
+        if target is None or target <= index:
+            continue
+
+        for controlled_index in range(index + 1, target):
+            controls[controlled_index].update(instruction.creg)
+
+    # NEQ/GT/LT enter their body through an intermediate label and use an
+    # unconditional pair to skip to the final label.  Include every condition
+    # evaluated in that prelude on each operation in the body.
+    for pair_index, exit_index in unconditional_pairs:
+        entry_index = pair_index + 2
+        if entry_index >= exit_index:
+            continue
+        if not isinstance(instructions[entry_index].op, Label):
+            continue
+
+        condition_controls = set()
+        prelude_index = pair_index - 1
+        while prelude_index >= 0 and isinstance(
+            instructions[prelude_index].op, Conditional
+        ):
+            if prelude_index not in unconditional_indices:
+                condition_controls.update(instructions[prelude_index].creg)
+            prelude_index -= 1
+
+        if not condition_controls:
+            continue
+
+        for controlled_index in range(entry_index + 1, exit_index):
+            controls[controlled_index].update(condition_controls)
+
+    return [tuple(sorted(control)) for control in controls]

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -775,7 +775,7 @@ class MatRenderer(BaseRenderer):
             ):
                 cbits = tuple(sorted(set(cbits).union(classical_controls[index])))
                 gate = op
-                controls = ()
+                controls = []
                 targets = qubits
 
                 if gate.is_controlled:

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -15,6 +15,7 @@ from matplotlib.patches import (
 
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.circuit.draw import BaseRenderer, StyleConfig
+from qutip_qip.circuit.draw._control_flow import infer_classical_controls
 from qutip_qip.operations import Gate, Measurement
 from qutip_qip.operations import gates as std
 
@@ -746,8 +747,9 @@ class MatRenderer(BaseRenderer):
         """
 
         self._add_wire_labels()
+        classical_controls = infer_classical_controls(self._qc._ops)
 
-        for instruction in self._qc._ops:
+        for index, instruction in enumerate(self._qc._ops):
             op = instruction.op
             qubits = instruction.qreg
             cbits = instruction.creg
@@ -771,6 +773,7 @@ class MatRenderer(BaseRenderer):
             elif isinstance(op, Gate) or (
                 isinstance(op, type) and issubclass(op, Gate)
             ):
+                cbits = tuple(sorted(set(cbits).union(classical_controls[index])))
                 gate = op
                 controls = ()
                 targets = qubits

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -15,7 +15,7 @@ from matplotlib.patches import (
 
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.circuit.draw import BaseRenderer, StyleConfig
-from qutip_qip.operations import Gate
+from qutip_qip.operations import Gate, Measurement
 from qutip_qip.operations import gates as std
 
 
@@ -747,13 +747,15 @@ class MatRenderer(BaseRenderer):
 
         self._add_wire_labels()
 
-        for instruction in self._qc.instructions:
-            gate = instruction.operation
-            qubits = instruction.qubits
-            cbits = instruction.cbits
+        for instruction in self._qc._ops:
+            op = instruction.op
+            qubits = instruction.qreg
+            cbits = instruction.creg
             style = instruction.style
 
-            if instruction.is_measurement_instruction():
+            if isinstance(op, Measurement) or (
+                isinstance(op, type) and issubclass(op, Measurement)
+            ):
                 self.merged_wires = list(qubits)
                 self.merged_wires.sort()
 
@@ -766,9 +768,17 @@ class MatRenderer(BaseRenderer):
                     ),
                 )
 
-            if instruction.is_gate_instruction():
-                targets = instruction.targets
-                controls = instruction.controls
+            elif isinstance(op, Gate) or (
+                isinstance(op, type) and issubclass(op, Gate)
+            ):
+                gate = op
+                controls = ()
+                targets = qubits
+
+                if gate.is_controlled:
+                    controls = qubits[: gate.num_ctrl_qubits]
+                    targets = qubits[gate.num_ctrl_qubits :]
+
                 style = style if style is not None else {}
                 self.text = gate.name
 

--- a/src/qutip_qip/circuit/draw/texrenderer.py
+++ b/src/qutip_qip/circuit/draw/texrenderer.py
@@ -9,6 +9,7 @@ from typing import Callable
 
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.operations import gates as std
+from qutip_qip.operations import Gate, Measurement
 
 
 # As a general note wherever you see {{}} in a python rf string that represents a {}
@@ -25,7 +26,7 @@ class TeXRenderer:
         self.qc = qc
         self.num_qubits = qc.num_qubits
         self.num_cbits = qc.num_cbits
-        self.instructions = qc.instructions
+        self.instructions = qc._ops
         self.input_states = qc.input_states
         self.reverse_states = qc.reverse_states
 
@@ -60,12 +61,20 @@ class TeXRenderer:
         rows = []
         col = []
 
-        for circ_instruction in self.instructions:
-            if circ_instruction.is_gate_instruction():
-                gate = circ_instruction.operation
-                targets = circ_instruction.targets
-                controls = circ_instruction.controls
-                cbits = circ_instruction.cbits
+        for op_instruction in self.instructions:
+            op = op_instruction.op
+            qubits = op_instruction.qreg
+            cbits = op_instruction.creg
+
+            if isinstance(op, Gate) or (isinstance(op, type) and issubclass(op, Gate)):
+                gate = op
+                targets = qubits
+                controls = ()
+
+                if gate.is_controlled:
+                    controls = qubits[: gate.num_ctrl_qubits]
+                    targets = qubits[gate.num_ctrl_qubits :]
+
                 col = []
                 _swap_processing = False
 
@@ -125,9 +134,9 @@ class TeXRenderer:
                     else:
                         col.append(r" \qw ")
 
-            else:
-                qubits = list(circ_instruction.qubits)
-                cbits = list(circ_instruction.cbits)
+            elif isinstance(op, Measurement) or (
+                isinstance(op, type) and issubclass(op, Measurement)
+            ):
                 col = []
 
                 for n in range(self.num_qubits + self.num_cbits):

--- a/src/qutip_qip/circuit/draw/texrenderer.py
+++ b/src/qutip_qip/circuit/draw/texrenderer.py
@@ -72,7 +72,7 @@ class TeXRenderer:
                 cbits = tuple(sorted(set(cbits).union(classical_controls[index])))
                 gate = op
                 targets = qubits
-                controls = ()
+                controls = []
 
                 if gate.is_controlled:
                     controls = qubits[: gate.num_ctrl_qubits]

--- a/src/qutip_qip/circuit/draw/texrenderer.py
+++ b/src/qutip_qip/circuit/draw/texrenderer.py
@@ -8,6 +8,7 @@ import collections
 from typing import Callable
 
 from qutip_qip.circuit import QubitCircuit
+from qutip_qip.circuit.draw._control_flow import infer_classical_controls
 from qutip_qip.operations import gates as std
 from qutip_qip.operations import Gate, Measurement
 
@@ -60,13 +61,15 @@ class TeXRenderer:
 
         rows = []
         col = []
+        classical_controls = infer_classical_controls(self.instructions)
 
-        for op_instruction in self.instructions:
+        for index, op_instruction in enumerate(self.instructions):
             op = op_instruction.op
             qubits = op_instruction.qreg
             cbits = op_instruction.creg
 
             if isinstance(op, Gate) or (isinstance(op, type) and issubclass(op, Gate)):
+                cbits = tuple(sorted(set(cbits).union(classical_controls[index])))
                 gate = op
                 targets = qubits
                 controls = ()
@@ -149,6 +152,11 @@ class TeXRenderer:
                     else:
                         col.append(r" \qw ")
 
+            else:
+                # Labels and branches affect execution but do not occupy a
+                # column in a circuit diagram.
+                continue
+
             col.append(r" \qw ")
             rows.append(col)
 
@@ -170,8 +178,8 @@ class TeXRenderer:
         )
         for n in n_iter:
             code += rf" & {input_states[n]}"
-            for m in range(len(self.instructions)):
-                code += rf" & {rows[m][n]}"
+            for row in rows:
+                code += rf" & {row[n]}"
             code += r" & \qw \\ " + "\n"
 
         return self._latex_template % code

--- a/src/qutip_qip/circuit/draw/text_renderer.py
+++ b/src/qutip_qip/circuit/draw/text_renderer.py
@@ -7,6 +7,7 @@ from typing import Type
 
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.circuit.draw import BaseRenderer, StyleConfig
+from qutip_qip.circuit.draw._control_flow import infer_classical_controls
 from qutip_qip.operations import Gate, Measurement
 from qutip_qip.operations import gates as std
 
@@ -396,8 +397,9 @@ class TextRenderer(BaseRenderer):
         Layout the circuit
         """
         self._add_wire_labels()
+        classical_controls = infer_classical_controls(self._qc._ops)
 
-        for op_instruction in self._qc._ops:
+        for index, op_instruction in enumerate(self._qc._ops):
             op = op_instruction.op
             qubits = list(op_instruction.qreg)
             cbits = list(op_instruction.creg)
@@ -417,6 +419,7 @@ class TextRenderer(BaseRenderer):
             elif isinstance(op, Gate) or (
                 isinstance(op, type) and issubclass(op, Gate)
             ):
+                cbits = sorted(set(cbits).union(classical_controls[index]))
                 gate = op
                 gate_text = gate.name
                 targets = qubits
@@ -453,6 +456,11 @@ class TextRenderer(BaseRenderer):
                     parts, width = self._draw_multiq_gate(
                         gate, gate_text, targets, controls, cbits
                     )
+
+            else:
+                # Conditional branches and labels affect execution, but have no
+                # visual representation in a circuit diagram.
+                continue
 
             # update the render strings for the operation
             layer = max(len(self._layer_list[i]) for i in wire_list)

--- a/src/qutip_qip/circuit/draw/text_renderer.py
+++ b/src/qutip_qip/circuit/draw/text_renderer.py
@@ -423,7 +423,7 @@ class TextRenderer(BaseRenderer):
                 gate = op
                 gate_text = gate.name
                 targets = qubits
-                controls = targets
+                controls = []
 
                 if gate.is_controlled:
                     controls = qubits[: gate.num_ctrl_qubits]

--- a/src/qutip_qip/circuit/draw/text_renderer.py
+++ b/src/qutip_qip/circuit/draw/text_renderer.py
@@ -7,7 +7,7 @@ from typing import Type
 
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.circuit.draw import BaseRenderer, StyleConfig
-from qutip_qip.operations import Gate
+from qutip_qip.operations import Gate, Measurement
 from qutip_qip.operations import gates as std
 
 
@@ -397,12 +397,15 @@ class TextRenderer(BaseRenderer):
         """
         self._add_wire_labels()
 
-        for circ_instruction in self._qc.instructions:
-            qubits = list(circ_instruction.qubits)
-            cbits = list(circ_instruction.cbits)
+        for op_instruction in self._qc._ops:
+            op = op_instruction.op
+            qubits = list(op_instruction.qreg)
+            cbits = list(op_instruction.creg)
 
             # generate the parts, width and wire_list for the gates
-            if circ_instruction.is_measurement_instruction():
+            if isinstance(op, Measurement) or (
+                isinstance(op, type) and issubclass(op, Measurement)
+            ):
                 wire_list = list(range(qubits[0] + 1)) + list(
                     range(
                         cbits[0] + self._qwires,
@@ -411,11 +414,17 @@ class TextRenderer(BaseRenderer):
                 )
                 parts, width = self._draw_measurement_gate(qubits, cbits)
 
-            elif circ_instruction.is_gate_instruction():
-                gate = circ_instruction.operation
+            elif isinstance(op, Gate) or (
+                isinstance(op, type) and issubclass(op, Gate)
+            ):
+                gate = op
                 gate_text = gate.name
-                targets = list(circ_instruction.targets)
-                controls = list(circ_instruction.controls)
+                targets = qubits
+                controls = targets
+
+                if gate.is_controlled:
+                    controls = qubits[: gate.num_ctrl_qubits]
+                    targets = qubits[gate.num_ctrl_qubits :]
 
                 if gate.is_parametric and gate.arg_label is not None:
                     gate_text = gate.arg_label
@@ -451,11 +460,15 @@ class TextRenderer(BaseRenderer):
             self._adjust_layer_pad(wire_list, xskip)
             self._manage_layers(width, wire_list, layer, xskip)
 
-            if circ_instruction.is_measurement_instruction():
+            if isinstance(op, Measurement) or (
+                isinstance(op, type) and issubclass(op, Measurement)
+            ):
                 self._update_singleq(qubits, parts)
                 self._update_cbridge(qubits, cbits, wire_list, width)
 
-            elif circ_instruction.is_gate_instruction():
+            elif isinstance(op, Gate) or (
+                isinstance(op, type) and issubclass(op, Gate)
+            ):
                 if gate == std.SWAP:
                     self._update_swap_gate(wire_list)
                 else:

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -23,8 +23,7 @@ class OpInstruction:
     op: Op
     qreg: tuple[int, ...] = tuple()
     creg: tuple[int, ...] = tuple()
-    # TODO add a style here instead of circuit instruction
-    # TODO move the circuit draw functionality based on Op then CircuitInstructions
+    style: dict = field(default_factory=dict)
 
     def __post_init__(self):
         pass

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -28,6 +28,8 @@ class OpInstruction:
     def __post_init__(self):
         pass
 
+    # TODO add instructions to test for gate, measurement etc. (used in circuit draw)
+
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -36,7 +36,6 @@ class CircuitInstruction(ABC):
     operation: Gate | Type[Gate] | Measurement | Conditional | Label
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
-    style: dict = field(default_factory=dict)
 
     def __post_init__(self):
         """Basic validation for all instructions."""

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -30,6 +30,9 @@ class OpInstruction:
 
     # TODO add instructions to test for gate, measurement etc. (used in circuit draw)
 
+    def __str__(self):
+        print(f"op={self.op}, qreg={self.qreg}, creg={self.creg}, style({self.style})")
+
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
@@ -174,7 +177,7 @@ class GateInstruction(CircuitInstruction):
 
     def __str__(self) -> str:
         return f"Gate({self.operation}), qubits({self.qubits}),\
-                cbits({self.cbits}), style({self.style})"
+                cbits({self.cbits})"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qutip_qip/transpiler/chain.py
+++ b/src/qutip_qip/transpiler/chain.py
@@ -264,7 +264,6 @@ def to_chain_structure(qc: QubitCircuit, setup="linear"):
                 controls=controls,
                 classical_controls=circ_instruction.cbits,
                 classical_control_value=circ_instruction.cbits_ctrl_value,
-                style=circ_instruction.style,
             )
 
     return qc_t

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -799,6 +799,26 @@ class TestQubitCircuit:
             ]
         )
 
+    @pytest.mark.parametrize(
+        ("check", "value"),
+        [("EQ", 1), ("NEQ", 0), ("GT", 0)],
+    )
+    def test_latex_code_conditional_blocks(self, check, value):
+        qc = QubitCircuit(1, num_cbits=1, reverse_states=True)
+        with qc.if_test(0, value, check):
+            qc.add_op(gates.X, qreg=0)
+            qc.add_op(gates.X, qreg=0)
+
+        renderer = TeXRenderer(qc)
+        latex = renderer.latex_code()
+        assert latex == renderer._latex_template % "\n".join(
+            [
+                r" &  &  \ctrl{1}  &  \ctrl{1}  & \qw \\ ",
+                r" &  &  \gate{X}  &  \gate{X}  & \qw \\ ",
+                "",
+            ]
+        )
+
     H = Qobj([[1 / np.sqrt(2), 1 / np.sqrt(2)], [1 / np.sqrt(2), -1 / np.sqrt(2)]])
     H_zyz_gates = _ZYZ_rotation(H)
     H_zyz_quantum_circuit = QubitCircuit(1)


### PR DESCRIPTION
**Description**
`add_gate`, `add_measurement` also parse now to the _ops list. Circuit draw code has been modified to use `_ops` instead of the previous `qc.instrcutions` list. All the renderers have been modified accordingly.

**Related issues or PRs**
None

**AI Tools Usage Disclosure**
GPT 5.6 Sol in Codex: Only the second last commit (inferring the classical control bits for a gate in the new Conditional branch, Label paradigm)