### PR TITLE
Remove unused set_up_params method

### DIFF
--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -54,7 +54,6 @@ class ModelProcessor(Processor):
         self.transpile_functions = []
         self._default_compiler = None
 
-
     def run_state(
         self, init_state=None, analytical=False, qc=None, states=None, **kwargs
     ):

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -54,16 +54,6 @@ class ModelProcessor(Processor):
         self.transpile_functions = []
         self._default_compiler = None
 
-    def set_up_params(self):
-        """
-        Save the parameters in the attribute `params` and check the validity.
-        (Defined in subclasses)
-
-        Notes
-        -----
-        All parameters will be multiplied by 2*pi for simplicity
-        """
-        raise NotImplementedError("Parameters should be defined in subclass.")
 
     def run_state(
         self, init_state=None, analytical=False, qc=None, states=None, **kwargs


### PR DESCRIPTION
This PR removes the unused set_up_params method from ModelProcessor.

In the discussion in #382, it was found that making the classes abstract is not the right  and set_up_params was found as dead code left over from an earlier cleanup. I verified that the method is not used elsewhere in the codebase, and removed it and confirmed that the test suite still passes.

Testing
Ran the full test suite with pytest.
Tests passed (589 passed, 13 skipped).

AI Tools Usage Disclosure

AI was used to understand the issue and some parts of codebase to get a better idea of what is it doing