### PR TITLE
Fix plot_pulses colors on matplotlib 3.11

### DIFF
--- a/src/qutip_qip/device/processor.py
+++ b/src/qutip_qip/device/processor.py
@@ -844,8 +844,13 @@ class Processor:
                 grid = grids[pulse_ind]
                 ax = plt.subplot(grid)
                 axis.append(ax)
-                ax.fill(tlist, coeff, color_list[i], alpha=0.7)
-                ax.plot(tlist, coeff, color_list[i])
+                # The color must be passed as a keyword argument. The third
+                # positional argument is only treated as a format string if it
+                # is a string; since matplotlib 3.11 the default property
+                # cycle yields RGB tuples, which are instead consumed as the
+                # x data of a second line, leaving the pulse itself uncolored.
+                ax.fill(tlist, coeff, color=color_list[i], alpha=0.7)
+                ax.plot(tlist, coeff, color=color_list[i])
                 if rescale_pulse_coeffs:
                     ymax = np.max(np.abs(coeff)) * 1.1
                 else:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -176,6 +176,40 @@ class TestCircuitProcessor:
         # left open, so we politely close it:
         plt.close(fig)
 
+    def test_plot_pulses_group_colors(self):
+        """
+        Each group of pulse labels gets its own color from the property cycle.
+
+        Regression test: matplotlib 3.11 changed the default property cycle to
+        yield RGB tuples rather than hex strings. A tuple passed as the third
+        positional argument of ax.plot is not a format string, so it is taken
+        as the x data of a further line instead of as a color, and every group
+        ends up drawn in the first color of the cycle.
+        """
+        plt = pytest.importorskip("matplotlib.pyplot")
+        from matplotlib.colors import to_rgba
+
+        tlist = np.linspace(0.0, 2 * np.pi, 20)
+        processor = Processor(num_qubits=1, spline_kind="cubic")
+        processor.add_control(sigmaz(), label="sz")
+        processor.add_control(sigmax(), label="sx")
+        processor.set_all_coeffs(
+            {
+                "sz": np.array([np.sin(t) for t in tlist]),
+                "sx": np.array([np.cos(t) for t in tlist]),
+            }
+        )
+        processor.set_all_tlist(tlist)
+
+        # One group per control, so each axis uses a different cycle color.
+        fig, axis = processor.plot_pulses(pulse_labels=[{"sz": "sz"}, {"sx": "sx"}])
+        color_list = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        for ax, expected in zip(axis, color_list):
+            # A stray line would mean the color was consumed as plot data.
+            assert len(ax.get_lines()) == 1
+            assert to_rgba(ax.get_lines()[0].get_color()) == to_rgba(expected)
+        plt.close(fig)
+
     def testSpline(self):
         """
         Test if the spline kind is correctly transferred into


### PR DESCRIPTION
matplotlib 3.11 changed the default `axes.prop_cycle` to yield RGB tuples instead of hex strings. `plot_pulses` passed the cycle color as the third positional argument of `ax.fill/ax.plot`. That slot is only treated as a format string when it is a string, so the tuple was instead consumed as the x data of a further line: the pulse was drawn with no color at all (falling back to the first entry of the cycle, blue) and the requested color was rendered as a spurious three-point line of its own R, G and B values. On all-zero pulse rows, where `plot_pulses` skips `set_ylim`, that stray line autoscaled the axis and showed up as a visible spike.

Pass the color as a keyword argument, which accepts both spellings and so works on all supported matplotlib versions.

Before:
<img width="1190" height="590" alt="image" src="https://github.com/user-attachments/assets/2fdb21ae-da8d-4aec-86b5-8d56fffb5e47" />
After
<img width="1190" height="589" alt="image" src="https://github.com/user-attachments/assets/8b263493-1623-45db-8928-460058f6022b" />

AI usage:
Claude Code Opus 4.8 was used to analyze and fix the bug.
