### PR TITLE
Measurement: Einsum Optimisation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           # For the sdist we should be as conservative as possible with our
           # Python version.  This should be the lowest supported version.  This
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           # This is about the build environment, not the released wheel version.
           python-version: '3.11'
@@ -133,7 +133,7 @@ jobs:
         uses: actions/download-artifact@v8
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -25,7 +25,7 @@ jobs:
           uses: actions/checkout@v7
 
         - name: Set up Python
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@v7
           with:
             python-version: 3.12
             cache: "pip"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/pulse-paper.yaml
+++ b/.github/workflows/pulse-paper.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: 3.12
           cache: "pip"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -53,7 +53,7 @@ A circuit with the various gates and registers available is demonstrated below:
   :options: +NORMALIZE_WHITESPACE
 
     [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      MeasurementInstruction(operation= Measurement(M), qubits=(1,), cbits=(0,), style={}),
+      MeasurementInstruction(operation=<class 'qutip_qip.operations.measurement.Mz'>, qubits=(1,), cbits=(0,), style={}),
       GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
       GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), style=None, cbits_ctrl_value=1),
       GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None)]

--- a/doc/source/qip-basics.rst
+++ b/doc/source/qip-basics.rst
@@ -53,7 +53,7 @@ A circuit with the various gates and registers available is demonstrated below:
   :options: +NORMALIZE_WHITESPACE
 
     [GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
-      MeasurementInstruction(operation=<class 'qutip_qip.operations.measurement.Mz'>, qubits=(1,), cbits=(0,), style={}),
+      MeasurementInstruction(operation=Measurement(Mz), qubits=(1,), cbits=(0,), style={}),
       GateInstruction(operation=Gate(CX, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None),
       GateInstruction(operation=Gate(X, num_qubits=1), qubits=(0,), cbits=(0,), style=None, cbits_ctrl_value=1),
       GateInstruction(operation=Gate(SWAP, num_qubits=2), qubits=(0, 1), cbits=(), style=None, cbits_ctrl_value=None)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.9.2",
-    "qutip>=5.0",
+    "qutip>=5.4",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -19,7 +19,7 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
-    operation: Gate | Type[Gate] | Measurement | Type[Measurement]
+    operation: Gate | Type[Gate] | Type[Measurement]
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
     style: dict = field(default_factory=dict)

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -19,7 +19,7 @@ def _validate_non_negative_int_tuple(T: any, txt: str = ""):
 
 @dataclass(frozen=True, slots=True)
 class CircuitInstruction(ABC):
-    operation: Gate | Type[Gate] | Measurement
+    operation: Gate | Type[Gate] | Measurement | Type[Measurement]
     qubits: tuple[int, ...] = tuple()
     cbits: tuple[int, ...] = tuple()
     style: dict = field(default_factory=dict)
@@ -168,7 +168,13 @@ class MeasurementInstruction(CircuitInstruction):
 
     def __post_init__(self) -> None:
         super(MeasurementInstruction, self).__post_init__()
-        if not isinstance(self.operation, Measurement):
+        if not (
+            isinstance(self.operation, Measurement)
+            or (
+                isinstance(self.operation, type)
+                and issubclass(self.operation, Measurement)
+            )
+        ):
             raise TypeError(f"Operation must be a measurement, got {self.operation}")
 
         if len(self.qubits) != len(self.cbits):

--- a/src/qutip_qip/circuit/instruction.py
+++ b/src/qutip_qip/circuit/instruction.py
@@ -3,6 +3,7 @@ from typing import Type
 from dataclasses import dataclass, field
 import warnings
 from qutip_qip.operations import Gate, Measurement
+from qutip_qip.operations.measurement import Mz
 
 
 def _validate_non_negative_int_tuple(T: any, txt: str = ""):
@@ -185,6 +186,10 @@ class MeasurementInstruction(CircuitInstruction):
         return True
 
     def to_qasm(self, qasm_out) -> None:
+        if self.operation is not Mz:
+            raise NotImplementedError(
+                f"Exporting non-Z basis measurement ({self.operation}) to QASM is not supported."
+            )
         for qubit, cbit in zip(self.qubits, self.cbits):
             qasm_out.output(f"measure q[{qubit}] -> c[{cbit}];")
 

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -1,15 +1,18 @@
 from itertools import product
 from operator import mul
 from functools import reduce
+from typing import Type
 import numpy as np
 import string
 
 from qutip import ket2dm, Qobj
 from qutip.core import data as _data
 from qutip.core.dimensions import einsum
+from qutip.measurement import measurement_statistics
 from qutip_qip.circuit.simulator import CircuitResult
-from qutip_qip.operations import expand_operator, Gate
+from qutip_qip.operations import expand_operator, Gate, Measurement
 from qutip_qip.typing import IntSequence
+from qutip_qip.circuit.simulator import CircuitResult
 
 
 def _decimal_to_binary(decimal, length):
@@ -515,14 +518,19 @@ class CircuitSimulator:
 
         return state
 
-    def _apply_measurement(self, operation, qubits, cbits):
+    def _apply_measurement(
+        self,
+        operation: Measurement | Type[Measurement],
+        qubits: tuple[int, ...],
+        cbits: tuple[int, ...],
+    ) -> Qobj:
         """
         Applies measurement gate specified by operation to current state.
 
         Parameters
         ----------
-        operation: :class:`.Measurement`
-            Measurement gate in a circuit object.
+        operation: :class:`.Measurement` or Type[:class:`.Measurement`]
+            Measurement gate in a circuit object or its class.
         qubits : tuple of int
             The indices of the qubits to be measured.
         cbits : tuple of int
@@ -534,7 +542,16 @@ class CircuitSimulator:
         state : qutip.Qobj
             The collapsed state after the measurement.
         """
-        states, probabilities = operation.measurement_comp_basis(self.state, qubits)
+        current_state = self.state
+        n = int(np.log2(current_state.shape[0]))
+        if isinstance(operation, type) and issubclass(operation, Measurement):
+            operation = operation()
+        raw_ops = operation.get_measurement_ops()
+        measurement_ops = [
+            expand_operator(oper=op, dims=[2] * n, targets=qubits) for op in raw_ops
+        ]
+
+        states, probabilities = measurement_statistics(current_state, measurement_ops)
 
         if self.mode == "state_vector_simulator":
             if self._measure_results:
@@ -542,7 +559,8 @@ class CircuitSimulator:
                 self._measure_ind += 1
             else:
                 probabilities = [p / sum(probabilities) for p in probabilities]
-                i = np.random.choice([0, 1], p=probabilities)
+                outcome_indices = np.arange(len(probabilities))
+                i = np.random.choice(outcome_indices, p=probabilities)
             self._probability *= probabilities[i]
             state = states[i]
             if cbits:

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -612,7 +612,10 @@ class CircuitSimulator:
             )
 
             for op in raw_ops:
-                unnorm_state = einsum(eq, op, current_state)
+                if state_dtype == "CuState":
+                    unnorm_state = self._evolve_state(op, qubits, current_state)
+                else:
+                    unnorm_state = einsum(eq, op, current_state)
                 p = float(np.real(unnorm_state.overlap(unnorm_state)))
 
                 if p >= tol:
@@ -644,7 +647,10 @@ class CircuitSimulator:
             unnorm_states = []
 
             for op in raw_ops:
-                unnorm_rho = einsum(eq, op, current_state, op.dag())
+                if state_dtype == "CuState":
+                    unnorm_rho = self._evolve_state(op, qubits, current_state)
+                else:
+                    unnorm_rho = einsum(eq, op, current_state, op.dag())
                 p = float(np.real(unnorm_rho.tr()))
 
                 if p >= tol:

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -544,7 +544,7 @@ class CircuitSimulator:
         """
         current_state = self.state
         n = self.qc.num_qubits
-        if issubclass(operation, Measurement):
+        if isinstance(operation, type) and issubclass(operation, Measurement):
             operation = operation()
         raw_ops = operation.get_measurement_ops()
         measurement_ops = [

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -2,6 +2,7 @@ from itertools import product
 from operator import mul
 from functools import reduce
 from typing import Type
+import string
 import numpy as np
 import string
 
@@ -244,9 +245,14 @@ class CircuitSimulator:
         if self.qc.instructions[self._op_index].is_measurement_instruction():
             targets = circ_instruction.qubits
             classical_store = circ_instruction.cbits
-            state = self._apply_measurement(
-                circ_instruction.operation, targets, classical_store
-            )
+            if self.mode in ("state_vector_simulator", "density_matrix_simulator"):
+                state = self._apply_measurement_einsum(
+                    circ_instruction.operation, targets, classical_store
+                )
+            else:
+                state = self._apply_measurement(
+                    circ_instruction.operation, targets, classical_store
+                )
 
         elif self.qc.instructions[self._op_index].is_gate_instruction():
             gate = circ_instruction.operation
@@ -571,6 +577,93 @@ class CircuitSimulator:
             states = list(filter(lambda x: x is not None, states))
             probabilities = list(filter(lambda x: x != 0, probabilities))
             state = sum(p * s for s, p in zip(states, probabilities))
+
+        else:
+            raise NotImplementedError(f"mode {self.mode} is not available.")
+
+        return state
+
+    def _apply_measurement_einsum(
+        self,
+        operation: Measurement,
+        qubits: tuple[int, ...],
+        cbits: tuple[int, ...],
+    ) -> Qobj:
+        """
+        Applies measurement gate specified by operation using tensor contraction (einsum).
+        """
+        current_state = self.state
+        num_qubits = self.qc.num_qubits
+        if isinstance(operation, type) and issubclass(operation, Measurement):
+            operation = operation()
+
+        state_dtype = type(current_state.data).__name__
+        op_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+
+        raw_ops = [op.to(op_dtype) for op in operation.get_measurement_ops()]
+
+        states = []
+        probabilities = []
+        tol = qutip.settings.core["atol"]
+
+        if self.mode == "state_vector_simulator":
+            eq = self._generate_einsum_eq(
+                qubits, num_qubits, is_oper=current_state.isoper
+            )
+
+            for op in raw_ops:
+                unnorm_state = einsum(eq, op, current_state)
+                p = float(np.real(unnorm_state.overlap(unnorm_state)))
+
+                if p >= tol:
+                    states.append(unnorm_state / np.sqrt(p))
+                    probabilities.append(p)
+                else:
+                    states.append(None)
+                    probabilities.append(0.0)
+
+            if self._measure_results:
+                i = int(self._measure_results[self._measure_ind])
+                self._measure_ind += 1
+            else:
+                prob_sum = sum(probabilities)
+                if prob_sum > 0:
+                    norm_probs = [p / prob_sum for p in probabilities]
+                else:
+                    norm_probs = [1.0 / len(probabilities)] * len(probabilities)
+                i = np.random.choice(len(probabilities), p=norm_probs)
+
+            self._probability *= probabilities[i]
+            state = states[i]
+            if cbits:
+                cbit_index = cbits[0]
+                self.cbits[cbit_index] = i
+
+        elif self.mode == "density_matrix_simulator":
+            eq = self._generate_dm_einsum_eq(qubits, num_qubits)
+            unnorm_states = []
+
+            for op in raw_ops:
+                unnorm_rho = einsum(eq, op, current_state, op.dag())
+                p = float(np.real(unnorm_rho.tr()))
+
+                if p >= tol:
+                    states.append(unnorm_rho / p)
+                    probabilities.append(p)
+                    unnorm_states.append(unnorm_rho)
+                else:
+                    states.append(None)
+                    probabilities.append(0.0)
+
+            if self._measure_results:
+                i = int(self._measure_results[self._measure_ind])
+                self._measure_ind += 1
+                self._probability *= probabilities[i]
+                state = states[i]
+                if cbits:
+                    self.cbits[cbits[0]] = i
+            else:
+                state = sum(unnorm_states) if unnorm_states else current_state
 
         else:
             raise NotImplementedError(f"mode {self.mode} is not available.")

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -4,16 +4,13 @@ from functools import reduce
 from typing import Type
 import string
 import numpy as np
-import string
 
-from qutip import ket2dm, Qobj
-from qutip.core import data as _data
-from qutip.core.dimensions import einsum
+from qutip import ket2dm, Qobj, einsum
+from qutip.settings import settings
 from qutip.measurement import measurement_statistics
 from qutip_qip.circuit.simulator import CircuitResult
 from qutip_qip.operations import expand_operator, Gate, Measurement
 from qutip_qip.typing import IntSequence
-from qutip_qip.circuit.simulator import CircuitResult
 
 
 def _decimal_to_binary(decimal, length):
@@ -286,7 +283,11 @@ class CircuitSimulator:
         self._op_index += 1
 
     def _generate_einsum_eq(
-        self, targets: int | IntSequence, num_qubits: int, is_oper: bool = False
+        self,
+        targets: int | IntSequence,
+        num_qubits: int,
+        num_cols: int = 1,
+        is_oper: bool = False,
     ) -> str:
         """
         Generates the einsum string for tensor contraction supporting up to 52 qubits.
@@ -298,6 +299,8 @@ class CircuitSimulator:
             The target qubits the gate acts on.
         num_qubits : int
             The total number of qubits (tensor dimensions) in the state.
+        num_cols : int, optional
+            The number of column dimensions in the state representation.
         is_oper : bool, optional
             Whether the state is an operator (e.g. unitary matrix) or ket vector.
 
@@ -322,14 +325,12 @@ class CircuitSimulator:
 
         sub_gate = "".join(gate_out + gate_in)
 
-        if is_oper:
-            col_in = list(chars[num_qubits + k : 2 * num_qubits + k])
-            sub_state = "".join(row_in + col_in)
-            sub_out = "".join(row_out + col_in)
-        else:
-            col_char = chars[num_qubits + k]
-            sub_state = "".join(row_in) + col_char
-            sub_out = "".join(row_out) + col_char
+        if is_oper and num_cols == 1:
+            num_cols = num_qubits
+
+        col_in = list(chars[num_qubits + k : num_qubits + k + num_cols])
+        sub_state = "".join(row_in + col_in)
+        sub_out = "".join(row_out + col_in)
 
         return f"{sub_gate},{sub_state}->{sub_out}"
 
@@ -381,15 +382,15 @@ class CircuitSimulator:
         return f"{sub_U},{sub_rho},{sub_Udag}->{sub_out}"
 
     def _evolve_state(
-        self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
+        self, operation: Gate | Qobj, targets_indices: int | IntSequence, state: Qobj
     ) -> Qobj:
         """
          Applies a unitary gate to the quantum state using operator expansion.
 
          Parameters
          ----------
-        operation : :class:`.Gate`
-             The quantum gate to be applied.
+        operation : :class:`.Gate` or :class:`qutip.Qobj`
+             The quantum gate or operator to be applied.
          targets_indices : int or sequence of int
              The indices of the target qubits.
          state : :class:`qutip.Qobj`
@@ -406,10 +407,12 @@ class CircuitSimulator:
         # Construct CuOperator with explicit hilbert_dims and target mode mapping
         # so cuQuantum knows which qubit sites to act on (calling .to('CuOperator')
         # on raw gate Qobjs loses multipartite mode information).
+        gate_qobj = (
+            operation.get_qobj() if hasattr(operation, "get_qobj") else operation
+        )
         if gate_dtype == "CuOperator":
             from qutip_cuquantum.operator import CuOperator as CuOperatorClass
 
-            gate_qobj = operation.get_qobj()
             U = Qobj(
                 CuOperatorClass(
                     gate_qobj.data,
@@ -419,7 +422,7 @@ class CircuitSimulator:
                 dims=gate_qobj.dims,
             )
         else:
-            U = operation.get_qobj().to(gate_dtype)
+            U = gate_qobj.to(gate_dtype)
 
         U = expand_operator(
             U,
@@ -465,20 +468,14 @@ class CircuitSimulator:
 
         gate_qobj = operation.get_qobj().to(gate_dtype)
 
-        original_dims = state.dims
-        original_shape = state.shape
-
         num_dims = len(self._state_dims[0])
+        num_cols = len(state.dims[1])
         is_oper = state.isoper
-        eq = self._generate_einsum_eq(targets_indices, num_dims, is_oper=is_oper)
-
-        malformed_state = einsum(eq, gate_qobj, state)
-        reshaped_data = _data.reshape(
-            malformed_state.data, original_shape[0], original_shape[1]
+        eq = self._generate_einsum_eq(
+            targets_indices, num_dims, num_cols=num_cols, is_oper=is_oper
         )
-        state = Qobj(reshaped_data, dims=original_dims).to(state_dtype)
 
-        return state
+        return einsum(eq, gate_qobj, state)
 
     def _evolve_state_einsum_dm(
         self, operation: Gate, targets_indices: int | IntSequence, state: Qobj
@@ -510,19 +507,10 @@ class CircuitSimulator:
 
         gate_qobj = operation.get_qobj().to(gate_dtype)
 
-        original_dims = state.dims
-        original_shape = state.shape
-
         num_dims = len(self._state_dims[0])
         eq = self._generate_dm_einsum_eq(targets_indices, num_dims)
 
-        malformed_state = einsum(eq, gate_qobj, state, gate_qobj.dag())
-        reshaped_data = _data.reshape(
-            malformed_state.data, original_shape[0], original_shape[1]
-        )
-        state = Qobj(reshaped_data, dims=original_dims).to(state_dtype)
-
-        return state
+        return einsum(eq, gate_qobj, state, gate_qobj.dag())
 
     def _apply_measurement(
         self,
@@ -585,12 +573,27 @@ class CircuitSimulator:
 
     def _apply_measurement_einsum(
         self,
-        operation: Measurement,
+        operation: Measurement | Type[Measurement],
         qubits: tuple[int, ...],
         cbits: tuple[int, ...],
     ) -> Qobj:
         """
         Applies measurement gate specified by operation using tensor contraction (einsum).
+
+        Parameters
+        ----------
+        operation : :class:`.Measurement` or Type[:class:`.Measurement`]
+            Measurement gate in a circuit object or its class.
+        qubits : tuple of int
+            The indices of the qubits to be measured.
+        cbits : tuple of int
+            The indices of the classical registers where the measurement
+            results will be stored.
+
+        Returns
+        -------
+        state : :class:`qutip.Qobj`
+            The collapsed state after the measurement.
         """
         current_state = self.state
         num_qubits = self.qc.num_qubits
@@ -598,17 +601,20 @@ class CircuitSimulator:
             operation = operation()
 
         state_dtype = type(current_state.data).__name__
-        op_dtype = "CuOperator" if state_dtype == "CuState" else state_dtype
+        raw_ops = operation.get_measurement_ops()
+        # Ops for CuState are converted to CuOperator in _evolve_state()
+        if state_dtype != "CuState":
+            raw_ops = [op.to(state_dtype) for op in raw_ops]
 
-        raw_ops = [op.to(op_dtype) for op in operation.get_measurement_ops()]
+        num_cols = len(current_state.dims[1])
 
         states = []
         probabilities = []
-        tol = qutip.settings.core["atol"]
+        tol = settings.core["atol"]
 
         if self.mode == "state_vector_simulator":
             eq = self._generate_einsum_eq(
-                qubits, num_qubits, is_oper=current_state.isoper
+                qubits, num_qubits, num_cols=num_cols, is_oper=current_state.isoper
             )
 
             for op in raw_ops:

--- a/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
+++ b/src/qutip_qip/circuit/simulator/matrix_mul_simulator.py
@@ -520,7 +520,7 @@ class CircuitSimulator:
 
     def _apply_measurement(
         self,
-        operation: Measurement | Type[Measurement],
+        operation: Type[Measurement],
         qubits: tuple[int, ...],
         cbits: tuple[int, ...],
     ) -> Qobj:
@@ -543,8 +543,8 @@ class CircuitSimulator:
             The collapsed state after the measurement.
         """
         current_state = self.state
-        n = int(np.log2(current_state.shape[0]))
-        if isinstance(operation, type) and issubclass(operation, Measurement):
+        n = self.qc.num_qubits
+        if issubclass(operation, Measurement):
             operation = operation()
         raw_ops = operation.get_measurement_ops()
         measurement_ops = [

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -54,7 +54,6 @@ class ModelProcessor(Processor):
         self.transpile_functions = []
         self._default_compiler = None
 
-
     def run_state(
         self, init_state=None, analytical=False, qc=None, states=None, **kwargs
     ):

--- a/src/qutip_qip/device/modelprocessor.py
+++ b/src/qutip_qip/device/modelprocessor.py
@@ -54,16 +54,6 @@ class ModelProcessor(Processor):
         self.transpile_functions = []
         self._default_compiler = None
 
-    def set_up_params(self):
-        """
-        Save the parameters in the attribute `params` and check the validity.
-        (Defined in subclasses)
-
-        Notes
-        -----
-        All parameters will be multiplied by 2*pi for simplicity
-        """
-        raise NotImplementedError("Parameters should be defined in subclass.")
 
     def run_state(
         self, init_state=None, analytical=False, qc=None, states=None, **kwargs

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -63,7 +63,13 @@ class Measurement:
                         the probability of measuring a state in a the state
                         specified by the index.
         """
-
+        warnings.warn(
+            "'measurement_comp_basis' has been deprecated and will be removed "
+            "in future versions. Please use 'get_measurement_ops()' combined "
+            "with simulator logic, or the upcoming 'apply()' method.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         n = int(np.log2(state.shape[0]))
         target = qubits[0]
         if target < n:

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,6 +1,7 @@
 import numpy as np
 import warnings
 import qutip
+from abc import ABC, abstractmethod
 from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
@@ -8,7 +9,7 @@ from qutip_qip.operations import expand_operator
 __all__ = ["Mz", "Mx", "My"]
 
 
-class Measurement:
+class Measurement(ABC):
     """
     Base class for quantum measurements.
     """
@@ -20,20 +21,18 @@ class Measurement:
         if type(self) is Measurement:
             warnings.warn(
                 "Direct instantiation of Measurement() is deprecated and will "
-                "be removed in future verisions. Please use a specific subclass "
+                "be removed in future versions. Please use a specific subclass "
                 "like 'Mz()' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
+    @abstractmethod
     def get_measurement_ops(self) -> list[Qobj]:
         """
         Returns a list of Kraus operators representing the measurement.
-        (Defaults to Z-basis for backward compatibility)
         """
-        op0 = basis(2, 0) * basis(2, 0).dag()
-        op1 = basis(2, 1) * basis(2, 1).dag()
-        return [op0, op1]
+        pass
 
     @classmethod
     def measurement_comp_basis(cls, state, qubits):

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,46 +1,45 @@
 import numpy as np
 import warnings
 import qutip
-from qutip import basis
+from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
 
-__all__ = ["Mz"]
+__all__ = ["Mz", "Mx", "My"]
 
 
 class Measurement:
     """
-    Representation of a quantum measurement, with its required parameters,
-    and target qubits.
+    Base class for quantum measurements.
     """
 
     name = "M"
+    num_qubits = 1
 
-    def __init__(self, name=None, targets=None, index=None, classical_store=None):
-        """
-        Create a measurement with specified parameters.
-        """
-        if name is not None:
+    def __init__(self, *args, **kwargs) -> None:
+        if type(self) is Measurement:
             warnings.warn(
-                "'name' argument in Measurement has been deprecated.",
+                "Direct instantiation of Measurement() is deprecated and will "
+                "be removed in future verisions. Please use a specific subclass "
+                "like 'Mz()' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
-        if index is not None:
-            raise AttributeError("argument index is no longer supported")
-
-        if targets is not None or classical_store is not None:
-            warnings.warn(
-                "'targets' and 'classical_store' arguments in Measurement are deprecated. "
-                "Please pass these directly to QubitCircuit.add_measurement() method.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    def get_measurement_ops(self) -> list[Qobj]:
+        """
+        Returns a list of Kraus operators representing the measurement.
+        (Defaults to Z-basis for backward compatibility)
+        """
+        op0 = basis(2, 0) * basis(2, 0).dag()
+        op1 = basis(2, 1) * basis(2, 1).dag()
+        return [op0, op1]
 
     @classmethod
     def measurement_comp_basis(cls, state, qubits):
         """
+        DEPRECATED: Old method for computational basis meaasurement.
+
         Measures a particular qubit (determined by the target)
         whose ket vector/ density matrix is specified in the
         computational basis and returns collapsed_states and probabilities
@@ -95,4 +94,31 @@ class Measurement:
         return str(self)
 
 
-Mz = Measurement()
+class Mz(Measurement):
+    name = "Mz"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        op0 = basis(2, 0) * basis(2, 0).dag()
+        op1 = basis(2, 1) * basis(2, 1).dag()
+        return [op0, op1]
+
+
+class Mx(Measurement):
+    name = "Mx"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        plus = (basis(2, 0) + basis(2, 1)).unit()
+        minus = (basis(2, 0) - basis(2, 1)).unit()
+        return [plus * plus.dag(), minus * minus.dag()]
+
+
+class My(Measurement):
+    name = "My"
+    num_qubits = 1
+
+    def get_measurement_ops(self) -> list[Qobj]:
+        plus_y = (basis(2, 0) + 1j * basis(2, 1)).unit()
+        minus_y = (basis(2, 0) - 1j * basis(2, 1)).unit()
+        return [plus_y * plus_y.dag(), minus_y * minus_y.dag()]

--- a/src/qutip_qip/operations/measurement.py
+++ b/src/qutip_qip/operations/measurement.py
@@ -1,7 +1,7 @@
 import numpy as np
 import warnings
 import qutip
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from qutip import basis, Qobj
 from qutip.measurement import measurement_statistics
 from qutip_qip.operations import expand_operator
@@ -9,7 +9,16 @@ from qutip_qip.operations import expand_operator
 __all__ = ["Mz", "Mx", "My"]
 
 
-class Measurement(ABC):
+class _MeasurementMetaClass(ABCMeta):
+    def __repr__(cls) -> str:
+        name = getattr(cls, "name", cls.__name__)
+        return f"Measurement({name})"
+
+    def __str__(cls) -> str:
+        return repr(cls)
+
+
+class Measurement(ABC, metaclass=_MeasurementMetaClass):
     """
     Base class for quantum measurements.
     """
@@ -22,7 +31,7 @@ class Measurement(ABC):
             warnings.warn(
                 "Direct instantiation of Measurement() is deprecated and will "
                 "be removed in future versions. Please use a specific subclass "
-                "like 'Mz()' instead.",
+                "like 'Mz' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -65,7 +74,7 @@ class Measurement(ABC):
         warnings.warn(
             "'measurement_comp_basis' has been deprecated and will be removed "
             "in future versions. Please use 'get_measurement_ops()' combined "
-            "with simulator logic, or the upcoming 'apply()' method.",
+            "with simulator logic.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -92,7 +101,7 @@ class Measurement(ABC):
 
     def __str__(self):
         if self.name:
-            return f" Measurement({self.name})"
+            return f"Measurement({self.name})"
         return "Measurement"
 
     def __repr__(self):

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1009,6 +1009,43 @@ class TestEinsumBackend:
 
         np.testing.assert_allclose(res_einsum.full(), expected_oper.full(), atol=1e-12)
 
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    @pytest.mark.parametrize("dtype", AVAILABLE_DTYPES)
+    def test_measurement_einsum_evolution(self, dtype):
+        """
+        Test measurement einsum evolution across backends (Dense, JAX, CuState).
+        """
+        if dtype == "CuState":
+            import qutip_cuquantum
+            from cuquantum.densitymat import WorkStream
+
+            qutip_cuquantum.set_as_default(WorkStream())
+
+        try:
+            qc = QubitCircuit(2, num_cbits=1)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+            qc.add_measurement(Mz, targets=[0], classical_store=0)
+
+            init_state = tensor(basis(2, 0), basis(2, 0)).to(dtype)
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            result = sim.run(init_state)
+
+            final_state = result.get_final_states()[0]
+            assert type(final_state.data) is type(init_state.data)
+            assert sim.cbits[0] in (0, 1)
+
+            if sim.cbits[0] == 0:
+                expected = tensor(basis(2, 0), basis(2, 0))
+            else:
+                expected = tensor(basis(2, 1), basis(2, 1))
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            if dtype == "CuState":
+                qutip_cuquantum.set_as_default(reverse=True)
+
 
 class TestAddGateError:
     def test_add_gate_errors(self):
@@ -1229,117 +1266,3 @@ def test_gates_class():
     result2 = circuit2.run(init_state)
 
     assert pytest.approx(qutip.fidelity(result1, result2), 1.0e-6) == 1
-
-
-try:
-    import qutip_cuquantum
-
-    HAS_CUQANTUM = True
-except ImportError:
-    HAS_CUQANTUM = False
-
-
-class TestCuQuantumBackend:
-    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
-    @pytest.mark.filterwarnings(
-        "ignore:ExternalStream is deprecated:DeprecationWarning"
-    )
-    def test_cuquantum_state_vector_simulator(self):
-        """Test state_vector_simulator mode with CuState on GPU."""
-        import qutip_cuquantum
-        from cuquantum.densitymat import WorkStream
-
-        ctx = WorkStream()
-        qutip_cuquantum.set_as_default(ctx)
-        try:
-            qc = QubitCircuit(2)
-            qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=0, targets=1)
-
-            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
-            sim = CircuitSimulator(qc, mode="state_vector_simulator")
-            result = sim.run(state)
-
-            final_state = result.get_final_states()[0]
-            assert type(final_state.data).__name__ == "CuState"
-
-            expected = (
-                tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
-            ).unit()
-            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
-        finally:
-            qutip_cuquantum.set_as_default(reverse=True)
-
-    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
-    @pytest.mark.filterwarnings(
-        "ignore:ExternalStream is deprecated:DeprecationWarning"
-    )
-    def test_cuquantum_density_matrix_simulator(self):
-        """Test density_matrix_simulator mode with CuState on GPU."""
-        import qutip_cuquantum
-        from cuquantum.densitymat import WorkStream
-
-        ctx = WorkStream()
-        qutip_cuquantum.set_as_default(ctx)
-        try:
-            qc = QubitCircuit(2)
-            qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=0, targets=1)
-
-            pure_state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
-            state = ket2dm(pure_state)
-            assert type(state.data).__name__ == "CuState"
-
-            sim = CircuitSimulator(qc, mode="density_matrix_simulator")
-            result = sim.run(state)
-
-            final_state = result.get_final_states()[0]
-            assert type(final_state.data).__name__ == "CuState"
-
-            expected = ket2dm(
-                (
-                    tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
-                ).unit()
-            )
-            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
-        finally:
-            qutip_cuquantum.set_as_default(reverse=True)
-
-    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
-    @pytest.mark.filterwarnings(
-        "ignore:ExternalStream is deprecated:DeprecationWarning"
-    )
-    def test_cuquantum_measurement(self):
-        """Test measurement simulator mode with CuState on GPU."""
-        import qutip_cuquantum
-        from cuquantum.densitymat import WorkStream
-        from qutip_qip.operations.measurement import Mz
-
-        ctx = WorkStream()
-        qutip_cuquantum.set_as_default(ctx)
-        try:
-            qc = QubitCircuit(2, num_cbits=1)
-            qc.add_gate(gates.H, targets=0)
-            qc.add_gate(gates.CX, controls=0, targets=1)
-            # Add measurement on qubit 0
-            qc.add_measurement(Mz, targets=[0], classical_store=0)
-
-            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
-            sim = CircuitSimulator(qc, mode="state_vector_simulator")
-            result = sim.run(state)
-
-            final_state = result.get_final_states()[0]
-            # Ensure type is preserved as CuState
-            assert type(final_state.data).__name__ == "CuState"
-
-            # Check that classical bit register was set to 0 or 1
-            assert sim.cbits[0] in (0, 1)
-
-            # Check correctness: final state should be either |00> or |11>
-            if sim.cbits[0] == 0:
-                expected = tensor(basis(2, 0), basis(2, 0))
-            else:
-                expected = tensor(basis(2, 1), basis(2, 1))
-            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
-        finally:
-            qutip_cuquantum.set_as_default(reverse=True)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1229,3 +1229,117 @@ def test_gates_class():
     result2 = circuit2.run(init_state)
 
     assert pytest.approx(qutip.fidelity(result1, result2), 1.0e-6) == 1
+
+
+try:
+    import qutip_cuquantum
+
+    HAS_CUQANTUM = True
+except ImportError:
+    HAS_CUQANTUM = False
+
+
+class TestCuQuantumBackend:
+    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    def test_cuquantum_state_vector_simulator(self):
+        """Test state_vector_simulator mode with CuState on GPU."""
+        import qutip_cuquantum
+        from cuquantum.densitymat import WorkStream
+
+        ctx = WorkStream()
+        qutip_cuquantum.set_as_default(ctx)
+        try:
+            qc = QubitCircuit(2)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+
+            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+            assert type(final_state.data).__name__ == "CuState"
+
+            expected = (
+                tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
+            ).unit()
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            qutip_cuquantum.set_as_default(reverse=True)
+
+    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    def test_cuquantum_density_matrix_simulator(self):
+        """Test density_matrix_simulator mode with CuState on GPU."""
+        import qutip_cuquantum
+        from cuquantum.densitymat import WorkStream
+
+        ctx = WorkStream()
+        qutip_cuquantum.set_as_default(ctx)
+        try:
+            qc = QubitCircuit(2)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+
+            pure_state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
+            state = ket2dm(pure_state)
+            assert type(state.data).__name__ == "CuState"
+
+            sim = CircuitSimulator(qc, mode="density_matrix_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+            assert type(final_state.data).__name__ == "CuState"
+
+            expected = ket2dm(
+                (
+                    tensor(basis(2, 0), basis(2, 0)) + tensor(basis(2, 1), basis(2, 1))
+                ).unit()
+            )
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            qutip_cuquantum.set_as_default(reverse=True)
+
+    @pytest.mark.skipif(not HAS_CUQANTUM, reason="qutip_cuquantum not installed")
+    @pytest.mark.filterwarnings(
+        "ignore:ExternalStream is deprecated:DeprecationWarning"
+    )
+    def test_cuquantum_measurement(self):
+        """Test measurement simulator mode with CuState on GPU."""
+        import qutip_cuquantum
+        from cuquantum.densitymat import WorkStream
+        from qutip_qip.operations.measurement import Mz
+
+        ctx = WorkStream()
+        qutip_cuquantum.set_as_default(ctx)
+        try:
+            qc = QubitCircuit(2, num_cbits=1)
+            qc.add_gate(gates.H, targets=0)
+            qc.add_gate(gates.CX, controls=0, targets=1)
+            # Add measurement on qubit 0
+            qc.add_measurement(Mz, targets=[0], classical_store=0)
+
+            state = tensor(basis(2, 0), basis(2, 0)).to("CuState")
+            sim = CircuitSimulator(qc, mode="state_vector_simulator")
+            result = sim.run(state)
+
+            final_state = result.get_final_states()[0]
+            # Ensure type is preserved as CuState
+            assert type(final_state.data).__name__ == "CuState"
+
+            # Check that classical bit register was set to 0 or 1
+            assert sim.cbits[0] in (0, 1)
+
+            # Check correctness: final state should be either |00> or |11>
+            if sim.cbits[0] == 0:
+                expected = tensor(basis(2, 0), basis(2, 0))
+            else:
+                expected = tensor(basis(2, 1), basis(2, 1))
+            np.testing.assert_allclose(final_state.full(), expected.full(), atol=1e-12)
+        finally:
+            qutip_cuquantum.set_as_default(reverse=True)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -17,6 +17,7 @@ from qutip import (
     ket2dm,
     identity,
 )
+from qutip.measurement import measurement_statistics
 
 from qutip_qip.circuit import (
     QubitCircuit,
@@ -96,6 +97,20 @@ def _measurement_circuit():
     qc.add_measurement(Mz, targets=[1], classical_store=1)
 
     return qc
+
+
+def _get_probs(state, measurement_obj, targets):
+    """Helper to get probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
+
+    _, probabilities = measurement_statistics(state, expanded_ops)
+    return probabilities
 
 
 class TestQubitCircuit:
@@ -337,7 +352,7 @@ class TestQubitCircuit:
         # checking correct addition of measurements
         assert qc.instructions[0].qubits[0] == 0
         assert qc.instructions[0].cbits[0] == 0
-        assert isinstance(qc.instructions[3].operation, Measurement)
+        assert issubclass(qc.instructions[3].operation, Measurement)
         assert qc.instructions[5].cbits[0] == 2
 
         # checking if gates are added correctly with measurements
@@ -412,7 +427,7 @@ class TestQubitCircuit:
         qc_rev = qc.reverse_circuit()
 
         assert qc_rev.instructions[0].operation == gates.H
-        assert isinstance(qc_rev.instructions[1].operation, Measurement)
+        assert issubclass(qc_rev.instructions[1].operation, Measurement)
         assert qc_rev.instructions[2].operation == gates.CX
         assert isinstance(qc_rev.instructions[3].operation, gates.RX)
 
@@ -550,13 +565,13 @@ class TestQubitCircuit:
         teleportation = _teleportation_circuit()
 
         state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-        _, initial_probabilities = Mz.measurement_comp_basis(state, qubits=[0])
+        initial_probabilities = _get_probs(state, Mz, [0])
 
         teleportation_sim = CircuitSimulator(teleportation)
         teleportation_sim_results = teleportation_sim.run(state)
         state_final = teleportation_sim_results.get_final_states(0)
 
-        _, final_probabilities = Mz.measurement_comp_basis(state_final, qubits=[2])
+        final_probabilities = _get_probs(state_final, Mz, [2])
 
         np.testing.assert_allclose(initial_probabilities, final_probabilities)
 
@@ -591,7 +606,7 @@ class TestQubitCircuit:
         teleportation = _teleportation_circuit()
 
         original_state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-        _, initial_probabilities = Mz.measurement_comp_basis(original_state, qubits=[0])
+        initial_probabilities = _get_probs(original_state, Mz, [0])
 
         teleportation_results = teleportation.run_statistics(original_state)
         states = teleportation_results.get_final_states()
@@ -600,7 +615,7 @@ class TestQubitCircuit:
         for i, state in enumerate(states):
             state_final = state
             prob = probabilities[i]
-            _, final_probabilities = Mz.measurement_comp_basis(state_final, qubits=[2])
+            final_probabilities = _get_probs(state_final, Mz, [2])
             np.testing.assert_allclose(initial_probabilities, final_probabilities)
             assert prob == pytest.approx(0.25, abs=1e-7)
 
@@ -610,8 +625,8 @@ class TestQubitCircuit:
         teleportation2 = _teleportation_circuit2()
 
         final_state = teleportation2.run(dm_state)
-        _, probs1 = Mz.measurement_comp_basis(final_state, qubits=[2])
-        _, probs2 = Mz.measurement_comp_basis(mixed_state, qubits=[2])
+        probs1 = _get_probs(final_state, Mz, [2])
+        probs2 = _get_probs(mixed_state, Mz, [2])
 
         np.testing.assert_allclose(probs1, probs2)
 
@@ -696,7 +711,7 @@ class TestQubitCircuit:
         rand_state = rand_ket(2)
         state = tensor(basis(2, 0), basis(2, 0), basis(2, 0), rand_state)
 
-        _, probs_initial = Mz.measurement_comp_basis(state, qubits=[3])
+        probs_initial = _get_probs(state, Mz, [3])
 
         simulator = CircuitSimulator(qc)
 
@@ -705,7 +720,7 @@ class TestQubitCircuit:
         result_cbits = result.get_cbits()
 
         for i, final_state in enumerate(final_states):
-            _, probs_final = Mz.measurement_comp_basis(final_state, qubits=[3])
+            probs_final = _get_probs(final_state, Mz, [3])
             np.testing.assert_allclose(probs_initial, probs_final)
             assert sum(result_cbits[i]) == 1
 

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -1,69 +1,99 @@
 import numpy as np
+import qutip
 import pytest
 from math import sqrt
-from qutip_qip.operations.measurement import Mz
-from qutip import basis, ket2dm, tensor, rand_ket
-import qutip
+from qutip_qip.operations import expand_operator
+from qutip_qip.operations.measurement import Measurement, Mz, Mx, My
+from qutip import basis, tensor
+from qutip.measurement import measurement_statistics
 
 
-@pytest.mark.repeat(10)
-def test_measurement_comp_basis():
-    """
-    Test measurements to test probability calculation in
-    computational basis measurements on a 3 qubit state
-    """
+def _get_measurement_results(state, measurement_obj, targets):
+    """Helper to apply measurement and return states and probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
 
-    qubit_kets = [rand_ket(2), rand_ket(2), rand_ket(2)]
-    qubit_dms = [ket2dm(qubit_kets[i]) for i in range(3)]
+    measurement_tol = qutip.settings.core["atol"] ** 2
+    states, probabilities = measurement_statistics(state, expanded_ops)
+    probabilities = [p if p > measurement_tol else 0.0 for p in probabilities]
+    states = [s if p > measurement_tol else None for s, p in zip(states, probabilities)]
+    return states, probabilities
 
-    state = tensor(qubit_kets)
-    density_mat = tensor(qubit_dms)
 
-    for i in range(3):
-        final_states, probabilities_state = Mz.measurement_comp_basis(state, [i])
-        final_dms, probabilities_dm = Mz.measurement_comp_basis(density_mat, [i])
+def test_measurement_classes():
+    """Test standard measurement class attributes and operators."""
+    for cls, name, num_ops in [(Mz, "Mz", 2), (Mx, "Mx", 2), (My, "My", 2)]:
+        meas = cls()
+        assert meas.name == name
+        assert meas.num_qubits == 1
+        ops = meas.get_measurement_ops()
+        assert len(ops) == num_ops
+        for op in ops:
+            assert isinstance(op, qutip.Qobj)
 
-        amps = qubit_kets[i].full()
-        probabilities_i = [np.abs(amps[0][0]) ** 2, np.abs(amps[1][0]) ** 2]
 
-        np.testing.assert_allclose(probabilities_state, probabilities_dm)
-        np.testing.assert_allclose(probabilities_state, probabilities_i)
-        for j, final_state in enumerate(final_states):
-            np.testing.assert_allclose(final_dms[j].full(), ket2dm(final_state).full())
+def test_custom_measurement_subclass():
+    """Test creating a custom Measurement subclass."""
+
+    class MyCustomMeasurement(Measurement):
+        def get_measurement_ops(self):
+            return [basis(2, 0) * basis(2, 0).dag(), basis(2, 1) * basis(2, 1).dag()]
+
+    meas = MyCustomMeasurement()
+    assert meas.name == "M"
+    assert meas.num_qubits == 1
+    assert len(meas.get_measurement_ops()) == 2
 
 
 @pytest.mark.parametrize("index", [0, 1])
-def test_measurement_collapse(index):
+@pytest.mark.parametrize("measurement_class", [Mz, Mx, My])
+def test_measurement_collapse(index, measurement_class):
     """
     Test if correct state is created after measurement using the example of
-    the Bell state
+    the Bell state in respective bases.
     """
+    if measurement_class == Mz:
+        v0 = basis(2, 0)
+        v1 = basis(2, 1)
+    elif measurement_class == Mx:
+        v0 = (basis(2, 0) + basis(2, 1)).unit()
+        v1 = (basis(2, 0) - basis(2, 1)).unit()
+    elif measurement_class == My:
+        v0 = (basis(2, 0) + 1j * basis(2, 1)).unit()
+        v1 = (basis(2, 0) - 1j * basis(2, 1)).unit()
 
-    state_00 = tensor(basis(2, 0), basis(2, 0))
-    state_11 = tensor(basis(2, 1), basis(2, 1))
+    state_00 = tensor(v0, v0)
+    state_11 = tensor(v1, v1)
 
     bell_state = (state_00 + state_11) / sqrt(2)
 
-    states, probabilities = Mz.measurement_comp_basis(bell_state, qubits=[index])
+    states, probabilities = _get_measurement_results(
+        bell_state, measurement_class, targets=[index]
+    )
     np.testing.assert_allclose(probabilities, [0.5, 0.5])
 
     for i, state in enumerate(states):
         if i == 0:
-            states_00, probability_00 = Mz.measurement_comp_basis(
-                state, qubits=[1 - index]
+            states_00, probability_00 = _get_measurement_results(
+                state, measurement_class, targets=[1 - index]
             )
-            assert probability_00[0] == 1
+            assert probability_00[0] == pytest.approx(1.0)
             assert states_00[1] is None
         else:
-            states_11, probability_11 = Mz.measurement_comp_basis(
-                state, qubits=[1 - index]
+            states_11, probability_11 = _get_measurement_results(
+                state, measurement_class, targets=[1 - index]
             )
-            assert probability_11[1] == 1
+            assert probability_11[1] == pytest.approx(1.0)
             assert states_11[0] is None
 
 
 def test_against_numerical_error():
     state = qutip.Qobj([[1], [1.0e-12]])
-    states, probabilities = Mz.measurement_comp_basis(state, [0])
+    states, probabilities = _get_measurement_results(state, Mz, [0])
     assert states[1] is None
     assert probabilities[1] == 0.0

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -8,7 +8,23 @@ from qutip_qip.qasm import read_qasm, circuit_to_qasm_str
 from qutip_qip.circuit import QubitCircuit
 from qutip import tensor, rand_ket, basis, identity
 from qutip_qip.operations.measurement import Mz
+from qutip_qip.operations import expand_operator
+from qutip.measurement import measurement_statistics
 import qutip_qip.operations.gates as gates
+
+
+def _get_probs(state, measurement_obj, targets):
+    """Helper to get probabilities"""
+    if isinstance(measurement_obj, type):
+        measurement_obj = measurement_obj()
+    n = int(np.log2(state.shape[0]))
+    raw_ops = measurement_obj.get_measurement_ops()
+    expanded_ops = [
+        expand_operator(oper=op, dims=[2] * n, targets=targets) for op in raw_ops
+    ]
+
+    _, probabilities = measurement_statistics(state, expanded_ops)
+    return probabilities
 
 
 @pytest.mark.parametrize(
@@ -76,8 +92,8 @@ def test_qasm_addcircuit():
     check_gate_instruction_defn(qc.instructions[4], "H", (0,))
     check_gate_instruction_defn(qc.instructions[5], "H", (1,))
     check_gate_instruction_defn(qc.instructions[6], "H", (0,), (), (0, 1), 0)
-    check_measurement_defn(qc.instructions[7], "M", (0,), (0,))
-    check_measurement_defn(qc.instructions[8], "M", (1,), (1,))
+    check_measurement_defn(qc.instructions[7], "Mz", (0,), (0,))
+    check_measurement_defn(qc.instructions[8], "Mz", (1,), (1,))
 
 
 def test_custom_gates():
@@ -102,9 +118,7 @@ def test_qasm_teleportation():
     initial_measurement = Mz
 
     state = tensor(rand_ket(2), basis(2, 0), basis(2, 0))
-    _, initial_probabilities = initial_measurement.measurement_comp_basis(
-        state, qubits=[0]
-    )
+    initial_probabilities = _get_probs(state, initial_measurement, [0])
 
     teleportation_results = teleportation.run_statistics(state)
 
@@ -114,9 +128,7 @@ def test_qasm_teleportation():
     for i, state in enumerate(states):
         final = state
         prob = probabilities[i]
-        _, final_probabilities = final_measurement.measurement_comp_basis(
-            final, qubits=[2]
-        )
+        final_probabilities = _get_probs(final, final_measurement, [2])
         np.testing.assert_allclose(initial_probabilities, final_probabilities)
         assert prob == pytest.approx(0.25, abs=1e-7)
 


### PR DESCRIPTION
**Description**
This PR adds an optimized `_apply_measurement()` method called `_apply_measurement_einsum()`, it replaces the former in the `step()` method for the `"state_vector_simulator" and "density_matrix_simulator"` (which are technically all of the modes).
This PR also adds a test for the same (currently in `test_circuit.py`)
This PR does not yet add any other documentation (other than a docstring)

Since this is intended for a new qutip release, some workflow tests fail as the old `qutip.einsum()` did not return the desired output(it split the tensor in half while in the new `qutip.einsum` the `_infer_out_dims()` method can use the equation string to determine the desired output dims), all tests pass locally:
<img width="1341" height="318" alt="image" src="https://github.com/user-attachments/assets/6f48ed79-5e11-4a28-8cd8-7cbd66d09d2f" />


**Related issues or PRs**
This PR is related to the GSoC project for qutip-qip, Related PRs are #402 and #406

**AI Tools Usage Disclosure**
Gemini 3.7 flash: Docstring, helping with rebasing and understanding the physics.
