### PR TITLE
Op Bloq design

### DIFF
--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -50,14 +50,14 @@ A circuit with the various gates and registers available is demonstrated below:
 **Output**:
 
 .. testoutput::
-  :options: +NORMALIZE_WHITESPACE
+  :options: +NORMALIZE_WHITESPACE +ELLIPSIS
 
     (GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
     MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,)),
     GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
-    ConditionalBranchInstruction(operation=Cbz(_name='Cbz', uuid='d80afec8c954475f888d7ded7ac32217', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=(0,)),
+    ConditionalBranchInstruction(operation=Cbz(_name='Cbz', uuid='...', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=(0,)),
     GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(), cbits_ctrl_value=None),
-    LabelInstruction(operation=Label(_name='5346b421a0ed43b289e56915ae886d4a', uuid='e3e49a682f0b479386bc1387d912b7c9', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=()),
+    LabelInstruction(operation=Label(_name='...', uuid='...', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=()),
     GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None))
 
 Unitaries

--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -52,11 +52,13 @@ A circuit with the various gates and registers available is demonstrated below:
 .. testoutput::
   :options: +NORMALIZE_WHITESPACE
 
-    [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
-      MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,)),
-      GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
-      GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), cbits_ctrl_value=1),
-      GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None)]
+    (GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
+    MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,)),
+    GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None),
+    ConditionalBranchInstruction(operation=Cbz(_name='Cbz', uuid='d80afec8c954475f888d7ded7ac32217', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=(0,)),
+    GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(), cbits_ctrl_value=None),
+    LabelInstruction(operation=Label(_name='5346b421a0ed43b289e56915ae886d4a', uuid='e3e49a682f0b479386bc1387d912b7c9', params=(), qreg_dim=(), num_creg=0, unitary=True, self_inverse=False), qubits=(), cbits=()),
+    GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), cbits_ctrl_value=None))
 
 Unitaries
 =========

--- a/src/qutip_qip/circuit/__init__.py
+++ b/src/qutip_qip/circuit/__init__.py
@@ -4,7 +4,6 @@ from .instruction import (
     CircuitInstruction,
     GateInstruction,
     MeasurementInstruction,
-    OpInstruction,
 )
 from .simulator import CircuitResult, CircuitSimulator
 from .circuit import QubitCircuit
@@ -16,5 +15,4 @@ __all__ = [
     "CircuitInstruction",
     "GateInstruction",
     "MeasurementInstruction",
-    "OpInstruction",
 ]

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -584,29 +584,22 @@ class QubitCircuit:
         start : int
             The qubit on which the first gate is applied.
         """
+        warnings.warn(
+            "QubitCircuit.add_circuit has been deprecated, instead use Ops",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if self.num_qubits - start < qc.num_qubits:
             raise NotImplementedError("Targets exceed number of qubits.")
 
-        for circuit_op in qc.instructions:
-            if circuit_op.is_gate_instruction():
-                self.add_gate(
-                    circuit_op.operation,
-                    targets=[start + t for t in circuit_op.targets],
-                    controls=[start + c for c in circuit_op.controls],
-                    classical_controls=circuit_op.cbits,
-                    classical_control_value=circuit_op.cbits_ctrl_value,
-                )
-
-            elif circuit_op.is_measurement_instruction():
-                self.add_measurement(
-                    circuit_op.operation,
-                    targets=[target + start for target in circuit_op.qubits],
-                    classical_store=list(circuit_op.cbits),
-                )
-
-            else:
-                raise TypeError(f"The circuit to be added contains unknown \
-                    operator {circuit_op[0]}")
+        for circuit_op in qc.ops:
+            self.add_op(
+                op=circuit_op.op,
+                qreg=[start + t for t in circuit_op.qreg],
+                creg=circuit_op.creg,
+                style=circuit_op.style,
+            )
 
     def adjacent_gates(*args, **kwargs):
         raise AttributeError(

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -92,6 +92,7 @@ class QubitCircuit:
 
         self.reverse_states = reverse_states
         self._instructions: list[CircuitInstruction] = []
+        self._built_count = -1
 
         if input_states:
             self.input_states = input_states
@@ -149,7 +150,7 @@ class QubitCircuit:
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._instructions
+        return self.instructions
 
     @gates.setter
     def gates(self, value: any) -> None:
@@ -227,6 +228,8 @@ class QubitCircuit:
 
     @property
     def instructions(self) -> list[CircuitInstruction]:
+        if self._built_count != len(self._builder._op_instructions):
+            self.build()
         return self._instructions
 
     def add_state(
@@ -324,6 +327,7 @@ class QubitCircuit:
             # TODO handle non-gate/non-measurement op
 
         self._instructions = tuple(self._instructions)
+        self._built_count = len(self._builder._op_instructions)
 
     def add_measurement(
         self,
@@ -373,14 +377,6 @@ class QubitCircuit:
 
         check_limit("targets", targets, 0, self.num_qubits - 1)
         check_limit("classical_store", classical_store, 0, self.num_cbits - 1)
-
-        self._instructions.append(
-            MeasurementInstruction(
-                operation=measurement,
-                qubits=tuple(targets),
-                cbits=tuple(classical_store),
-            )
-        )
 
         self.add_op(
             op=measurement,
@@ -557,15 +553,6 @@ class QubitCircuit:
         qubits = []
         qubits.extend(controls)
         qubits.extend(targets)
-
-        self._instructions.append(
-            GateInstruction(
-                operation=gate,
-                qubits=tuple(qubits),
-                cbits=tuple(classical_controls),
-                cbits_ctrl_value=classical_control_value,
-            )
-        )
 
         if len(classical_controls) > 0:
             with self._builder.if_test(classical_controls, classical_control_value):
@@ -836,14 +823,17 @@ class QubitCircuit:
                 _resolve_2q_basis(basis_unit, qc_temp, temp_resolved)
                 break
         if not match:
-            qc_temp._instructions = temp_resolved.instructions
+            qc_temp._builder = temp_resolved._builder
 
         if len(basis_1q) != 2:
             return qc_temp
 
         instructions = qc_temp.instructions
-        qc_temp._instructions = []
+        phase = qc_temp.global_phase
         half_pi = np.pi / 2
+
+        qc_temp._builder = BloqBuilder(qc_temp.num_qubits, qc_temp.num_cbits)
+        qc_temp.add_global_phase(phase)
 
         for circ_instruction in instructions:
             gate = circ_instruction.operation

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -10,7 +10,7 @@ from typing import Iterable, Type, Self
 from qutip import qeye, Qobj, basis, tensor
 import numpy as np
 
-from qutip_qip.circuit import CircuitSimulator, OpInstruction
+from qutip_qip.circuit import CircuitSimulator
 from qutip_qip.circuit._decompose import (
     _resolve_to_universal,
     _resolve_2q_basis,
@@ -27,6 +27,7 @@ from qutip_qip.operations import (
     Gate,
     Measurement,
     Op,
+    OpInstruction,
     expand_operator,
     get_unitary_gate,
 )

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -623,41 +623,7 @@ class QubitCircuit:
         remove : string
             If first or all gates/measurements are to be removed.
         """
-        if index is not None:
-            if index > len(self.instructions):
-                raise ValueError("Index exceeds number \
-                    of gates + measurements.")
-
-            if end is not None and end <= len(self.instructions):
-                for i in range(end - index):
-                    self._instructions.pop(index + i)
-
-            elif end is not None and end > self.num_qubits:
-                raise ValueError("End target exceeds number \
-                    of gates + measurements.")
-
-            else:
-                self._instructions.pop(index)
-
-        elif name is not None and remove == "first":
-            for circuit_op in self.instructions:
-                if name == circuit_op.operation.name:
-                    self._instructions.remove(circuit_op)
-                    break
-
-        elif name is not None and remove == "last":
-            for i in reversed(range(len(self.instructions))):
-                if name == self.instructions[i].operation.name:
-                    self._instructions.pop(i)
-                    break
-
-        elif name is not None and remove == "all":
-            for i in reversed(range(len(self.instructions))):
-                if name == self.instructions[i].operation.name:
-                    self._instructions.pop(i)
-
-        else:
-            self._instructions.pop()
+        raise AttributeError("remove_gate_or_measurement method has been removed. ")
 
     def reverse_circuit(self):
         """
@@ -668,8 +634,14 @@ class QubitCircuit:
         qubit_circuit : :class:`.QubitCircuit`
             Return :class:`.QubitCircuit` of resolved gates for the
             qubit circuit in the reverse order.
-
         """
+
+        warnings.warn(
+            "QubitCircuit.reverse_circuit has been deprecated and will be future in future versions",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         temp = QubitCircuit(
             self.num_qubits,
             reverse_states=self.reverse_states,
@@ -678,22 +650,13 @@ class QubitCircuit:
             output_states=self.output_states,
         )
 
-        for circ_instruction in reversed(self.instructions):
-            if circ_instruction.is_gate_instruction():
-                temp.add_gate(
-                    gate=circ_instruction.operation,
-                    targets=circ_instruction.targets,
-                    controls=circ_instruction.controls,
-                    classical_controls=circ_instruction.cbits,
-                    classical_control_value=circ_instruction.cbits_ctrl_value,
-                )
-
-            elif circ_instruction.is_measurement_instruction():
-                temp.add_measurement(
-                    measurement=circ_instruction.operation,
-                    targets=circ_instruction.qubits,
-                    classical_store=circ_instruction.cbits[0],
-                )
+        for circ_op in reversed(self.ops):
+            temp.add_op(
+                op=circ_op.op,
+                qreg=circ_op.qreg,
+                creg=circ_op.creg,
+                style=circ_op.style,
+            )
 
         return temp
 

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -232,8 +232,6 @@ class QubitCircuit:
     def instructions(self) -> list[CircuitInstruction]:
         return self._instructions
 
-    # TODO: Add method to add auxiliary qubits
-
     def add_state(
         self,
         state: str,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -382,7 +382,7 @@ class QubitCircuit:
             )
         )
 
-        self._builder.add_op(
+        self.add_op(
             op=measurement,
             qreg=tuple(targets),
             creg=tuple(classical_store),

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -4,8 +4,6 @@ Quantum circuit representation and simulation.
 
 import warnings
 import inspect
-from contextlib import contextmanager
-from enum import StrEnum
 from typing import Iterable, Type, Self
 from qutip import qeye, Qobj, basis, tensor
 import numpy as np
@@ -22,12 +20,13 @@ from qutip_qip.circuit.instruction import (
     LabelInstruction,
     MeasurementInstruction,
 )
-from qutip_qip.operations.conditional import Cbnz, Cbz, Conditional, Label
+from qutip_qip.operations.conditional import Conditional, Label, ClassicalControlCheck
 from qutip_qip.operations import (
     BloqBuilder,
     Gate,
     Measurement,
     Op,
+    OpInstruction,
     expand_operator,
     get_unitary_gate,
 )
@@ -47,15 +46,6 @@ except ImportError:
 
     def DisplaySVG(data, *args, **kwargs):
         return data
-
-
-class ClassicalControlCheck(StrEnum):
-    EQ = "EQ"
-    NEQ = "NEQ"
-    GT = "GT"
-    LT = "LT"
-    GTE = "GTE"  # This can be subimplemented using GT - 1
-    LTE = "LTE"
 
 
 class QubitCircuit:
@@ -101,9 +91,7 @@ class QubitCircuit:
         self._builder = BloqBuilder(num_qubits, num_cbits, qreg_dim=self.dims)
 
         self.reverse_states = reverse_states
-        self._ops: list[Op] = []
         self._instructions: list[CircuitInstruction] = []
-        self._label_counter = 0
 
         if input_states:
             self.input_states = input_states
@@ -234,6 +222,10 @@ class QubitCircuit:
         self._user_gates = gate_classes
 
     @property
+    def ops(self) -> tuple[OpInstruction, ...]:
+        return self._builder.instructions
+
+    @property
     def instructions(self) -> list[CircuitInstruction]:
         return self._instructions
 
@@ -271,14 +263,13 @@ class QubitCircuit:
             for i in targets:
                 self.output_states[i] = state
 
-    @contextmanager
     def if_test(
         self: Self,
         cbits: int | IntSequence,
         value: int,
         check: ClassicalControlCheck = "EQ",
     ):
-        self._builder.if_test(cbits, value)
+        return self._builder.if_test(cbits, value, check)
 
     def add_op(
         self: Self,

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -85,7 +85,7 @@ class QubitCircuit:
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self._num_qubits = N
+            num_qubits = N
 
         self.dims = dims if dims is not None else [2] * num_qubits
         self._builder = BloqBuilder(num_qubits, num_cbits, qreg_dim=self.dims)

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -24,10 +24,10 @@ from qutip_qip.circuit.instruction import (
 )
 from qutip_qip.operations.conditional import Cbnz, Cbz, Conditional, Label
 from qutip_qip.operations import (
+    BloqBuilder,
     Gate,
     Measurement,
     Op,
-    OpInstruction,
     expand_operator,
     get_unitary_gate,
 )
@@ -89,7 +89,6 @@ class QubitCircuit:
         N=None,
     ):
         # number of qubits in the register
-        self._num_qubits = num_qubits
         if N is not None:
             warnings.warn(
                 "The 'N' parameter is deprecated. Please use 'num_qubits' instead.",
@@ -98,13 +97,13 @@ class QubitCircuit:
             )
             self._num_qubits = N
 
+        self.dims = dims if dims is not None else [2] * num_qubits
+        self._builder = BloqBuilder(num_qubits, num_cbits, qreg_dim=self.dims)
+
         self.reverse_states = reverse_states
-        self.num_cbits: int = num_cbits
-        self._global_phase: float = 0.0
         self._ops: list[Op] = []
         self._instructions: list[CircuitInstruction] = []
         self._label_counter = 0
-        self.dims = dims if dims is not None else [2] * self.num_qubits
 
         if input_states:
             self.input_states = input_states
@@ -124,7 +123,14 @@ class QubitCircuit:
         """
         Number of qubits in the circuit.
         """
-        return self._num_qubits
+        return self._builder.num_qreg
+
+    @property
+    def num_cbits(self) -> int:
+        """
+        Number of cbits in the circuit.
+        """
+        return self._builder.num_creg
 
     @property
     def N(self) -> int:
@@ -136,18 +142,17 @@ class QubitCircuit:
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._num_qubits
+        return self.num_qubits
 
     def __repr__(self) -> str:
         return ""
 
     @property
     def global_phase(self):
-        return self._global_phase
+        return self._builder.global_phase
 
     def add_global_phase(self, phase: float):
-        self._global_phase += phase
-        self._global_phase %= 2 * np.pi
+        self._builder.add_global_phase(phase)
 
     @property
     def gates(self) -> list[CircuitInstruction]:
@@ -273,151 +278,25 @@ class QubitCircuit:
         value: int,
         check: ClassicalControlCheck = "EQ",
     ):
-        # TODO Validate the arguments
-        if type(cbits) is int:
-            cbits = [cbits]
-
-        # GTE, LTE checks can be implemented as GT, LT conditions itself
-        if check == ClassicalControlCheck.GTE:
-            check = ClassicalControlCheck.GT
-            value -= 1
-
-        elif check == ClassicalControlCheck.LTE:
-            check = ClassicalControlCheck.LT
-            value += 1
-
-        label = Label(f"label_{self._label_counter}")
-        self._label_counter += 1
-
-        if check == ClassicalControlCheck.EQ:
-            if (value < 0) or (value >= 2 ** len(cbits)):
-                return  # Useless if_test condition
-
-            else:
-                for index, cbit in enumerate(cbits):
-                    if (value >> index) & 1 == 1:
-                        # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
-                        self.add_op(Cbz(label=label), creg=cbit)
-                    else:
-                        # If does not match for cbit_value=0, then branch to label
-                        self.add_op(Cbnz(label=label), creg=cbit)
-
-        elif check == ClassicalControlCheck.NEQ:
-            neq_label = Label(f"label_{self._label_counter}")
-            self._label_counter += 1
-
-            if (value < 0) or (value >= 2 ** len(cbits)):
-                # This is an unconditional jump essentially
-                self.add_op(Cbz(label=neq_label), creg=0)
-                self.add_op(Cbnz(label=neq_label), creg=0)
-
-            else:
-                for index, cbit in enumerate(cbits):
-                    target_bit_value = (value >> index) & 1
-
-                    if target_bit_value == 1:
-                        # If a mismatch match for cbit_value=1, then branch to neqlabel
-                        self.add_op(Cbz(label=neq_label), creg=cbit)
-                    else:
-                        self.add_op(Cbnz(label=neq_label), creg=cbit)
-
-                # This will only execute if non of the earlier conditional branching executes.
-                # means NEQ is FALSE. We must skip the conditional block.
-
-                # This must be preferably replaced Jump statement (unconditional)
-                self.add_op(Cbz(label=label), creg=0)
-                self.add_op(Cbnz(label=label), creg=0)
-
-            # Successful entry point for the NEQ condition
-            self.add_op(neq_label)
-
-        elif check == ClassicalControlCheck.GT:
-            # Check for redundant conditions
-            if value >= 2 ** len(cbits):  # Never true
-                return
-
-            elif value >= 0:  # for value less than 0, condition is always true
-                gt_label = Label(f"label_{self._label_counter}")
-                self._label_counter += 1
-
-                for index, cbit in enumerate(cbits):
-                    target_bit_value = (value >> index) & 1
-
-                    # We break at first point of discontinuity (but to different labels)
-                    if target_bit_value == 1:
-                        self.add_op(Cbz(label=label), creg=cbit)
-                    else:
-                        self.add_op(Cbnz(label=gt_label), creg=cbit)
-
-                # If execution falls through the entire loop without jumping,
-                # it means every single bit matched exactly.
-                # self.add_op(Jump(label=label))
-                self.add_op(Cbz(label=label), creg=0)
-                self.add_op(Cbnz(label=label), creg=0)
-
-                # Entry point for the GT conditional block
-                self.add_op(gt_label)
-
-        elif check == ClassicalControlCheck.LT:
-            # Check for redundant conditions
-            if value <= 0:  # Never true
-                return
-
-            elif value < 2 ** len(
-                cbits
-            ):  # for value larger than 2^m, condition is always true
-                lt_label = Label(f"label_{self._label_counter}")
-                self._label_counter += 1
-
-                for index, cbit in enumerate(cbits):
-                    target_bit_value = (value >> index) & 1
-
-                    # We break at first point of discontinuity (but to different labels)
-                    if target_bit_value == 1:
-                        self.add_op(Cbz(label=lt_label), creg=cbit)
-                    else:
-                        self.add_op(Cbnz(label=label), creg=cbit)
-
-                # If execution falls through the entire loop without jumping,
-                # it means every single bit matched exactly.
-                # self.add_op(Jump(label=label))
-                self.add_op(Cbz(label=label), creg=0)
-                self.add_op(Cbnz(label=label), creg=0)
-
-                # Entry point for the GT conditional block
-                self.add_op(lt_label)
-
-        else:
-            raise ValueError(f"Invalid check {check}")
-
-        # Yields the control back to the code inside the "with" context block
-        try:
-            yield
-        finally:
-            self.add_op(label)
+        self._builder.if_test(cbits, value)
 
     def add_op(
         self: Self,
         op: Op,
         qreg: int | IntSequence = (),
         creg: int | IntSequence = (),
+        style: dict | None = None,
     ):
-        if type(qreg) is int:
-            qreg = [qreg]
-
-        if type(creg) is int:
-            creg = [creg]
-
-        # TODO validate the inputs
-        self._ops.append(OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg)))
+        self._builder.add_op(op, qreg, creg, style)
 
     def build(self: Self):
         """
         Converts _ops list to a frozen _instructions tuple.
         """
         self._instructions = []
+        bloq = self._builder.build()
 
-        for op_instruction in self._ops:
+        for op_instruction in bloq.instructions:
             op = op_instruction.op
 
             if isinstance(op, Gate) or (isinstance(op, type) and issubclass(op, Gate)):
@@ -512,12 +391,10 @@ class QubitCircuit:
             )
         )
 
-        self._ops.append(
-            OpInstruction(
-                op=measurement,
-                qreg=tuple(targets),
-                creg=tuple(classical_store),
-            )
+        self._builder.add_op(
+            op=measurement,
+            qreg=tuple(targets),
+            creg=tuple(classical_store),
         )
 
     def add_gate(
@@ -699,17 +576,11 @@ class QubitCircuit:
             )
         )
 
-        instruction = OpInstruction(
-            op=gate,
-            qreg=tuple(qubits),
-            style=style,
-        )
-
         if len(classical_controls) > 0:
-            with self.if_test(classical_controls, classical_control_value):
-                self._ops.append(instruction)
+            with self._builder.if_test(classical_controls, classical_control_value):
+                self.add_op(op=gate, qreg=tuple(qubits), style=style)
         else:
-            self._ops.append(instruction)
+            self.add_op(op=gate, qreg=tuple(qubits), style=style)
 
     def add_circuit(self, qc, start=0):  # TODO Instead of start have a qubit mapping?
         """

--- a/src/qutip_qip/circuit/circuit.py
+++ b/src/qutip_qip/circuit/circuit.py
@@ -22,7 +22,7 @@ from qutip_qip.circuit.instruction import (
     LabelInstruction,
     MeasurementInstruction,
 )
-from qutip_qip.circuit.conditional import Cbnz, Cbz, Conditional, Label
+from qutip_qip.operations.conditional import Cbnz, Cbz, Conditional, Label
 from qutip_qip.operations import (
     Gate,
     Measurement,

--- a/src/qutip_qip/circuit/conditional.py
+++ b/src/qutip_qip/circuit/conditional.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from qutip_qip.operations import Op
 
 
@@ -5,14 +7,21 @@ class Label(Op):
     """A static marker in the instruction list."""
 
     def __init__(self, name):
-        self.name = name
+        super().__init__(_name=name)
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
 class Conditional(Op):
     """Classical conditional control flow statements"""
 
-    def __init__(self, label):
-        self.label = label
+    label: str
+
+    def __init__(self, label: str):
+        # Don't make it super(), it will throw an error because slots=True
+        # destroys __class__ reference to the original class until Python 3.13
+        # Check CPython Issue #90562, TODO: this has been resolved in Python 3.14
+        super(Conditional, self).__init__(_name=type(self).__name__)  #
+        object.__setattr__(self, "label", label)
 
 
 class Cbz(Conditional):

--- a/src/qutip_qip/circuit/draw/_control_flow.py
+++ b/src/qutip_qip/circuit/draw/_control_flow.py
@@ -1,4 +1,4 @@
-from qutip_qip.circuit.conditional import Cbnz, Cbz, Conditional, Label
+from qutip_qip.operations.conditional import Cbnz, Cbz, Conditional, Label
 
 
 def _is_unconditional_pair(instructions, index):

--- a/src/qutip_qip/circuit/draw/mat_renderer.py
+++ b/src/qutip_qip/circuit/draw/mat_renderer.py
@@ -747,9 +747,9 @@ class MatRenderer(BaseRenderer):
         """
 
         self._add_wire_labels()
-        classical_controls = infer_classical_controls(self._qc._ops)
+        classical_controls = infer_classical_controls(self._qc.ops)
 
-        for index, instruction in enumerate(self._qc._ops):
+        for index, instruction in enumerate(self._qc.ops):
             op = instruction.op
             qubits = instruction.qreg
             cbits = instruction.creg

--- a/src/qutip_qip/circuit/draw/texrenderer.py
+++ b/src/qutip_qip/circuit/draw/texrenderer.py
@@ -27,7 +27,7 @@ class TeXRenderer:
         self.qc = qc
         self.num_qubits = qc.num_qubits
         self.num_cbits = qc.num_cbits
-        self.instructions = qc._ops
+        self.instructions = qc.ops
         self.input_states = qc.input_states
         self.reverse_states = qc.reverse_states
 

--- a/src/qutip_qip/circuit/draw/text_renderer.py
+++ b/src/qutip_qip/circuit/draw/text_renderer.py
@@ -397,9 +397,9 @@ class TextRenderer(BaseRenderer):
         Layout the circuit
         """
         self._add_wire_labels()
-        classical_controls = infer_classical_controls(self._qc._ops)
+        classical_controls = infer_classical_controls(self._qc.ops)
 
-        for index, op_instruction in enumerate(self._qc._ops):
+        for index, op_instruction in enumerate(self._qc.ops):
             op = op_instruction.op
             qubits = list(op_instruction.qreg)
             cbits = list(op_instruction.creg)

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Type
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import warnings
 from qutip_qip.circuit.conditional import Conditional, Label, Cbnz, Cbz
 from qutip_qip.operations import Gate, Measurement, Op
@@ -16,22 +16,6 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
         if q < 0:
             raise ValueError(f"{txt} indices must be non-negative, found {q}")
-
-
-@dataclass(frozen=True, slots=True)
-class OpInstruction:
-    op: Op
-    qreg: tuple[int, ...] = tuple()
-    creg: tuple[int, ...] = tuple()
-    style: dict = field(default_factory=dict)
-
-    def __post_init__(self):
-        pass
-
-    # TODO add instructions to test for gate, measurement etc. (used in circuit draw)
-
-    def __str__(self):
-        print(f"op={self.op}, qreg={self.qreg}, creg={self.creg}, style({self.style})")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Type
 from dataclasses import dataclass
 import warnings
-from qutip_qip.circuit.conditional import Conditional, Label, Cbnz, Cbz
-from qutip_qip.operations import Gate, Measurement, Op
+from qutip_qip.operations.conditional import Conditional, Label, Cbnz, Cbz
+from qutip_qip.operations import Gate, Measurement
 
 
 def _validate_non_negative_int_tuple(T: any, txt: str = ""):

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -5,7 +5,7 @@ from typing import Self
 import numpy as np
 
 from qutip import ket2dm, Qobj
-from qutip_qip.circuit.conditional import Cbz, Cbnz
+from qutip_qip.operations.conditional import Cbz, Cbnz
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator
 

--- a/src/qutip_qip/operations/__init__.py
+++ b/src/qutip_qip/operations/__init__.py
@@ -14,7 +14,7 @@ from .parametric import ParametricGate, AngleParametricGate
 from .controlled import ControlledGate, get_controlled_gate
 from .measurement import Measurement
 from .op import Op, OpInstruction
-from .bloq import Bloq
+from .bloq import Bloq, BloqBuilder
 from .old_gates import (
     rx,
     ry,
@@ -62,6 +62,7 @@ __all__ = [
     "Op",
     "OpInstruction",
     "Bloq",
+    "BloqBuilder",
     "rx",
     "ry",
     "rz",

--- a/src/qutip_qip/operations/__init__.py
+++ b/src/qutip_qip/operations/__init__.py
@@ -13,7 +13,7 @@ from .gateclass import Gate, get_unitary_gate
 from .parametric import ParametricGate, AngleParametricGate
 from .controlled import ControlledGate, get_controlled_gate
 from .measurement import Measurement
-from .op import Op
+from .op import Op, OpInstruction
 from .bloq import Bloq
 from .old_gates import (
     rx,
@@ -60,6 +60,7 @@ __all__ = [
     "AngleParametricGate",
     "Measurement",
     "Op",
+    "OpInstruction",
     "Bloq",
     "rx",
     "ry",

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -1,25 +1,37 @@
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from uuid import uuid4
+
 from qutip_qip.operations import OpInstruction
 
 
 @dataclass(frozen=True, slots=True)
 class Bloq:
+    uuid: str = field(default_factory=lambda: uuid4().hex)
     qreg_dim: tuple[int, ...] = ()
     aux_qreg_dim: tuple[int, ...] = ()
 
     qreg_count: int = 0
     creg_count: int = 0
+    global_phase: float = 0.0
     instructions: tuple[OpInstruction, ...] = ()
 
-    # qreg_dim, qreg_count, creg_count etc. has been copied here, although
-    # these we can directly access from the associated Op, so that Op and Bloq remain separate
-    # The only linking between them happens via the BloqRepository.
+    # qreg_dim, qreg_count, creg_count etc. has been copied here, although these
+    # can be directly access from the associated Op, they are separate so that Op and Bloq
+    # remain separate. The only linking between them happens via the BloqRepository.
 
 
 class BloqBuilder:
+    def __init__(self, num_qreg: int, num_creg: int = 0) -> None:
+        self.num_qreg = num_qreg
+        self.num_creg = num_creg
+
     def add_aux_qreg(self, count=1, dim=2) -> tuple[int, ...]: ...
     def add_op(self, op, qregs, cregs=()) -> None: ...
 
     @contextmanager
     def if_test(self, creg, value: int, check="EQ") -> None: ...
+
+    def add_global_phase(self, phase: float) -> None: ...
+
+    def build(self) -> Bloq: ...

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -101,7 +101,7 @@ class BloqBuilder:
         if not (isinstance(dim, Int) and dim > 0):
             raise TypeError(f"dim must be of type int, got {dim}")
 
-        self._aux_qreg_dim.append([dim] * count)
+        self._aux_qreg_dim.extend([dim] * count)
 
     def add_aux_creg(self, count: Int = 1) -> None:
         if not (isinstance(count, Int) and count > 0):
@@ -124,7 +124,7 @@ class BloqBuilder:
     def aux_creg(self) -> tuple[int, ...]:
         return tuple(range(self.num_qcreg, self.num_creg + self.num_aux_creg))
 
-    def add_op(self, op, qreg=(), creg=()) -> None:
+    def add_op(self, op, qreg=(), creg=(), style: dict = None) -> None:
         # Type checking is handled internally within OpInstruction
         # We just check each element of qreg, creg are within the limit
         if isinstance(qreg, Int):
@@ -136,12 +136,12 @@ class BloqBuilder:
         check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
 
         self._op_instructions.append(
-            OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg))
+            OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg), style=style)
         )
 
     @contextmanager
     def if_test(self, creg, value: Int) -> None:
-        if type(creg) is Int:
+        if isinstance(creg, Int):
             creg = [creg]
 
         # TODO test each element in creg is an int
@@ -154,17 +154,26 @@ class BloqBuilder:
         for index, cbit in enumerate(creg):
             if (value >> index) & 1 == 1:
                 # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
-                self.add_op(Cbz(label), creg=creg)
+                self.add_op(Cbz(label), creg=cbit)
             else:
                 # If does not match for cbit_value=0, then branch to label
-                self.add_op(Cbnz(label), creg=creg)
+                self.add_op(Cbnz(label), creg=cbit)
+
+        try:
+            yield
+        finally:
+            self.add_op(label)
 
     def build(self) -> Bloq:
         return Bloq(
             qreg_dim=self._qreg_dim,
+            aux_qreg_dim=tuple(self._aux_qreg_dim),
             num_creg=self.num_creg,
-            aux_qreg_dim=self._aux_qreg_dim,
-            num_aux_creg=self.num_aux_qreg,
+            num_aux_creg=self.num_aux_creg,
             global_phase=self.global_phase,
             instructions=self.instructions,
         )
+
+
+class BloqRepository:
+    pass

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -3,7 +3,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from uuid import uuid4
 
-from qutip_qip.operations import Op, OpInstruction
+from qutip_qip.operations import OpInstruction
+from qutip_qip.operations.conditional import Cbz, Cbnz
 from qutip_qip.typing import Int
 from qutip_qip.utils import check_limit
 
@@ -61,12 +62,20 @@ class BloqBuilder:
         return len(self._qreg_dim)
 
     @property
+    def num_aux_qreg(self) -> int:
+        return len(self._aux_qreg_dim)
+
+    @property
     def num_creg(self) -> int:
         return self._num_creg
 
     @property
-    def instructions(self) -> list[OpInstruction]:
-        return self._op_instructions
+    def num_aux_creg(self) -> int:
+        return self._num_aux_creg
+
+    @property
+    def instructions(self) -> tuple[OpInstruction, ...]:
+        return tuple(self._op_instructions)
 
     @property
     def global_phase(self) -> float:
@@ -76,25 +85,72 @@ class BloqBuilder:
         self._global_phase += phase
         self._global_phase %= 2 * math.pi
 
-    def add_aux_qreg(self, count: int = 1, dim: int = 2) -> tuple[int, ...]: ...
+    def add_aux_qreg(self, count: Int = 1, dim: Int = 2) -> None:
+        if not (isinstance(count, Int) and count > 0):
+            raise TypeError(f"count must be of type int, got {count}")
+
+        if not (isinstance(dim, Int) and dim > 0):
+            raise TypeError(f"dim must be of type int, got {dim}")
+
+        self._aux_qreg_dim.append([dim] * count)
+
+    @property
+    def qreg(self) -> tuple[int, ...]:
+        return tuple(range(self.num_qreg))
+
+    @property
+    def aux_qreg(self) -> tuple[int, ...]:
+        return tuple(range(self.num_qreg, self.num_qreg + self.num_aux_qreg))
+
+    @property
+    def creg(self) -> tuple[int, ...]:
+        return tuple(range(self.num_creg))
+
+    @property
+    def aux_creg(self) -> tuple[int, ...]:
+        return tuple(range(self.num_qcreg, self.num_creg + self.num_aux_creg))
 
     def add_op(self, op, qreg=(), creg=()) -> None:
         # Type checking is handled internally within OpInstruction
         # We just check each element of qreg, creg are within the limit
-        if type(qreg, Int):
+        if isinstance(qreg, Int):
             qreg = [qreg]
-
-        if type(creg, Int):
+        if isinstance(creg, Int):
             creg = [creg]
 
-        check_limit("qreg", qreg, 0, self.num_qreg - 1)
-        check_limit("creg", creg, 0, self.num_creg - 1)
+        check_limit("qreg", qreg, 0, self.num_qreg + self.num_aux_qreg - 1)
+        check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
 
         self._op_instructions.append(
             OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg))
         )
 
     @contextmanager
-    def if_test(self, creg, value: int, check="EQ") -> None: ...
+    def if_test(self, creg, value: Int) -> None:
+        if type(creg) is Int:
+            creg = [creg]
 
-    def build(self) -> Bloq: ...
+        # TODO test each element in creg is an int
+        check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
+
+        if (value < 0) or (value >= 2 ** len(creg)):
+            raise ValueError("Check value not in the limit")
+
+        label = uuid4().hex
+        for index, cbit in enumerate(creg):
+            if (value >> index) & 1 == 1:
+                # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
+                self.add_op(Cbz(label), creg=creg)
+            else:
+                # If does not match for cbit_value=0, then branch to label
+                self.add_op(Cbnz(label), creg=creg)
+
+    def build(self) -> Bloq:
+        return Bloq(
+            qreg_dim=self._qreg_dim,
+            num_creg=self.num_creg,
+            aux_qreg_dim=self._aux_qreg_dim,
+            num_aux_creg=self.num_aux_qreg,
+            global_phase=self.global_phase,
+            instructions=self.instructions,
+        )

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -122,7 +122,7 @@ class BloqBuilder:
 
     @property
     def aux_creg(self) -> tuple[int, ...]:
-        return tuple(range(self.num_qcreg, self.num_creg + self.num_aux_creg))
+        return tuple(range(self.num_creg, self.num_creg + self.num_aux_creg))
 
     def add_op(self, op, qreg=(), creg=(), style: dict = None) -> None:
         # Type checking is handled internally within OpInstruction
@@ -144,12 +144,18 @@ class BloqBuilder:
         if isinstance(creg, Int):
             creg = [creg]
 
-        # TODO test each element in creg is an int
-        check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
+        if check == ClassicalControlCheck.GTE:
+            check = ClassicalControlCheck.GT
+            value -= 1
 
-        label = Label(uuid4().hex)
+        if check == ClassicalControlCheck.LTE:
+            check = ClassicalControlCheck.LT
+            value += 1
+
+        check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
         num_bits = len(creg)
         lg_check_value = 2**num_bits
+        label = Label(uuid4().hex)
 
         if check == ClassicalControlCheck.EQ:
             if (value < 0) or (value >= lg_check_value):

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -3,17 +3,27 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from uuid import uuid4
 
-from qutip_qip.operations import OpInstruction
+from qutip_qip.operations import Op, OpInstruction
+from qutip_qip.typing import Int
+from qutip_qip.utils import check_limit
 
 
 @dataclass(frozen=True, slots=True)
 class Bloq:
     uuid: str = field(default_factory=lambda: uuid4().hex)
-    qreg_dim: tuple[int, ...] = ()
-    aux_qreg_dim: tuple[int, ...] = ()
+    qreg_dim: tuple[Int, ...] = ()
+    aux_qreg_dim: tuple[Int, ...] = ()
 
-    qreg_count: int = 0
-    creg_count: int = 0
+    @property
+    def num_qreg(self) -> int:
+        return len(self.qreg_dim)
+
+    @property
+    def num_aux_qreg(self) -> int:
+        return len(self.aux_qreg_dim)
+
+    num_creg: Int = 0
+    num_aux_creg: Int = 0
     global_phase: float = 0.0
     instructions: tuple[OpInstruction, ...] = ()
 
@@ -25,24 +35,30 @@ class BloqBuilder:
     def __init__(
         self, num_qreg: int, num_creg: int = 0, qreg_dim: tuple[int, ...] | None = None
     ) -> None:
-        self._num_qreg = num_qreg
-        self._num_creg = num_creg
-        self._op_instructions = []
-        self._global_phase = 0.0
+        if num_qreg < 0:
+            raise ValueError("num_qreg must be greater than or equal to 0.")
 
-        if (qreg_dim is not None) and (len(qreg_dim) != num_qreg):
+        if num_creg < 0:
+            raise ValueError("num_creg must be greater than or equal to 0.")
+
+        if qreg_dim and len(qreg_dim) != num_qreg:
             raise ValueError(
                 f"Lenght of qreg_dim={qreg_dim} must be equal to num_qreg={num_qreg}"
             )
 
+        self._qreg_dim = qreg_dim
         if self._qreg_dim is None:
             self._qreg_dim = (2,) * num_qreg
-        else:
-            self._qreg_dim = tuple(qreg_dim)
+
+        self._aux_qreg_dim = []
+        self._num_creg = num_creg
+        self._num_aux_creg = 0
+        self._global_phase = 0.0
+        self._op_instructions = []
 
     @property
     def num_qreg(self) -> int:
-        return self._num_qreg
+        return len(self._qreg_dim)
 
     @property
     def num_creg(self) -> int:
@@ -60,8 +76,23 @@ class BloqBuilder:
         self._global_phase += phase
         self._global_phase %= 2 * math.pi
 
-    def add_aux_qreg(self, count=1, dim=2) -> tuple[int, ...]: ...
-    def add_op(self, op, qregs, cregs=()) -> None: ...
+    def add_aux_qreg(self, count: int = 1, dim: int = 2) -> tuple[int, ...]: ...
+
+    def add_op(self, op, qreg=(), creg=()) -> None:
+        # Type checking is handled internally within OpInstruction
+        # We just check each element of qreg, creg are within the limit
+        if type(qreg, Int):
+            qreg = [qreg]
+
+        if type(creg, Int):
+            creg = [creg]
+
+        check_limit("qreg", qreg, 0, self.num_qreg - 1)
+        check_limit("creg", creg, 0, self.num_creg - 1)
+
+        self._op_instructions.append(
+            OpInstruction(op=op, qreg=tuple(qreg), creg=tuple(creg))
+        )
 
     @contextmanager
     def if_test(self, creg, value: int, check="EQ") -> None: ...

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from uuid import uuid4
 
 from qutip_qip.operations import OpInstruction
-from qutip_qip.operations.conditional import Cbz, Cbnz
+from qutip_qip.operations.conditional import Cbz, Cbnz, ClassicalControlCheck, Label
 from qutip_qip.typing import Int
 from qutip_qip.utils import check_limit
 
@@ -140,24 +140,111 @@ class BloqBuilder:
         )
 
     @contextmanager
-    def if_test(self, creg, value: Int) -> None:
+    def if_test(self, creg, value: Int, check: ClassicalControlCheck = "EQ") -> None:
         if isinstance(creg, Int):
             creg = [creg]
 
         # TODO test each element in creg is an int
         check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
 
-        if (value < 0) or (value >= 2 ** len(creg)):
-            raise ValueError("Check value not in the limit")
+        label = Label(uuid4().hex)
+        lg_check_value = 2 ** len(creg)
 
-        label = uuid4().hex
-        for index, cbit in enumerate(creg):
-            if (value >> index) & 1 == 1:
-                # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
-                self.add_op(Cbz(label), creg=cbit)
+        if check == ClassicalControlCheck.EQ:
+            if (value < 0) or (value >= lg_check_value):
+                return  # Useless if_test condition
+
             else:
-                # If does not match for cbit_value=0, then branch to label
-                self.add_op(Cbnz(label), creg=cbit)
+                for index, cbit in enumerate(creg):
+                    if (value >> index) & 1 == 1:
+                        # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
+                        self.add_op(Cbz(label=label), creg=cbit)
+                    else:
+                        # If does not match for cbit_value=0, then branch to label
+                        self.add_op(Cbnz(label=label), creg=cbit)
+
+        elif check == ClassicalControlCheck.NEQ:
+            neq_label = Label(uuid4().hex)
+            if (value < 0) or (value >= lg_check_value):
+                # This is an unconditional jump essentially
+                self.add_op(Cbz(label=neq_label), creg=0)
+                self.add_op(Cbnz(label=neq_label), creg=0)
+
+            else:
+                for index, cbit in enumerate(creg):
+                    target_bit_value = (value >> index) & 1
+
+                    if target_bit_value == 1:
+                        # If a mismatch match for cbit_value=1, then branch to neqlabel
+                        self.add_op(Cbz(label=neq_label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=neq_label), creg=cbit)
+
+                # This will only execute if non of the earlier conditional branching executes.
+                # means NEQ is FALSE. We must skip the conditional block.
+
+                # This must be preferably replaced Jump statement (unconditional)
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
+
+            # Successful entry point for the NEQ condition
+            self.add_op(neq_label)
+
+        elif check == ClassicalControlCheck.GT:
+            # Check for redundant conditions
+            if value >= lg_check_value:  # Never true
+                return
+
+            elif value >= 0:  # for value less than 0, condition is always true
+                gt_label = Label(uuid4().hex)
+
+                for index, cbit in enumerate(creg):
+                    target_bit_value = (value >> index) & 1
+
+                    # We break at first point of discontinuity (but to different labels)
+                    if target_bit_value == 1:
+                        self.add_op(Cbz(label=label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=gt_label), creg=cbit)
+
+                # If execution falls through the entire loop without jumping,
+                # it means every single bit matched exactly.
+                # self.add_op(Jump(label=label))
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
+
+                # Entry point for the GT conditional block
+                self.add_op(gt_label)
+
+        elif check == ClassicalControlCheck.LT:
+            # Check for redundant conditions
+            if value <= 0:  # Never true
+                return
+
+            elif (
+                value < lg_check_value
+            ):  # for value larger than 2^m, condition is always true
+                lt_label = Label(uuid4().hex)
+                for index, cbit in enumerate(creg):
+                    target_bit_value = (value >> index) & 1
+
+                    # We break at first point of discontinuity (but to different labels)
+                    if target_bit_value == 1:
+                        self.add_op(Cbz(label=lt_label), creg=cbit)
+                    else:
+                        self.add_op(Cbnz(label=label), creg=cbit)
+
+                # If execution falls through the entire loop without jumping,
+                # it means every single bit matched exactly.
+                # self.add_op(Jump(label=label))
+                self.add_op(Cbz(label=label), creg=0)
+                self.add_op(Cbnz(label=label), creg=0)
+
+                # Entry point for the GT conditional block
+                self.add_op(lt_label)
+
+        else:
+            raise ValueError(f"Invalid check {check}")
 
         try:
             yield

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from qutip_qip.operations import OpInstruction
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Bloq:
-    qreg_dim: tuple[int, ...]
+    qreg_dim: tuple[int, ...] = ()
     aux_qreg_dim: tuple[int, ...] = ()
 
-    qreg_count: int
-    creg_count: int
-    instructions: tuple[OpInstruction, ...]
+    qreg_count: int = 0
+    creg_count: int = 0
+    instructions: tuple[OpInstruction, ...] = ()
 
     # qreg_dim, qreg_count, creg_count etc. has been copied here, although
     # these we can directly access from the associated Op, so that Op and Bloq remain separate

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -33,8 +33,17 @@ class Bloq:
 
 
 class BloqBuilder:
+    __slots__ = (
+        "_qreg_dim",
+        "_aux_qreg_dim",
+        "_num_creg",
+        "_num_aux_creg",
+        "_global_phase",
+        "_op_instructions",
+    )
+
     def __init__(
-        self, num_qreg: int, num_creg: int = 0, qreg_dim: tuple[int, ...] | None = None
+        self, num_qreg: int, num_creg: int = 0, qreg_dim: tuple[int, ...] = ()
     ) -> None:
         if num_qreg < 0:
             raise ValueError("num_qreg must be greater than or equal to 0.")
@@ -42,13 +51,13 @@ class BloqBuilder:
         if num_creg < 0:
             raise ValueError("num_creg must be greater than or equal to 0.")
 
-        if qreg_dim and len(qreg_dim) != num_qreg:
+        if len(qreg_dim) and len(qreg_dim) != num_qreg:
             raise ValueError(
                 f"Lenght of qreg_dim={qreg_dim} must be equal to num_qreg={num_qreg}"
             )
 
         self._qreg_dim = qreg_dim
-        if self._qreg_dim is None:
+        if len(self._qreg_dim) == 0:
             self._qreg_dim = (2,) * num_qreg
 
         self._aux_qreg_dim = []
@@ -93,6 +102,11 @@ class BloqBuilder:
             raise TypeError(f"dim must be of type int, got {dim}")
 
         self._aux_qreg_dim.append([dim] * count)
+
+    def add_aux_creg(self, count: Int = 1) -> None:
+        if not (isinstance(count, Int) and count > 0):
+            raise TypeError(f"count must be of type int, got {count}")
+        self._num_aux_creg += count
 
     @property
     def qreg(self) -> tuple[int, ...]:

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -53,7 +53,7 @@ class BloqBuilder:
 
         if len(qreg_dim) and len(qreg_dim) != num_qreg:
             raise ValueError(
-                f"Lenght of qreg_dim={qreg_dim} must be equal to num_qreg={num_qreg}"
+                f"Length of qreg_dim={qreg_dim} must be equal to num_qreg={num_qreg}"
             )
 
         self._qreg_dim = qreg_dim
@@ -148,7 +148,8 @@ class BloqBuilder:
         check_limit("creg", creg, 0, self.num_creg + self.num_aux_creg - 1)
 
         label = Label(uuid4().hex)
-        lg_check_value = 2 ** len(creg)
+        num_bits = len(creg)
+        lg_check_value = 2**num_bits
 
         if check == ClassicalControlCheck.EQ:
             if (value < 0) or (value >= lg_check_value):
@@ -156,7 +157,7 @@ class BloqBuilder:
 
             else:
                 for index, cbit in enumerate(creg):
-                    if (value >> index) & 1 == 1:
+                    if (value >> (num_bits - 1 - index)) & 1 == 1:  # MSB first ordering
                         # If does not match for cbit_value=1, then branch to label (don't execute the conditional if)
                         self.add_op(Cbz(label=label), creg=cbit)
                     else:
@@ -172,7 +173,7 @@ class BloqBuilder:
 
             else:
                 for index, cbit in enumerate(creg):
-                    target_bit_value = (value >> index) & 1
+                    target_bit_value = (value >> (num_bits - 1 - index)) & 1
 
                     if target_bit_value == 1:
                         # If a mismatch match for cbit_value=1, then branch to neqlabel
@@ -199,7 +200,7 @@ class BloqBuilder:
                 gt_label = Label(uuid4().hex)
 
                 for index, cbit in enumerate(creg):
-                    target_bit_value = (value >> index) & 1
+                    target_bit_value = (value >> (num_bits - 1 - index)) & 1
 
                     # We break at first point of discontinuity (but to different labels)
                     if target_bit_value == 1:
@@ -226,7 +227,7 @@ class BloqBuilder:
             ):  # for value larger than 2^m, condition is always true
                 lt_label = Label(uuid4().hex)
                 for index, cbit in enumerate(creg):
-                    target_bit_value = (value >> index) & 1
+                    target_bit_value = (value >> (num_bits - 1 - index)) & 1
 
                     # We break at first point of discontinuity (but to different labels)
                     if target_bit_value == 1:

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -1,1 +1,25 @@
-class Bloq: ...
+from contextlib import contextmanager
+from dataclasses import dataclass
+from qutip_qip.operations import OpInstruction
+
+
+@dataclass(frozen=True)
+class Bloq:
+    qreg_dim: tuple[int, ...]
+    aux_qreg_dim: tuple[int, ...] = ()
+
+    qreg_count: int
+    creg_count: int
+    instructions: tuple[OpInstruction, ...]
+
+    # qreg_dim, qreg_count, creg_count etc. has been copied here, although
+    # these we can directly access from the associated Op, so that Op and Bloq remain separate
+    # The only linking between them happens via the BloqRepository.
+
+
+class BloqBuilder:
+    def add_aux_qreg(self, count=1, dim=2) -> tuple[int, ...]: ...
+    def add_op(self, op, qregs, cregs=()) -> None: ...
+
+    @contextmanager
+    def if_test(self, creg, value: int, check="EQ") -> None: ...

--- a/src/qutip_qip/operations/bloq.py
+++ b/src/qutip_qip/operations/bloq.py
@@ -1,3 +1,4 @@
+import math
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from uuid import uuid4
@@ -16,22 +17,53 @@ class Bloq:
     global_phase: float = 0.0
     instructions: tuple[OpInstruction, ...] = ()
 
-    # qreg_dim, qreg_count, creg_count etc. has been copied here, although these
-    # can be directly access from the associated Op, they are separate so that Op and Bloq
-    # remain separate. The only linking between them happens via the BloqRepository.
+    # Op and Bloq are kept separate and qreg_dim, qreg_count, creg_count etc. have been copied here.
+    # The only linking between them happens via the BloqRepository.
 
 
 class BloqBuilder:
-    def __init__(self, num_qreg: int, num_creg: int = 0) -> None:
-        self.num_qreg = num_qreg
-        self.num_creg = num_creg
+    def __init__(
+        self, num_qreg: int, num_creg: int = 0, qreg_dim: tuple[int, ...] | None = None
+    ) -> None:
+        self._num_qreg = num_qreg
+        self._num_creg = num_creg
+        self._op_instructions = []
+        self._global_phase = 0.0
+
+        if (qreg_dim is not None) and (len(qreg_dim) != num_qreg):
+            raise ValueError(
+                f"Lenght of qreg_dim={qreg_dim} must be equal to num_qreg={num_qreg}"
+            )
+
+        if self._qreg_dim is None:
+            self._qreg_dim = (2,) * num_qreg
+        else:
+            self._qreg_dim = tuple(qreg_dim)
+
+    @property
+    def num_qreg(self) -> int:
+        return self._num_qreg
+
+    @property
+    def num_creg(self) -> int:
+        return self._num_creg
+
+    @property
+    def instructions(self) -> list[OpInstruction]:
+        return self._op_instructions
+
+    @property
+    def global_phase(self) -> float:
+        return self._global_phase
+
+    def add_global_phase(self, phase: float) -> None:
+        self._global_phase += phase
+        self._global_phase %= 2 * math.pi
 
     def add_aux_qreg(self, count=1, dim=2) -> tuple[int, ...]: ...
     def add_op(self, op, qregs, cregs=()) -> None: ...
 
     @contextmanager
     def if_test(self, creg, value: int, check="EQ") -> None: ...
-
-    def add_global_phase(self, phase: float) -> None: ...
 
     def build(self) -> Bloq: ...

--- a/src/qutip_qip/operations/conditional.py
+++ b/src/qutip_qip/operations/conditional.py
@@ -24,6 +24,8 @@ class Conditional(Op):
         object.__setattr__(self, "label", label)
 
 
+# TODO: Implement this in future using NOT + Cbnz
+# So we won't require 3 classes, only one
 class Cbz(Conditional):
     "Conditional branch on zero"
 

--- a/src/qutip_qip/operations/conditional.py
+++ b/src/qutip_qip/operations/conditional.py
@@ -7,10 +7,10 @@ class Label(Op):
     """A static marker in the instruction list."""
 
     def __init__(self, name):
-        super().__init__(_name=name)
+        super(Label, self).__init__(_name=name)
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
+# @dataclass
 class Conditional(Op):
     """Classical conditional control flow statements"""
 

--- a/src/qutip_qip/operations/conditional.py
+++ b/src/qutip_qip/operations/conditional.py
@@ -1,6 +1,16 @@
 from dataclasses import dataclass
+from enum import StrEnum
 
 from qutip_qip.operations import Op
+
+
+class ClassicalControlCheck(StrEnum):
+    EQ = "EQ"
+    NEQ = "NEQ"
+    GT = "GT"
+    LT = "LT"
+    GTE = "GTE"  # This can be subimplemented using GT - 1
+    LTE = "LTE"
 
 
 class Label(Op):

--- a/src/qutip_qip/operations/gateclass.py
+++ b/src/qutip_qip/operations/gateclass.py
@@ -1,11 +1,12 @@
 # annotations import won't be needed after minimum version becomes 3.14 (PEP 749)
 from __future__ import annotations
 import inspect
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod
 from typing import Type
 
 import numpy as np
 from qutip import Qobj
+from .op import Op
 from qutip_qip.operations.namespace import NameSpace
 
 _read_only_set: set[str] = set(
@@ -122,7 +123,7 @@ class _GateMetaClass(ABCMeta):
         return f"Gate({gatename}, num_qubits={num_qubits})"
 
 
-class Gate(ABC, metaclass=_GateMetaClass):
+class Gate(Op, metaclass=_GateMetaClass):
     r"""
     Abstract base class for a quantum gate.
 

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -4,11 +4,12 @@ import qutip
 from qutip import basis
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
+from .op import Op
 
 __all__ = ["Mz"]
 
 
-class Measurement:
+class Measurement(Op):
     """
     Representation of a quantum measurement, with its required parameters,
     and target qubits.

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -10,7 +10,8 @@ from qutip_qip.utils import convert_type_input_to_sequence
 P = TypeVar("P")
 
 
-@dataclass(frozen=True, slots=True)
+# @dataclass(frozen=True)  # TODO: Add slots when minimum Python is bumped to 3.14
+@dataclass
 class Op:
     _name: str
     uuid: str = field(default_factory=lambda: uuid4().hex)

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 from uuid import uuid4
@@ -22,11 +23,11 @@ class Op:
         else:
             return f"{self._name}({', '.join(map(str, self.params))})"
 
-    creg_count: int = 0
     qreg_dim: tuple[int, ...] = ()
+    num_creg: int = 0
 
     @property
-    def qreg_count(self) -> int:
+    def num_qreg(self) -> int:
         return len(self.qreg_dim)
 
     unitary: bool = True
@@ -35,7 +36,7 @@ class Op:
 
 # Think of Parametric Op as Op Factory, takes params and returns a Op
 # TODO: Update this typing when updating min Python version to 3.12
-class ParametricOp(Generic[P]):
+class ParametricOp(ABC, Generic[P]):
     def __call__(self, *params) -> Op: ...
     def validate_params(self, *params: P) -> None: ...
 

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
+from uuid import uuid4
 
 # TODO: Add typing bound constraint to this
 P = TypeVar("P")
@@ -7,6 +8,7 @@ P = TypeVar("P")
 
 @dataclass(frozen=True, slots=True)
 class Op:
+    uuid: str = field(default_factory=lambda: uuid4().hex)
     _name: str
     params: tuple[P, ...] = ()
 
@@ -45,6 +47,3 @@ class OpInstruction:
 
     def __post_init__(self):
         pass
-
-    def __str__(self):
-        print(f"op={self.op}, qreg={self.qreg}, creg={self.creg}, style({self.style})")

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -5,7 +5,7 @@ from typing import Generic, TypeVar
 P = TypeVar("P")
 
 
-@dataclass(frozen=True)
+@dataclass
 class Op:
     _name: str
     params: tuple[P, ...] = ()
@@ -17,8 +17,12 @@ class Op:
         else:
             return f"{self._name}({', '.join(map(str, self.params))})"
 
+    @name.setter
+    def name(self, new_name: str) -> None:
+        self._name = new_name
+
     creg_count: int = 0
-    qreg_dim: tuple[int, ...]
+    qreg_dim: tuple[int, ...] = ()
 
     @property
     def qreg_count(self) -> int:

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -11,8 +11,8 @@ P = TypeVar("P")
 
 @dataclass(frozen=True, slots=True)
 class Op:
-    uuid: str = field(default_factory=lambda: uuid4().hex)
     _name: str
+    uuid: str = field(default_factory=lambda: uuid4().hex)
     params: tuple[P, ...] = ()
 
     @property
@@ -49,8 +49,11 @@ class OpInstruction:
     style: dict = field(default_factory=dict)  # For circuit draw
 
     def __post_init__(self):
-        if not (isinstance(self.op, Op) or issubclass(self.op, Op)):
-            raise TypeError("op must be a subclass or instance of type Op")
+        # TODO: Enable this after Gate, Measurement class also inherit from Op
+        # if not (isinstance(self.op, Op)) or (
+        #     (isinstance(self.op, type) and issubclass(self.op, Op))
+        # ):
+        #     raise TypeError("op must be a subclass or instance of type Op")
 
-        convert_type_input_to_sequence(self.qreg, "qreg", Int)
-        convert_type_input_to_sequence(self.creg, "creg", Int)
+        convert_type_input_to_sequence(Int, "qreg", self.qreg)
+        convert_type_input_to_sequence(Int, "creg", self.creg)

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -5,7 +5,7 @@ from typing import Generic, TypeVar
 P = TypeVar("P")
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Op:
     _name: str
     params: tuple[P, ...] = ()
@@ -16,10 +16,6 @@ class Op:
             return self._name
         else:
             return f"{self._name}({', '.join(map(str, self.params))})"
-
-    @name.setter
-    def name(self, new_name: str) -> None:
-        self._name = new_name
 
     creg_count: int = 0
     qreg_dim: tuple[int, ...] = ()

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -51,11 +51,11 @@ class OpInstruction:
     style: dict = field(default_factory=dict)  # For circuit draw
 
     def __post_init__(self):
-        # TODO: Enable this after Gate, Measurement class also inherit from Op
-        # if not (isinstance(self.op, Op)) or (
-        #     (isinstance(self.op, type) and issubclass(self.op, Op))
-        # ):
-        #     raise TypeError("op must be a subclass or instance of type Op")
+        if not (
+            isinstance(self.op, Op)
+            or ((isinstance(self.op, type) and issubclass(self.op, Op)))
+        ):
+            raise TypeError("op must be a subclass or instance of type Op")
 
         convert_type_input_to_sequence(Int, "qreg", self.qreg)
         convert_type_input_to_sequence(Int, "creg", self.creg)

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -1,1 +1,50 @@
-class Op: ...
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+# TODO: Add typing bound constraint to this
+P = TypeVar("P")
+
+
+@dataclass(frozen=True)
+class Op:
+    _name: str
+    params: tuple[P, ...] = ()
+
+    @property
+    def name(self) -> str:  # e.g. "MultiSWAP(3)" for drawing
+        if not self.params:
+            return self._name
+        else:
+            return f"{self._name}({', '.join(map(str, self.params))})"
+
+    creg_count: int = 0
+    qreg_dim: tuple[int, ...]
+
+    @property
+    def qreg_count(self) -> int:
+        return len(self.qreg_dim)
+
+    unitary: bool = True
+    self_inverse: bool = False
+
+
+# Think of Parametric Op as Op Factory, takes params and returns a Op
+# TODO: Update this typing when updating min Python version to 3.12
+class ParametricOp(Generic[P]):
+    def __call__(self, *params) -> Op: ...
+    def validate_params(self, *params: P) -> None: ...
+
+
+# Class to keep track of this Op on this qubit, cbit
+@dataclass(frozen=True, slots=True)
+class OpInstruction:
+    op: Op
+    qreg: tuple[int, ...] = tuple()
+    creg: tuple[int, ...] = tuple()
+    style: dict = field(default_factory=dict)  # For circuit draw
+
+    def __post_init__(self):
+        pass
+
+    def __str__(self):
+        print(f"op={self.op}, qreg={self.qreg}, creg={self.creg}, style({self.style})")

--- a/src/qutip_qip/operations/op.py
+++ b/src/qutip_qip/operations/op.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 from uuid import uuid4
 
+from qutip_qip.typing import Int
+from qutip_qip.utils import convert_type_input_to_sequence
+
 # TODO: Add typing bound constraint to this
 P = TypeVar("P")
 
@@ -46,4 +49,8 @@ class OpInstruction:
     style: dict = field(default_factory=dict)  # For circuit draw
 
     def __post_init__(self):
-        pass
+        if not (isinstance(self.op, Op) or issubclass(self.op, Op)):
+            raise TypeError("op must be a subclass or instance of type Op")
+
+        convert_type_input_to_sequence(self.qreg, "qreg", Int)
+        convert_type_input_to_sequence(self.creg, "creg", Int)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -217,9 +217,11 @@ class TestQubitCircuit:
         qc.add_gate(gates.RY(1.570796), targets=4)
         qc.add_gate(gates.RY(1.570796), targets=5)
         qc.add_gate(gates.CRX(np.pi / 2), controls=[1], targets=[2])
+        qc.build()
 
         qc1 = QubitCircuit(6, num_cbits=2)
         qc1.add_circuit(qc)
+        qc1.build()
 
         # Test if all gates and measurements are added
         assert len(qc1.instructions) == len(qc.instructions)
@@ -249,6 +251,7 @@ class TestQubitCircuit:
 
         qc2 = QubitCircuit(8, num_cbits=2)
         qc2.add_circuit(qc, start=2)
+        qc2.build()
 
         # Test if all gates are added
         assert len(qc2.instructions) == len(qc.instructions)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -449,6 +449,7 @@ class TestQubitCircuit:
         qc.add_state("-", targets=[1])
 
         qc_rev = qc.reverse_circuit()
+        qc_rev.build()
 
         assert qc_rev.instructions[0].operation == gates.H
         assert isinstance(qc_rev.instructions[1].operation, Measurement)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -322,11 +322,12 @@ class TestQubitCircuit:
         assert qc.instructions[0].qubits[0] == 0
         assert qc.instructions[0].cbits[0] == 0
         assert isinstance(qc.instructions[3].operation, Measurement)
-        assert qc.instructions[5].cbits[0] == 2
+        assert qc.instructions[5].cbits[0] == 1
 
         # checking if gates are added correctly with measurements
         assert qc.instructions[2].operation == gates.TOFFOLI
-        assert qc.instructions[4].cbits == (0, 1)
+        assert qc.instructions[4].cbits == (0,)
+        assert qc.instructions[5].cbits == (1,)
 
     @pytest.mark.parametrize("gate", [gates.X, gates.Y, gates.Z, gates.S, gates.T])
     def test_exceptions(self, gate):

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -75,9 +75,15 @@ def test_qasm_addcircuit():
     check_gate_instruction_defn(qc.instructions[3], "CX", (1,), (0,))
     check_gate_instruction_defn(qc.instructions[4], "H", (0,))
     check_gate_instruction_defn(qc.instructions[5], "H", (1,))
-    check_gate_instruction_defn(qc.instructions[6], "H", (0,), (), (0, 1), 0)
-    check_measurement_defn(qc.instructions[7], "M", (0,), (0,))
-    check_measurement_defn(qc.instructions[8], "M", (1,), (1,))
+    assert qc.instructions[6].is_conditional_instruction()
+    assert qc.instructions[6].operation.name == "Cbnz"
+    assert qc.instructions[6].cbits == (0,)
+    assert qc.instructions[7].operation.name == "Cbnz"
+    assert qc.instructions[7].cbits == (1,)
+    check_gate_instruction_defn(qc.instructions[8], "H", (0,))
+    assert qc.instructions[9].is_label_instruction()
+    check_measurement_defn(qc.instructions[10], "M", (0,), (0,))
+    check_measurement_defn(qc.instructions[11], "M", (1,), (1,))
 
 
 def test_custom_gates():

--- a/tests/test_qpe.py
+++ b/tests/test_qpe.py
@@ -122,7 +122,11 @@ class TestQPE(unittest.TestCase):
         num_counting = 2
 
         circuit1 = qpe(U, num_counting_qubits=num_counting, to_cnot=False)
+        circuit1.build()
+
         circuit2 = qpe(U, num_counting_qubits=num_counting, to_cnot=True)
+        circuit2.build()
+
         has_cnot = any(gate.operation == std.CX for gate in circuit2.instructions)
         assert_(has_cnot)
         assert_(len(circuit2.instructions) > len(circuit1.instructions))

--- a/tests/test_shor_code.py
+++ b/tests/test_shor_code.py
@@ -11,7 +11,7 @@ def code():
 def test_shor_circuit_structure(code):
     qc = code.encode_circuit()
     assert qc.num_qubits == 9
-    assert len(qc.instructions) > 0
+    assert len(qc.ops) > 0
 
 
 def test_shor_encodes_zero(code):


### PR DESCRIPTION
**Description**
Add Op, Bloq Design as per #362 and integrates `BloqBuilder` within `QuantumCircuit` internally.

@BoxiLi In next PR I will implement the Op resolving part and will also clean up the `qc.resolve_gates` and decomposition patching we had using the former, so keeping the work until now as a separate PR.

Also I have deprecated, removed (with warning) a few methods in `QubitCircuit` which are either trivial like `reverse_circuit` or will no longer be possible e.g. `remove_gates_and_measurements`.

Note for myself: qasm generation for `if_test` needs to be looked into after the next PR.

**Related issues or PRs**
None

**AI Tools Usage Disclosure**
None